### PR TITLE
Remove Reckon --no-configuration-cache

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -31,5 +31,4 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
       - name: Build
-        # FIXME reckon is not CC compatible
-        run: ./gradlew --no-configuration-cache --info --stacktrace :build
+        run: ./gradlew --info --stacktrace :build

--- a/.github/workflows/gradle-dependency-submission.yml
+++ b/.github/workflows/gradle-dependency-submission.yml
@@ -22,8 +22,6 @@ jobs:
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4
         with:
-          # FIXME reckon is not CC compatible
-          additional-arguments: --no-configuration-cache
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"

--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -26,5 +26,4 @@ jobs:
           build-scan-terms-of-use-url: "https://gradle.com/help/legal-terms-of-use"
           build-scan-terms-of-use-agree: "yes"
       - name: Publish
-        # FIXME reckon is not CC compatible
-        run: ./gradlew --no-configuration-cache --info --stacktrace :publish
+        run: ./gradlew --info --stacktrace :publish


### PR DESCRIPTION
Testing removal of `--no-configuration-cache` due to Reckon plugin update resolving CC issues.