### PR TITLE
Resolve .git worktree pointer for semver plugin

### DIFF
--- a/aggregation/settings.gradle.kts
+++ b/aggregation/settings.gradle.kts
@@ -38,8 +38,24 @@ dependencyResolutionManagement {
 
 semver {
     isEnabled.set(true)
-    gitDir.set(layout.settingsDirectory.dir("../.git"))
+    // Resolve .git worktree pointer files: jgit's FileRepositoryBuilder.setGitDir() (used by
+    // com.javiersc.semver 0.9.0) does not follow `gitdir:` pointers, so in a git worktree the
+    // raw `.git` file must be replaced with the real worktree git directory.
+    gitDir.set(layout.settingsDirectory.dir(resolveGitDir("../.git").absolutePath))
     tagPrefix.set("v")
+}
+
+fun resolveGitDir(relativePath: String): java.io.File {
+    val marker = layout.settingsDirectory.asFile.resolve(relativePath)
+    if (!marker.isFile) return marker
+    val pointer = marker.readLines()
+        .firstOrNull { it.startsWith("gitdir:") }
+        ?.substringAfter("gitdir:")
+        ?.trim()
+        ?: return marker
+    val pointed = java.io.File(pointer)
+    val resolved = if (pointed.isAbsolute) pointed else marker.parentFile.resolve(pointed)
+    return resolved.canonicalFile
 }
 
 include("dokka")

--- a/gradle/settings/src/main/kotlin/com.kelvsyc.internal.settings.gradle.kts
+++ b/gradle/settings/src/main/kotlin/com.kelvsyc.internal.settings.gradle.kts
@@ -39,6 +39,22 @@ dependencyResolutionManagement {
 
 configure<SemverSettingsExtension> {
     isEnabled.set(true)
-    gitDir.set(layout.settingsDirectory.dir("../../.git"))
+    // Resolve .git worktree pointer files: jgit's FileRepositoryBuilder.setGitDir() (used by
+    // com.javiersc.semver 0.9.0) does not follow `gitdir:` pointers, so in a git worktree the
+    // raw `.git` file must be replaced with the real worktree git directory.
+    gitDir.set(layout.settingsDirectory.dir(resolveGitDir("../../.git").absolutePath))
     tagPrefix.set("v")
+}
+
+fun resolveGitDir(relativePath: String): java.io.File {
+    val marker = layout.settingsDirectory.asFile.resolve(relativePath)
+    if (!marker.isFile) return marker
+    val pointer = marker.readLines()
+        .firstOrNull { it.startsWith("gitdir:") }
+        ?.substringAfter("gitdir:")
+        ?.trim()
+        ?: return marker
+    val pointed = java.io.File(pointer)
+    val resolved = if (pointed.isAbsolute) pointed else marker.parentFile.resolve(pointed)
+    return resolved.canonicalFile
 }

--- a/metadata/settings.gradle.kts
+++ b/metadata/settings.gradle.kts
@@ -38,8 +38,24 @@ dependencyResolutionManagement {
 
 semver {
     isEnabled.set(true)
-    gitDir.set(layout.settingsDirectory.dir("../.git"))
+    // Resolve .git worktree pointer files: jgit's FileRepositoryBuilder.setGitDir() (used by
+    // com.javiersc.semver 0.9.0) does not follow `gitdir:` pointers, so in a git worktree the
+    // raw `.git` file must be replaced with the real worktree git directory.
+    gitDir.set(layout.settingsDirectory.dir(resolveGitDir("../.git").absolutePath))
     tagPrefix.set("v")
+}
+
+fun resolveGitDir(relativePath: String): java.io.File {
+    val marker = layout.settingsDirectory.asFile.resolve(relativePath)
+    if (!marker.isFile) return marker
+    val pointer = marker.readLines()
+        .firstOrNull { it.startsWith("gitdir:") }
+        ?.substringAfter("gitdir:")
+        ?.trim()
+        ?: return marker
+    val pointed = java.io.File(pointer)
+    val resolved = if (pointed.isAbsolute) pointed else marker.parentFile.resolve(pointed)
+    return resolved.canonicalFile
 }
 
 include("bom")


### PR DESCRIPTION
## Summary

- `com.javiersc.semver` 0.9.0 forces `FileRepositoryBuilder.setGitDir()` before `findGitDir()`, short-circuiting jgit's native worktree-pointer discovery. In a `git worktree`, the repo-root `.git` is a pointer file (`gitdir: <path>`) rather than a directory, so jgit NPEs on `AnyObjectId.hashCode()` while resolving `HEAD`. The failure typically surfaces as a Dokka apply error, since Dokka HTML is the first plugin to read `project.version`.
- Resolve the `gitdir:` pointer ourselves in the three settings sites that configure semver (`gradle/settings`, `aggregation`, `metadata`). No-op in primary checkouts where `.git` is a real directory.
- This is an interim workaround. Replacing `com.javiersc.semver` with a configuration-cache-compatible, worktree-aware alternative is queued as tech debt across gradle-tools / kotlin-tools / rifflet (which share this versioning logic).

## Test plan

- [x] `./gradlew :build --dry-run` — succeeds from a Conductor worktree, configuration cache stores cleanly
- [x] `./gradlew :clients-base:test :clients-base:detekt` — passes
- [x] `./gradlew :clients-base:properties --no-configuration-cache` — `version: 0.1.1.112+DIRTY` (semver computes correctly)
- [ ] CI verifies primary-checkout behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)