### PR TITLE
Fix JaCoCo coverage report not visible on PRs

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           artifact-ids: ${{needs.build.outputs.aggregate-jacoco-id}}
+          path: jacoco-aggregate
       - name: Report JaCoCo
         uses: madrapps/jacoco-report@v1.7.2
         with:


### PR DESCRIPTION
## Summary

- `actions/download-artifact@v8` with `artifact-ids` but no `path` extracts to the workspace root, not a `<artifact-name>/` subdirectory
- The JaCoCo XML landed at `testCodeCoverageReport.xml` but `madrapps/jacoco-report` looked for `jacoco-aggregate/testCodeCoverageReport.xml`, producing "no coverage information" on every PR
- Fixes this by adding `path: jacoco-aggregate` to the download step, matching the pattern already used by the `pages` job (`path: kdoc`)

## Test plan

- [ ] Merge this PR and verify the next code-change PR shows actual coverage percentages in the "Aggregate Code Coverage" comment instead of "no coverage information present for the Files changed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)