### PR TITLE
[aws-java-extensions] Fix config-cache serialization in AWS Java BuildServices

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ dependencies {
 | Library | Description |
 |---------|-------------|
 | `gradle-extensions` | Kotlin DSL extensions and utility types for Gradle plugin development |
-| `aws-java-extensions` | Base client info interface and credential adapters for the AWS SDK for Java |
+| `aws-java-extensions` | Config-cache-safe BuildService base class, `AwsBuildServiceParams`, and credential adapters for the AWS SDK for Java |
 | `aws-kotlin-extensions` | Base client info interface and credential extensions for the AWS SDK for Kotlin |
 | `moshi-extensions` | `ValueSource` implementations and `Provider` extensions for Moshi JSON parsing |
 | `pkl-extensions` | `ValueSource` implementations for evaluating Pkl configuration files |

--- a/cores/aws-codeartifact-java-base/build.gradle.kts
+++ b/cores/aws-codeartifact-java-base/build.gradle.kts
@@ -13,11 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
-    api(libs.aws.auth.java)
     api(libs.aws.http.client.spi.java)
-    api(libs.aws.regions.java)
     api(libs.aws.codeartifact.java)
     api(libs.aws.sdk.core.java)
 

--- a/cores/aws-codeartifact-java-base/settings.gradle.kts
+++ b/cores/aws-codeartifact-java-base/settings.gradle.kts
@@ -8,3 +8,4 @@ plugins {
 
 includeBuild("../clients-base")
 includeBuild("../gradle-extensions")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/CodeArtifactAsyncClientBuildService.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/CodeArtifactAsyncClientBuildService.kt
@@ -1,50 +1,16 @@
 package com.kelvsyc.gradle.aws.java.codeartifact
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.codeartifact.CodeartifactAsyncClient
 
 /**
  * Build service managing an asynchronous [CodeartifactAsyncClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<CodeArtifactAsyncClientBuildService>` parameter.
+ * parameters via the [AwsBuildServiceParams] extension functions as needed. The same registration can then
+ * be shared with value sources and work actions via a `Property<CodeArtifactAsyncClientBuildService>` parameter.
  */
-abstract class CodeArtifactAsyncClientBuildService :
-    AbstractClientBuildService<CodeartifactAsyncClient, CodeArtifactAsyncClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [CodeArtifactAsyncClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): CodeartifactAsyncClient = CodeartifactAsyncClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class CodeArtifactAsyncClientBuildService : AbstractAwsJavaClientBuildService<CodeartifactAsyncClient, AwsBuildServiceParams>() {
+    override fun createClient(): CodeartifactAsyncClient = configureBuilder(CodeartifactAsyncClient.builder()).build()
 }

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/CodeArtifactClientBuildService.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/CodeArtifactClientBuildService.kt
@@ -1,50 +1,16 @@
 package com.kelvsyc.gradle.aws.java.codeartifact
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient
 
 /**
  * Build service managing a synchronous [CodeartifactClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<CodeArtifactClientBuildService>` parameter.
+ * parameters via the [AwsBuildServiceParams] extension functions as needed. The same registration can then
+ * be shared with value sources and work actions via a `Property<CodeArtifactClientBuildService>` parameter.
  */
-abstract class CodeArtifactClientBuildService :
-    AbstractClientBuildService<CodeartifactClient, CodeArtifactClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [CodeArtifactClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): CodeartifactClient = CodeartifactClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class CodeArtifactClientBuildService : AbstractAwsJavaClientBuildService<CodeartifactClient, AwsBuildServiceParams>() {
+    override fun createClient(): CodeartifactClient = configureBuilder(CodeartifactClient.builder()).build()
 }

--- a/cores/aws-ecr-java-base/build.gradle.kts
+++ b/cores/aws-ecr-java-base/build.gradle.kts
@@ -13,10 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
 
     api(libs.aws.ecr.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-ecr-java-base/settings.gradle.kts
+++ b/cores/aws-ecr-java-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/EcrClientBuildService.kt
+++ b/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/EcrClientBuildService.kt
@@ -1,49 +1,16 @@
 package com.kelvsyc.gradle.aws.java.ecr
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.ecr.EcrClient
 
 /**
  * Build service managing a synchronous [EcrClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<EcrClientBuildService>` parameter.
+ * parameters via the [AwsBuildServiceParams] extension functions as needed. The same registration can then
+ * be shared with value sources and work actions via a `Property<EcrClientBuildService>` parameter.
  */
-abstract class EcrClientBuildService : AbstractClientBuildService<EcrClient, EcrClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [EcrClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): EcrClient = EcrClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class EcrClientBuildService : AbstractAwsJavaClientBuildService<EcrClient, AwsBuildServiceParams>() {
+    override fun createClient(): EcrClient = configureBuilder(EcrClient.builder()).build()
 }

--- a/cores/aws-java-extensions/README.md
+++ b/cores/aws-java-extensions/README.md
@@ -1,11 +1,13 @@
 # AWS Java Extensions
 
-A Gradle library providing the base client info interface and Gradle credential adapters for the AWS SDK for Java.
+A Gradle library providing config-cache-safe build service infrastructure and Gradle credential adapters for the AWS
+SDK for Java.
 
 ## Dependency
 
 This library is a transitive dependency of the AWS Java Base plugins (`aws-s3-java-base`, `aws-codeartifact-java-base`,
-etc.). Direct use is only needed when building plugins that define new AWS Java client info types.
+etc.). Direct use is only needed when building plugins that define new AWS Java client build services or client info
+types.
 
 ```kotlin
 dependencies {
@@ -13,31 +15,68 @@ dependencies {
 }
 ```
 
-## `AwsClientInfo<T>`
+## `AwsBuildServiceParams`
 
-Base interface for AWS Java SDK client registrations. Extends `ServiceClientInfo<T>` where `T : AwsClient`.
+Config-cache-safe `BuildServiceParameters` interface for AWS Java SDK client build services. All fields are
+serializable primitives; use the extension functions below to configure them rather than setting fields directly.
 
 | Property | Type | Description |
 |---|---|---|
-| `region` | `Property<Region>` | AWS region. Leave unset to use `DefaultAwsRegionProviderChain`. |
-| `credentials` | `Property<AwsCredentialsProvider>` | Credentials provider. If absent, uses `AnonymousCredentialsProvider`. |
+| `regionId` | `Property<String>` | AWS region identifier (e.g. `"us-east-1"`). Leave unset to delegate to `DefaultAwsRegionProviderChain`. |
+| `credentialSource` | `Property<AwsCredentialSource>` | Which credentials provider to construct. Leave unset for `AnonymousCredentialsProvider`. |
+| `accessKeyId` | `Property<String>` | Access key ID. Used when `credentialSource` is `STATIC`. |
+| `secretAccessKey` | `Property<String>` | Secret access key. Used when `credentialSource` is `STATIC`. |
+| `sessionToken` | `Property<String>` | Session token for temporary credentials. Optional; used when `credentialSource` is `STATIC`. |
+| `credentialsProfile` | `Property<String>` | Named credentials profile. Used when `credentialSource` is `PROFILE`. |
 
-Set `credentials` using the AWS SDK's standard providers:
+### Extension functions
+
+Configure an `AwsBuildServiceParams` instance atomically using one of these functions:
 
 ```kotlin
-// Default credential chain (environment, ~/.aws/credentials, instance profile, etc.)
-credentials.set(DefaultCredentialsProvider.create())
-
-// From Gradle PasswordCredentials (reads myClientUsername / myClientPassword)
-val gradleCreds = providers.credentials(PasswordCredentials::class.java, "myClient")
-credentials.set(GradleCredentialsProviders(gradleCreds))
-
-// From Gradle AwsCredentials (reads accessKey, secretKey, sessionToken)
-val gradleAwsCreds = providers.credentials(AwsCredentials::class.java, "myClient")
-credentials.set(GradleSessionCredentialsProvider(gradleAwsCreds))
+gradle.sharedServices.registerIfAbsent("s3", S3ClientBuildService::class) {
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()               // DefaultCredentialsProvider
+        // anonymous()                     // AnonymousCredentialsProvider (default)
+        // staticCredentials(akid, secret) // AwsBasicCredentials
+        // sessionCredentials(akid, secret, token) // AwsSessionCredentials
+        // profileCredentials("my-profile")        // ProfileCredentialsProvider
+    }
+}
 ```
 
+| Function | Credential result |
+|---|---|
+| `anonymous()` | `AnonymousCredentialsProvider` |
+| `defaultCredentials()` | `DefaultCredentialsProvider` (env vars, `~/.aws/credentials`, EC2/ECS metadata, …) |
+| `staticCredentials(accessKey, secretKey)` | `StaticCredentialsProvider` with `AwsBasicCredentials` |
+| `sessionCredentials(accessKey, secretKey, token)` | `StaticCredentialsProvider` with `AwsSessionCredentials` |
+| `profileCredentials(profile)` | `ProfileCredentialsProvider` for the named profile |
+| `from(Provider<PasswordCredentials>)` | `StaticCredentialsProvider`; maps `username` → `accessKeyId`, `password` → `secretAccessKey` |
+| `from(Provider<AwsCredentials>)` | `StaticCredentialsProvider`; maps Gradle `AwsCredentials` fields; uses session credentials when `sessionToken` is non-null |
+
+## `AbstractAwsJavaClientBuildService<C, P>`
+
+Abstract base class for AWS Java SDK client build services. Extend this and implement `createClient()`, using
+`configureBuilder()` to apply region and credentials from `AwsBuildServiceParams` to any standard AWS client builder:
+
+```kotlin
+abstract class SnsClientBuildService : AbstractAwsJavaClientBuildService<SnsClient, AwsBuildServiceParams>() {
+    override fun createClient(): SnsClient = configureBuilder(SnsClient.builder()).build()
+}
+```
+
+| Method | Description |
+|---|---|
+| `resolveRegion(): Region?` | Returns the `Region` from `regionId`, or `null` if unset. |
+| `resolveCredentialsProvider(): AwsCredentialsProvider` | Constructs the credentials provider from `credentialSource` and its supporting fields. |
+| `configureBuilder(builder: B): B` | Calls `resolveRegion()` and `resolveCredentialsProvider()` on any `AwsClientBuilder`, then returns it. |
+
 ## Credential Adapters
+
+These classes adapt Gradle credential providers to `AwsCredentialsProvider` for use anywhere an
+`AwsCredentialsProvider` is needed directly (outside of build service parameters).
 
 ### `GradleCredentialsProviders`
 
@@ -56,6 +95,16 @@ Adapts a `Provider<org.gradle.api.credentials.AwsCredentials>` to an `AwsCredent
 ```kotlin
 class GradleSessionCredentialsProvider(credentials: Provider<AwsCredentials>) : AwsCredentialsProvider
 ```
+
+## `AwsClientInfo<T>`
+
+Base interface for AWS Java SDK client registrations in the `ClientsBaseService` container. Extends
+`ServiceClientInfo<T>` where `T : AwsClient`.
+
+| Property | Type | Description |
+|---|---|---|
+| `region` | `Property<Region>` | AWS region. Leave unset to use `DefaultAwsRegionProviderChain`. |
+| `credentials` | `Property<AwsCredentialsProvider>` | Credentials provider. If absent, uses `AnonymousCredentialsProvider`. |
 
 ## See Also
 

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildService.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildService.kt
@@ -1,0 +1,90 @@
+package com.kelvsyc.gradle.aws.java
+
+import com.kelvsyc.gradle.clients.AbstractClientBuildService
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.awscore.AwsClient
+import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
+import software.amazon.awssdk.regions.Region
+
+/**
+ * Abstract base class for AWS Java SDK client build services with config-cache-safe parameters.
+ *
+ * Subclass this and implement [createClient], using [configureBuilder] to apply region and
+ * credentials from the shared [AwsBuildServiceParams] to any standard AWS client builder:
+ *
+ * ```kotlin
+ * abstract class SnsClientBuildService : AbstractAwsJavaClientBuildService<SnsClient, AwsBuildServiceParams>() {
+ *     override fun createClient(): SnsClient = configureBuilder(SnsClient.builder()).build()
+ * }
+ * ```
+ *
+ * Configure the service at registration time using the extension functions on [AwsBuildServiceParams]:
+ *
+ * ```kotlin
+ * gradle.sharedServices.registerIfAbsent("sns", SnsClientBuildService::class) {
+ *     parameters {
+ *         regionId.set("us-east-1")
+ *         defaultCredentials()
+ *     }
+ * }
+ * ```
+ *
+ * @param C The AWS client type managed by this build service
+ * @param P The [AwsBuildServiceParams] subtype; use [AwsBuildServiceParams] directly unless
+ *   additional parameters are needed
+ */
+abstract class AbstractAwsJavaClientBuildService<C : AwsClient, P : AwsBuildServiceParams>
+    : AbstractClientBuildService<C, P>() {
+
+    /**
+     * Returns the [Region] from [AwsBuildServiceParams.regionId], or `null` if unset.
+     *
+     * When `null` is returned and passed to a client builder without calling `region()`, the AWS
+     * SDK falls back to [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
+     */
+    protected fun resolveRegion(): Region? = parameters.regionId.orNull?.let { Region.of(it) }
+
+    /**
+     * Constructs an [AwsCredentialsProvider] from [AwsBuildServiceParams.credentialSource] and
+     * its supporting fields.
+     *
+     * | [AwsCredentialSource] | Result |
+     * |---|---|
+     * | `DEFAULT_CHAIN` | [DefaultCredentialsProvider] |
+     * | `STATIC` (no session token) | [StaticCredentialsProvider] with [AwsBasicCredentials] |
+     * | `STATIC` (with session token) | [StaticCredentialsProvider] with [AwsSessionCredentials] |
+     * | `PROFILE` | [ProfileCredentialsProvider] for the named profile |
+     * | `ANONYMOUS` or unset | [AnonymousCredentialsProvider] |
+     */
+    protected fun resolveCredentialsProvider(): AwsCredentialsProvider =
+        when (parameters.credentialSource.orNull) {
+            AwsCredentialSource.DEFAULT_CHAIN -> DefaultCredentialsProvider.create()
+            AwsCredentialSource.STATIC -> {
+                val key = parameters.accessKeyId.get()
+                val secret = parameters.secretAccessKey.get()
+                parameters.sessionToken.orNull
+                    ?.let { StaticCredentialsProvider.create(AwsSessionCredentials.create(key, secret, it)) }
+                    ?: StaticCredentialsProvider.create(AwsBasicCredentials.create(key, secret))
+            }
+            AwsCredentialSource.PROFILE ->
+                ProfileCredentialsProvider.create(parameters.credentialsProfile.get())
+            AwsCredentialSource.ANONYMOUS, null -> AnonymousCredentialsProvider.create()
+        }
+
+    /**
+     * Applies [resolveRegion] and [resolveCredentialsProvider] to [builder] and returns it.
+     *
+     * Works with any standard AWS SDK client builder that extends [AwsClientBuilder].
+     */
+    protected fun <B> configureBuilder(builder: B): B where B : AwsClientBuilder<B, *> {
+        resolveRegion()?.let { builder.region(it) }
+        builder.credentialsProvider(resolveCredentialsProvider())
+        return builder
+    }
+}

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParams.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParams.kt
@@ -1,0 +1,59 @@
+package com.kelvsyc.gradle.aws.java
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildServiceParameters
+
+/**
+ * Config-cache-safe [BuildServiceParameters] for AWS Java SDK client build services.
+ *
+ * All properties are serializable primitives. Do not set them directly; use the extension functions
+ * on this interface (e.g. [anonymous], [defaultCredentials], [staticCredentials], [from]) which
+ * atomically set [credentialSource] and its supporting fields together.
+ */
+interface AwsBuildServiceParams : BuildServiceParameters {
+    /**
+     * AWS region identifier, e.g. `"us-east-1"`.
+     *
+     * Leave unset to delegate region resolution to
+     * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
+     */
+    val regionId: Property<String>
+
+    /**
+     * Which credentials provider to construct. Leave unset to use
+     * [AnonymousCredentialsProvider][software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider].
+     *
+     * Use the extension functions rather than setting this directly.
+     */
+    val credentialSource: Property<AwsCredentialSource>
+
+    /**
+     * AWS access key ID. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     *
+     * Set via [staticCredentials], [sessionCredentials], or [from].
+     */
+    val accessKeyId: Property<String>
+
+    /**
+     * AWS secret access key. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     *
+     * Set via [staticCredentials], [sessionCredentials], or [from].
+     */
+    val secretAccessKey: Property<String>
+
+    /**
+     * AWS session token for temporary credentials. Optional; used when [credentialSource] is
+     * [AwsCredentialSource.STATIC]. When absent, [AwsBasicCredentials][software.amazon.awssdk.auth.credentials.AwsBasicCredentials]
+     * is used instead of [AwsSessionCredentials][software.amazon.awssdk.auth.credentials.AwsSessionCredentials].
+     *
+     * Set via [sessionCredentials] or [from].
+     */
+    val sessionToken: Property<String>
+
+    /**
+     * Named AWS credentials profile. Used when [credentialSource] is [AwsCredentialSource.PROFILE].
+     *
+     * Set via [profileCredentials].
+     */
+    val credentialsProfile: Property<String>
+}

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensions.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensions.kt
@@ -1,0 +1,89 @@
+package com.kelvsyc.gradle.aws.java
+
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.provider.Provider
+import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
+
+/**
+ * Configures these parameters to use
+ * [AnonymousCredentialsProvider][software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider].
+ */
+fun AwsBuildServiceParams.anonymous() {
+    credentialSource.set(AwsCredentialSource.ANONYMOUS)
+}
+
+/**
+ * Configures these parameters to use
+ * [DefaultCredentialsProvider][software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider],
+ * which resolves credentials from environment variables, `~/.aws/credentials`, EC2/ECS/EKS
+ * instance metadata, and other standard sources.
+ */
+fun AwsBuildServiceParams.defaultCredentials() {
+    credentialSource.set(AwsCredentialSource.DEFAULT_CHAIN)
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
+ * with [AwsBasicCredentials][software.amazon.awssdk.auth.credentials.AwsBasicCredentials].
+ */
+fun AwsBuildServiceParams.staticCredentials(accessKey: Provider<String>, secretKey: Provider<String>) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(accessKey)
+    secretAccessKey.set(secretKey)
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
+ * with [AwsSessionCredentials][software.amazon.awssdk.auth.credentials.AwsSessionCredentials].
+ */
+fun AwsBuildServiceParams.sessionCredentials(
+    accessKey: Provider<String>,
+    secretKey: Provider<String>,
+    token: Provider<String>,
+) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(accessKey)
+    secretAccessKey.set(secretKey)
+    sessionToken.set(token)
+}
+
+/**
+ * Configures these parameters to use a
+ * [ProfileCredentialsProvider][software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider]
+ * for the named profile.
+ */
+fun AwsBuildServiceParams.profileCredentials(profile: String) {
+    credentialSource.set(AwsCredentialSource.PROFILE)
+    credentialsProfile.set(profile)
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
+ * sourced from Gradle [PasswordCredentials], mapping [PasswordCredentials.getUsername] to the
+ * access key ID and [PasswordCredentials.getPassword] to the secret access key.
+ */
+@JvmName("fromPasswordCredentials")
+fun AwsBuildServiceParams.from(credentials: Provider<PasswordCredentials>) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(credentials.map { it.username })
+    secretAccessKey.set(credentials.map { it.password })
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
+ * sourced from Gradle [AwsCredentials][GradleAwsCredentials]. When
+ * [AwsCredentials.getSessionToken][GradleAwsCredentials.getSessionToken] is non-null,
+ * [AwsSessionCredentials][software.amazon.awssdk.auth.credentials.AwsSessionCredentials] are
+ * used; otherwise [AwsBasicCredentials][software.amazon.awssdk.auth.credentials.AwsBasicCredentials].
+ */
+@JvmName("fromAwsCredentials")
+fun AwsBuildServiceParams.from(credentials: Provider<GradleAwsCredentials>) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(credentials.map { it.accessKey })
+    secretAccessKey.set(credentials.map { it.secretKey })
+    sessionToken.set(credentials.map { it.sessionToken ?: "" }.filter { it.isNotEmpty() })
+}

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsCredentialSource.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsCredentialSource.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.aws.java
+
+/**
+ * Discriminator for which AWS credentials provider to construct from [AwsBuildServiceParams].
+ *
+ * Set via the extension functions on [AwsBuildServiceParams] rather than directly.
+ */
+enum class AwsCredentialSource {
+    /** Use [software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider]. */
+    ANONYMOUS,
+
+    /**
+     * Use [software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider], which checks
+     * environment variables, `~/.aws/credentials`, EC2/ECS/EKS instance credentials, and other
+     * standard sources in order.
+     */
+    DEFAULT_CHAIN,
+
+    /**
+     * Use [software.amazon.awssdk.auth.credentials.StaticCredentialsProvider] built from
+     * [AwsBuildServiceParams.accessKeyId], [AwsBuildServiceParams.secretAccessKey], and
+     * optionally [AwsBuildServiceParams.sessionToken].
+     */
+    STATIC,
+
+    /**
+     * Use [software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider] for the profile
+     * named by [AwsBuildServiceParams.credentialsProfile].
+     */
+    PROFILE,
+}

--- a/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildServiceSpec.kt
+++ b/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildServiceSpec.kt
@@ -1,0 +1,109 @@
+package com.kelvsyc.gradle.aws.java
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.api.services.BuildServiceSpec
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.awscore.AwsClient
+import software.amazon.awssdk.regions.Region
+
+class AbstractAwsJavaClientBuildServiceSpec : FunSpec() {
+    abstract class TestService : AbstractAwsJavaClientBuildService<AwsClient, AwsBuildServiceParams>() {
+        fun testResolveRegion() = resolveRegion()
+        fun testResolveCredentialsProvider() = resolveCredentialsProvider()
+        override fun createClient(): AwsClient = error("not used in tests")
+    }
+
+    init {
+        test("resolveRegion - returns null when regionId is absent") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java)
+
+            service.get().testResolveRegion().shouldBeNull()
+        }
+
+        test("resolveRegion - returns Region when regionId is set") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.regionId.set("us-east-1")
+            }
+
+            service.get().testResolveRegion() shouldBe Region.US_EAST_1
+        }
+
+        test("resolveCredentialsProvider - returns AnonymousCredentialsProvider when credentialSource is absent") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java)
+
+            service.get().testResolveCredentialsProvider().shouldBeInstanceOf<AnonymousCredentialsProvider>()
+        }
+
+        test("resolveCredentialsProvider - returns AnonymousCredentialsProvider when credentialSource is ANONYMOUS") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.ANONYMOUS)
+            }
+
+            service.get().testResolveCredentialsProvider().shouldBeInstanceOf<AnonymousCredentialsProvider>()
+        }
+
+        test("resolveCredentialsProvider - returns DefaultCredentialsProvider when credentialSource is DEFAULT_CHAIN") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.DEFAULT_CHAIN)
+            }
+
+            service.get().testResolveCredentialsProvider().shouldBeInstanceOf<DefaultCredentialsProvider>()
+        }
+
+        test("resolveCredentialsProvider - returns StaticCredentialsProvider with AwsBasicCredentials when STATIC and no sessionToken") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
+                spec.parameters.accessKeyId.set("AKID")
+                spec.parameters.secretAccessKey.set("SECRET")
+            }
+
+            val provider = service.get().testResolveCredentialsProvider()
+            provider.shouldBeInstanceOf<StaticCredentialsProvider>()
+            val creds = provider.resolveCredentials() as AwsBasicCredentials
+            creds.accessKeyId() shouldBe "AKID"
+            creds.secretAccessKey() shouldBe "SECRET"
+        }
+
+        test("resolveCredentialsProvider - returns StaticCredentialsProvider with AwsSessionCredentials when STATIC with sessionToken") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
+                spec.parameters.accessKeyId.set("AKID")
+                spec.parameters.secretAccessKey.set("SECRET")
+                spec.parameters.sessionToken.set("TOKEN")
+            }
+
+            val provider = service.get().testResolveCredentialsProvider()
+            provider.shouldBeInstanceOf<StaticCredentialsProvider>()
+            val creds = provider.resolveCredentials() as AwsSessionCredentials
+            creds.accessKeyId() shouldBe "AKID"
+            creds.secretAccessKey() shouldBe "SECRET"
+            creds.sessionToken() shouldBe "TOKEN"
+        }
+
+        test("resolveCredentialsProvider - returns ProfileCredentialsProvider when credentialSource is PROFILE") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.PROFILE)
+                spec.parameters.credentialsProfile.set("my-profile")
+            }
+
+            service.get().testResolveCredentialsProvider().shouldBeInstanceOf<ProfileCredentialsProvider>()
+        }
+    }
+}

--- a/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensionsSpec.kt
+++ b/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensionsSpec.kt
@@ -1,0 +1,107 @@
+package com.kelvsyc.gradle.aws.java
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
+
+class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
+    init {
+        test("anonymous - sets credentialSource to ANONYMOUS") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.anonymous()
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.ANONYMOUS
+        }
+
+        test("defaultCredentials - sets credentialSource to DEFAULT_CHAIN") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.defaultCredentials()
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.DEFAULT_CHAIN
+        }
+
+        test("staticCredentials - sets credentialSource to STATIC and maps accessKey and secretKey") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.staticCredentials(project.provider { "AKID" }, project.provider { "SECRET" })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.isPresent.shouldBeFalse()
+        }
+
+        test("sessionCredentials - sets credentialSource to STATIC and maps all three fields") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.sessionCredentials(
+                project.provider { "AKID" },
+                project.provider { "SECRET" },
+                project.provider { "TOKEN" },
+            )
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.get() shouldBe "TOKEN"
+        }
+
+        test("profileCredentials - sets credentialSource to PROFILE and sets credentialsProfile") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.profileCredentials("my-profile")
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.PROFILE
+            params.credentialsProfile.get() shouldBe "my-profile"
+        }
+
+        test("from PasswordCredentials - sets STATIC and maps username and password") {
+            val project = ProjectBuilder.builder().build()
+            val creds = mockk<PasswordCredentials>()
+            every { creds.username } returns "AKID"
+            every { creds.password } returns "SECRET"
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.from(project.provider { creds })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.isPresent.shouldBeFalse()
+        }
+
+        test("from GradleAwsCredentials - sets STATIC and maps all fields when sessionToken is present") {
+            val project = ProjectBuilder.builder().build()
+            val creds = mockk<GradleAwsCredentials>()
+            every { creds.accessKey } returns "AKID"
+            every { creds.secretKey } returns "SECRET"
+            every { creds.sessionToken } returns "TOKEN"
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.from(project.provider { creds })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.get() shouldBe "TOKEN"
+        }
+
+        test("from GradleAwsCredentials - leaves sessionToken absent when sessionToken is null") {
+            val project = ProjectBuilder.builder().build()
+            val creds = mockk<GradleAwsCredentials>()
+            every { creds.accessKey } returns "AKID"
+            every { creds.secretKey } returns "SECRET"
+            every { creds.sessionToken } returns null
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.from(project.provider { creds })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.sessionToken.isPresent.shouldBeFalse()
+        }
+    }
+}

--- a/cores/aws-kms-java-base/build.gradle.kts
+++ b/cores/aws-kms-java-base/build.gradle.kts
@@ -13,11 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.kms.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
     api(libs.aws.sdk.core.java)
 
     testImplementation(libs.mockk)

--- a/cores/aws-kms-java-base/settings.gradle.kts
+++ b/cores/aws-kms-java-base/settings.gradle.kts
@@ -7,3 +7,5 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../gradle-extensions")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/KmsClientBuildService.kt
+++ b/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/KmsClientBuildService.kt
@@ -1,36 +1,12 @@
 package com.kelvsyc.gradle.aws.java.kms
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.kms.KmsClient
 
 /**
  * Build service managing a [KmsClient] instance.
  */
-abstract class KmsClientBuildService : AbstractClientBuildService<KmsClient, KmsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [KmsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<Region>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): KmsClient = KmsClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class KmsClientBuildService : AbstractAwsJavaClientBuildService<KmsClient, AwsBuildServiceParams>() {
+    override fun createClient(): KmsClient = configureBuilder(KmsClient.builder()).build()
 }

--- a/cores/aws-lambda-java-base/build.gradle.kts
+++ b/cores/aws-lambda-java-base/build.gradle.kts
@@ -13,11 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.lambda.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
     api(libs.aws.sdk.core.java)
 
     testImplementation(libs.mockk)

--- a/cores/aws-lambda-java-base/settings.gradle.kts
+++ b/cores/aws-lambda-java-base/settings.gradle.kts
@@ -8,3 +8,4 @@ plugins {
 
 includeBuild("../clients-base")
 includeBuild("../gradle-extensions")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/LambdaClientBuildService.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/LambdaClientBuildService.kt
@@ -1,50 +1,16 @@
 package com.kelvsyc.gradle.aws.java.lambda
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.lambda.LambdaClient
 
 /**
  * Build service managing a synchronous [LambdaClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<LambdaClientBuildService>` parameter.
+ * parameters via the [AwsBuildServiceParams] extension functions as needed. The same registration can then
+ * be shared with value sources and work actions via a `Property<LambdaClientBuildService>` parameter.
  */
-abstract class LambdaClientBuildService :
-    AbstractClientBuildService<LambdaClient, LambdaClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [LambdaClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): LambdaClient = LambdaClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class LambdaClientBuildService : AbstractAwsJavaClientBuildService<LambdaClient, AwsBuildServiceParams>() {
+    override fun createClient(): LambdaClient = configureBuilder(LambdaClient.builder()).build()
 }

--- a/cores/aws-s3-java-base/build.gradle.kts
+++ b/cores/aws-s3-java-base/build.gradle.kts
@@ -13,12 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
 
     api(libs.aws.s3.java)
     api(libs.aws.s3.transfer.manager.java)
-    api(libs.aws.sdk.core.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-s3-java-base/settings.gradle.kts
+++ b/cores/aws-s3-java-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/S3AsyncClientBuildService.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/S3AsyncClientBuildService.kt
@@ -1,46 +1,27 @@
 package com.kelvsyc.gradle.aws.java.s3
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.s3.S3AsyncClient
 
 /**
- * Build service managing an asynchronous [S3AsyncClient] instance built via the CRT builder.
+ * Build service managing an asynchronous [S3AsyncClient] instance built via the CRT builder,
+ * with config-cache-safe parameters.
+ *
+ * Configure region and credentials via the [AwsBuildServiceParams] extension functions:
+ * ```kotlin
+ * gradle.sharedServices.registerIfAbsent("s3-async", S3AsyncClientBuildService::class) {
+ *     parameters {
+ *         regionId.set("us-east-1")
+ *         defaultCredentials()
+ *     }
+ * }
+ * ```
  */
-abstract class S3AsyncClientBuildService :
-    AbstractClientBuildService<S3AsyncClient, S3AsyncClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [S3AsyncClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
+abstract class S3AsyncClientBuildService : AbstractAwsJavaClientBuildService<S3AsyncClient, AwsBuildServiceParams>() {
     override fun createClient(): S3AsyncClient = S3AsyncClient.crtBuilder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
+        resolveRegion()?.let { region(it) }
+        credentialsProvider(resolveCredentialsProvider())
     }.build()
 }
+

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/S3ClientBuildService.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/S3ClientBuildService.kt
@@ -1,45 +1,23 @@
 package com.kelvsyc.gradle.aws.java.s3
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.s3.S3Client
 
 /**
- * Build service managing a synchronous [S3Client] instance.
+ * Build service managing a synchronous [S3Client] instance with config-cache-safe parameters.
+ *
+ * Configure region and credentials via the [AwsBuildServiceParams] extension functions:
+ * ```kotlin
+ * gradle.sharedServices.registerIfAbsent("s3", S3ClientBuildService::class) {
+ *     parameters {
+ *         regionId.set("us-east-1")
+ *         defaultCredentials()
+ *     }
+ * }
+ * ```
  */
-abstract class S3ClientBuildService : AbstractClientBuildService<S3Client, S3ClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [S3ClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): S3Client = S3Client.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class S3ClientBuildService : AbstractAwsJavaClientBuildService<S3Client, AwsBuildServiceParams>() {
+    override fun createClient(): S3Client = configureBuilder(S3Client.builder()).build()
 }
+

--- a/cores/aws-secrets-manager-java-base/build.gradle.kts
+++ b/cores/aws-secrets-manager-java-base/build.gradle.kts
@@ -13,12 +13,11 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.secrets.manager.java)
     api(libs.aws.secrets.manager.caching.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-secrets-manager-java-base/settings.gradle.kts
+++ b/cores/aws-secrets-manager-java-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerAsyncClientBuildService.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerAsyncClientBuildService.kt
@@ -1,46 +1,24 @@
 package com.kelvsyc.gradle.aws.java.secretsmanager
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerAsyncClient
 
 /**
- * Build service managing an asynchronous [SecretsManagerAsyncClient] instance.
+ * Build service managing an asynchronous [SecretsManagerAsyncClient] instance with config-cache-safe parameters.
+ *
+ * Configure region and credentials via the [AwsBuildServiceParams] extension functions:
+ * ```kotlin
+ * gradle.sharedServices.registerIfAbsent("secretsManager-async", SecretsManagerAsyncClientBuildService::class) {
+ *     parameters {
+ *         regionId.set("us-east-1")
+ *         defaultCredentials()
+ *     }
+ * }
+ * ```
  */
 abstract class SecretsManagerAsyncClientBuildService :
-    AbstractClientBuildService<SecretsManagerAsyncClient, SecretsManagerAsyncClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SecretsManagerAsyncClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SecretsManagerAsyncClient = SecretsManagerAsyncClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+    AbstractAwsJavaClientBuildService<SecretsManagerAsyncClient, AwsBuildServiceParams>() {
+    override fun createClient(): SecretsManagerAsyncClient = configureBuilder(SecretsManagerAsyncClient.builder()).build()
 }
+

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerClientBuildService.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerClientBuildService.kt
@@ -1,49 +1,24 @@
 package com.kelvsyc.gradle.aws.java.secretsmanager
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
 
 /**
- * Build service managing a synchronous [SecretsManagerClient] instance.
+ * Build service managing a synchronous [SecretsManagerClient] instance with config-cache-safe parameters.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed.
+ * Configure region and credentials via the [AwsBuildServiceParams] extension functions:
+ * ```kotlin
+ * gradle.sharedServices.registerIfAbsent("secretsManager", SecretsManagerClientBuildService::class) {
+ *     parameters {
+ *         regionId.set("us-east-1")
+ *         defaultCredentials()
+ *     }
+ * }
+ * ```
  */
 abstract class SecretsManagerClientBuildService :
-    AbstractClientBuildService<SecretsManagerClient, SecretsManagerClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SecretsManagerClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SecretsManagerClient = SecretsManagerClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+    AbstractAwsJavaClientBuildService<SecretsManagerClient, AwsBuildServiceParams>() {
+    override fun createClient(): SecretsManagerClient = configureBuilder(SecretsManagerClient.builder()).build()
 }
+

--- a/cores/aws-ses-java-base/build.gradle.kts
+++ b/cores/aws-ses-java-base/build.gradle.kts
@@ -13,10 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
 
     api(libs.aws.ses.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
     api(libs.aws.sdk.core.java)
 
     testImplementation(libs.mockk)

--- a/cores/aws-ses-java-base/settings.gradle.kts
+++ b/cores/aws-ses-java-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-ses-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ses/SesAsyncClientBuildService.kt
+++ b/cores/aws-ses-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ses/SesAsyncClientBuildService.kt
@@ -1,50 +1,18 @@
 package com.kelvsyc.gradle.aws.java.ses
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.ses.SesAsyncClient
 
 /**
  * Build service managing an asynchronous [SesAsyncClient] instance.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * tasks and work actions via a `Property<SesAsyncClientBuildService>` parameter.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams.regionId] and credentials as needed using the extension
+ * functions on [AwsBuildServiceParams]. The same registration can then be shared with tasks
+ * and work actions via a `Property<SesAsyncClientBuildService>` parameter.
  */
-abstract class SesAsyncClientBuildService :
-    AbstractClientBuildService<SesAsyncClient, SesAsyncClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SesAsyncClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SesAsyncClient = SesAsyncClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SesAsyncClientBuildService : AbstractAwsJavaClientBuildService<SesAsyncClient, AwsBuildServiceParams>() {
+    override fun createClient(): SesAsyncClient = configureBuilder(SesAsyncClient.builder()).build()
 }
+

--- a/cores/aws-ses-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ses/SesClientBuildService.kt
+++ b/cores/aws-ses-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ses/SesClientBuildService.kt
@@ -1,49 +1,18 @@
 package com.kelvsyc.gradle.aws.java.ses
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.ses.SesClient
 
 /**
  * Build service managing a synchronous [SesClient] instance.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * tasks and work actions via a `Property<SesClientBuildService>` parameter.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams.regionId] and credentials as needed using the extension
+ * functions on [AwsBuildServiceParams]. The same registration can then be shared with tasks
+ * and work actions via a `Property<SesClientBuildService>` parameter.
  */
-abstract class SesClientBuildService : AbstractClientBuildService<SesClient, SesClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SesClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SesClient = SesClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SesClientBuildService : AbstractAwsJavaClientBuildService<SesClient, AwsBuildServiceParams>() {
+    override fun createClient(): SesClient = configureBuilder(SesClient.builder()).build()
 }
+

--- a/cores/aws-sns-java-base/build.gradle.kts
+++ b/cores/aws-sns-java-base/build.gradle.kts
@@ -13,10 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
 
     api(libs.aws.sns.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-sns-java-base/settings.gradle.kts
+++ b/cores/aws-sns-java-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-sns-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sns/SnsAsyncClientBuildService.kt
+++ b/cores/aws-sns-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sns/SnsAsyncClientBuildService.kt
@@ -1,50 +1,18 @@
 package com.kelvsyc.gradle.aws.java.sns
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 
 /**
  * Build service managing an asynchronous [SnsAsyncClient] instance.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<SnsAsyncClientBuildService>` parameter.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams.regionId] and credentials as needed using the extension
+ * functions on [AwsBuildServiceParams]. The same registration can then be shared with value
+ * sources and work actions via a `Property<SnsAsyncClientBuildService>` parameter.
  */
-abstract class SnsAsyncClientBuildService :
-    AbstractClientBuildService<SnsAsyncClient, SnsAsyncClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SnsAsyncClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SnsAsyncClient = SnsAsyncClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SnsAsyncClientBuildService : AbstractAwsJavaClientBuildService<SnsAsyncClient, AwsBuildServiceParams>() {
+    override fun createClient(): SnsAsyncClient = configureBuilder(SnsAsyncClient.builder()).build()
 }
+

--- a/cores/aws-sns-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sns/SnsClientBuildService.kt
+++ b/cores/aws-sns-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sns/SnsClientBuildService.kt
@@ -1,49 +1,18 @@
 package com.kelvsyc.gradle.aws.java.sns
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.sns.SnsClient
 
 /**
  * Build service managing a synchronous [SnsClient] instance.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<SnsClientBuildService>` parameter.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams.regionId] and credentials as needed using the extension
+ * functions on [AwsBuildServiceParams]. The same registration can then be shared with value
+ * sources and work actions via a `Property<SnsClientBuildService>` parameter.
  */
-abstract class SnsClientBuildService : AbstractClientBuildService<SnsClient, SnsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SnsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SnsClient = SnsClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SnsClientBuildService : AbstractAwsJavaClientBuildService<SnsClient, AwsBuildServiceParams>() {
+    override fun createClient(): SnsClient = configureBuilder(SnsClient.builder()).build()
 }
+

--- a/cores/aws-sqs-java-base/build.gradle.kts
+++ b/cores/aws-sqs-java-base/build.gradle.kts
@@ -13,10 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
 
     api(libs.aws.sqs.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-sqs-java-base/settings.gradle.kts
+++ b/cores/aws-sqs-java-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-sqs-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sqs/SqsAsyncClientBuildService.kt
+++ b/cores/aws-sqs-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sqs/SqsAsyncClientBuildService.kt
@@ -1,50 +1,18 @@
 package com.kelvsyc.gradle.aws.java.sqs
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 
 /**
  * Build service managing an asynchronous [SqsAsyncClient] instance.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * tasks and work actions via a `Property<SqsAsyncClientBuildService>` parameter.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams.regionId] and credentials as needed using the extension
+ * functions on [AwsBuildServiceParams]. The same registration can then be shared with tasks
+ * and work actions via a `Property<SqsAsyncClientBuildService>` parameter.
  */
-abstract class SqsAsyncClientBuildService :
-    AbstractClientBuildService<SqsAsyncClient, SqsAsyncClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SqsAsyncClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SqsAsyncClient = SqsAsyncClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SqsAsyncClientBuildService : AbstractAwsJavaClientBuildService<SqsAsyncClient, AwsBuildServiceParams>() {
+    override fun createClient(): SqsAsyncClient = configureBuilder(SqsAsyncClient.builder()).build()
 }
+

--- a/cores/aws-sqs-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sqs/SqsClientBuildService.kt
+++ b/cores/aws-sqs-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sqs/SqsClientBuildService.kt
@@ -1,49 +1,18 @@
 package com.kelvsyc.gradle.aws.java.sqs
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.sqs.SqsClient
 
 /**
  * Build service managing a synchronous [SqsClient] instance.
  *
- * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * tasks and work actions via a `Property<SqsClientBuildService>` parameter.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams.regionId] and credentials as needed using the extension
+ * functions on [AwsBuildServiceParams]. The same registration can then be shared with tasks
+ * and work actions via a `Property<SqsClientBuildService>` parameter.
  */
-abstract class SqsClientBuildService : AbstractClientBuildService<SqsClient, SqsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SqsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to fall back to
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain].
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider].
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SqsClient = SqsClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SqsClientBuildService : AbstractAwsJavaClientBuildService<SqsClient, AwsBuildServiceParams>() {
+    override fun createClient(): SqsClient = configureBuilder(SqsClient.builder()).build()
 }
+

--- a/cores/aws-ssm-java-base/build.gradle.kts
+++ b/cores/aws-ssm-java-base/build.gradle.kts
@@ -13,11 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.ssm.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-ssm-java-base/settings.gradle.kts
+++ b/cores/aws-ssm-java-base/settings.gradle.kts
@@ -7,3 +7,5 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../gradle-extensions")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/SsmClientBuildService.kt
+++ b/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/SsmClientBuildService.kt
@@ -1,36 +1,12 @@
 package com.kelvsyc.gradle.aws.java.ssm
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.ssm.SsmClient
 
 /**
  * Build service managing an [SsmClient] instance.
  */
-abstract class SsmClientBuildService : AbstractClientBuildService<SsmClient, SsmClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SsmClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<Region>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): SsmClient = SsmClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class SsmClientBuildService : AbstractAwsJavaClientBuildService<SsmClient, AwsBuildServiceParams>() {
+    override fun createClient(): SsmClient = configureBuilder(SsmClient.builder()).build()
 }

--- a/cores/aws-sts-java-base/build.gradle.kts
+++ b/cores/aws-sts-java-base/build.gradle.kts
@@ -13,11 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.sts.java)
-    api(libs.aws.auth.java)
-    api(libs.aws.regions.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-sts-java-base/settings.gradle.kts
+++ b/cores/aws-sts-java-base/settings.gradle.kts
@@ -7,3 +7,5 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../gradle-extensions")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/StsClientBuildService.kt
+++ b/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/StsClientBuildService.kt
@@ -1,52 +1,16 @@
 package com.kelvsyc.gradle.aws.java.sts
 
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
-import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
-import software.amazon.awssdk.regions.Region
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
 import software.amazon.awssdk.services.sts.StsClient
 
 /**
  * Build service managing an [StsClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
- * value sources and work actions via a `Property<StsClientBuildService>` parameter.
+ * parameters via the [AwsBuildServiceParams] extension functions as needed. The same registration can then
+ * be shared with value sources and work actions via a `Property<StsClientBuildService>` parameter.
  */
-abstract class StsClientBuildService : AbstractClientBuildService<StsClient, StsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [StsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to identify the region using
-         * [DefaultAwsRegionProviderChain][software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain],
-         * the default used by the AWS SDK for Java.
-         */
-        val region: Property<Region>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * If unset, the client uses [AnonymousCredentialsProvider]. Set to
-         * [DefaultCredentialsProvider][software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider]
-         * to use the default credentials chain.
-         */
-        val credentials: Property<AwsCredentialsProvider>
-    }
-
-    override fun createClient(): StsClient = StsClient.builder().apply {
-        if (parameters.region.isPresent) {
-            region(parameters.region.get())
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider(parameters.credentials.get())
-        } else {
-            credentialsProvider(AnonymousCredentialsProvider.create())
-        }
-    }.build()
+abstract class StsClientBuildService : AbstractAwsJavaClientBuildService<StsClient, AwsBuildServiceParams>() {
+    override fun createClient(): StsClient = configureBuilder(StsClient.builder()).build()
 }

--- a/gradle/plugins/kotlin-convention/src/main/kotlin/com.kelvsyc.internal.kotlin-gradle-library.gradle.kts
+++ b/gradle/plugins/kotlin-convention/src/main/kotlin/com.kelvsyc.internal.kotlin-gradle-library.gradle.kts
@@ -97,4 +97,6 @@ tasks.withType<Test>().configureEach {
             ?.let { listOf("-javaagent:$it") }
             ?: emptyList()
     })
+    // Gradle's ProjectBuilder needs java.lang open for class-loader injection on JDK 25+
+    jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED")
 }


### PR DESCRIPTION
## Summary

- Adds `AwsCredentialSource` enum, `AwsBuildServiceParams` interface, `AbstractAwsJavaClientBuildService` base class, and `AwsBuildServiceParams` extension functions to `aws-java-extensions`, replacing non-serializable `Property<Region>` and `Property<AwsCredentialsProvider>` with config-cache-safe serializable primitives
- Migrates 17 `BuildService` implementations across 11 `aws-*-java-base` components to extend `AbstractAwsJavaClientBuildService` and depend on `aws-java-extensions` instead of `aws.auth.java`/`aws.regions.java` directly
- Adds `--add-opens=java.base/java.lang=ALL-UNNAMED` to the `kotlin-gradle-library` convention's test JVM args for JDK 25 `ProjectBuilder` compatibility

## Test plan

- [ ] `./gradlew :aws-java-extensions:test :aws-java-extensions:detekt` — new unit tests for `resolveRegion`, `resolveCredentialsProvider`, and all extension functions pass
- [ ] `./gradlew :test` — full suite across all components passes
- [ ] Manual smoke test: register a `S3ClientBuildService` in a consumer build with `--configuration-cache` and confirm no serialization error

🤖 Generated with [Claude Code](https://claude.com/claude-code)