### PR TITLE
[aws-kotlin-extensions] Fix config-cache serialization in AWS Kotlin BuildServices

### DIFF
--- a/cores/aws-codeartifact-kotlin-base/README.md
+++ b/cores/aws-codeartifact-kotlin-base/README.md
@@ -19,10 +19,17 @@ dependencies {
 
 ```kotlin
 val codeArtifact = gradle.sharedServices.registerIfAbsent("ca", CodeArtifactClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "ca").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "ca"))
+    }
 }
 ```
+
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Source: `GetAuthorizationTokenValueSource`
 

--- a/cores/aws-codeartifact-kotlin-base/build.gradle.kts
+++ b/cores/aws-codeartifact-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.codeartifact.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.aws.smithy.runtime.core)
     implementation(libs.kotlinx.coroutines.core)
 

--- a/cores/aws-codeartifact-kotlin-base/settings.gradle.kts
+++ b/cores/aws-codeartifact-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/CodeArtifactClientBuildService.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/CodeArtifactClientBuildService.kt
@@ -1,33 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.codeartifact
 
 import aws.sdk.kotlin.services.codeartifact.CodeartifactClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing a [CodeartifactClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
+ * tasks, work actions and value sources via a `Property<CodeArtifactClientBuildService>` parameter.
  */
 abstract class CodeArtifactClientBuildService :
-    AbstractClientBuildService<CodeartifactClient, CodeArtifactClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [CodeArtifactClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<String>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<CredentialsProvider>
-    }
-
+    AbstractAwsKotlinClientBuildService<CodeartifactClient, AwsBuildServiceParams>() {
     override fun createClient(): CodeartifactClient = CodeartifactClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-ecr-kotlin-base/README.md
+++ b/cores/aws-ecr-kotlin-base/README.md
@@ -19,10 +19,17 @@ dependencies {
 
 ```kotlin
 val ecr = gradle.sharedServices.registerIfAbsent("ecr", EcrClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "ecr").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "ecr"))
+    }
 }
 ```
+
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Sources
 

--- a/cores/aws-ecr-kotlin-base/build.gradle.kts
+++ b/cores/aws-ecr-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.ecr.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-ecr-kotlin-base/settings.gradle.kts
+++ b/cores/aws-ecr-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/EcrClientBuildService.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/EcrClientBuildService.kt
@@ -1,32 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.ecr
 
 import aws.sdk.kotlin.services.ecr.EcrClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [EcrClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
+ * tasks, work actions and value sources via a `Property<EcrClientBuildService>` parameter.
  */
-abstract class EcrClientBuildService : AbstractClientBuildService<EcrClient, EcrClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [EcrClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<String>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class EcrClientBuildService :
+    AbstractAwsKotlinClientBuildService<EcrClient, AwsBuildServiceParams>() {
     override fun createClient(): EcrClient = EcrClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-kms-kotlin-base/README.md
+++ b/cores/aws-kms-kotlin-base/README.md
@@ -19,10 +19,17 @@ dependencies {
 
 ```kotlin
 val kms = gradle.sharedServices.registerIfAbsent("kms", KmsClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "kms").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "kms"))
+    }
 }
 ```
+
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Sources
 

--- a/cores/aws-kms-kotlin-base/build.gradle.kts
+++ b/cores/aws-kms-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.kms.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-kms-kotlin-base/settings.gradle.kts
+++ b/cores/aws-kms-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/KmsClientBuildService.kt
+++ b/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/KmsClientBuildService.kt
@@ -1,32 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.kms
 
 import aws.sdk.kotlin.services.kms.KmsClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing a [KmsClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
+ * tasks, work actions and value sources via a `Property<KmsClientBuildService>` parameter.
  */
-abstract class KmsClientBuildService : AbstractClientBuildService<KmsClient, KmsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [KmsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<String>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class KmsClientBuildService :
+    AbstractAwsKotlinClientBuildService<KmsClient, AwsBuildServiceParams>() {
     override fun createClient(): KmsClient = KmsClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-kotlin-extensions/README.md
+++ b/cores/aws-kotlin-extensions/README.md
@@ -1,12 +1,13 @@
 # AWS Kotlin Extensions
 
-A Gradle library providing the base client info interface and Gradle credential adapters for the AWS SDK for Kotlin.
+A Gradle library providing config-cache-safe build service infrastructure and Gradle credential adapters for the AWS
+SDK for Kotlin.
 
 ## Dependency
 
 This library is a transitive dependency of the AWS Kotlin Base plugins (`aws-s3-kotlin-base`,
 `aws-codeartifact-kotlin-base`, etc.). Direct use is only needed when building plugins that define new AWS Kotlin
-client info types.
+client build services or client info types.
 
 ```kotlin
 dependencies {
@@ -14,25 +15,80 @@ dependencies {
 }
 ```
 
-## `AwsClientInfo<T>`
+## `AwsBuildServiceParams`
 
-Base interface for AWS Kotlin SDK client registrations. Extends `ServiceClientInfo<T>` where `T : SdkClient`.
+Config-cache-safe `BuildServiceParameters` interface for AWS Kotlin SDK client build services. All fields are
+serializable primitives; use the extension functions below to configure them rather than setting fields directly.
 
 | Property | Type | Description |
 |---|---|---|
-| `region` | `Property<String>` | AWS region string (e.g. `"us-east-1"`). Leave unset to use the SDK default chain. |
-| `credentials` | `Property<CredentialsProvider>` | Credentials provider. Leave unset to use the SDK default chain. |
+| `region` | `Property<String>` | AWS region identifier (e.g. `"us-east-1"`). Leave unset to delegate region resolution to the AWS SDK for Kotlin's default region provider chain. |
+| `credentialSource` | `Property<AwsCredentialSource>` | Which credentials provider to construct. Leave unset for anonymous mode (no `credentialsProvider` is assigned to the client). |
+| `accessKeyId` | `Property<String>` | Access key ID. Used when `credentialSource` is `STATIC`. |
+| `secretAccessKey` | `Property<String>` | Secret access key. Used when `credentialSource` is `STATIC`. |
+| `sessionToken` | `Property<String>` | Session token for temporary credentials. Optional; used when `credentialSource` is `STATIC`. |
+| `credentialsProfile` | `Property<String>` | Named credentials profile. Used when `credentialSource` is `PROFILE`. |
+
+### Extension functions
+
+Configure an `AwsBuildServiceParams` instance atomically using one of these functions:
+
+```kotlin
+gradle.sharedServices.registerIfAbsent("s3", S3ClientBuildService::class) {
+    parameters {
+        region.set("us-east-1")
+        defaultCredentials()               // DefaultChainCredentialsProvider
+        // anonymous()                     // No credentialsProvider assigned (default)
+        // staticCredentials(akid, secret) // StaticCredentialsProvider with basic Credentials
+        // sessionCredentials(akid, secret, token) // StaticCredentialsProvider with session Credentials
+        // profileCredentials("my-profile")        // ProfileCredentialsProvider
+    }
+}
+```
+
+| Function | Credential result |
+|---|---|
+| `anonymous()` | No `credentialsProvider` is assigned; the AWS SDK for Kotlin falls back to its own default. |
+| `defaultCredentials()` | `DefaultChainCredentialsProvider` (env vars, `~/.aws/credentials`, EC2/ECS metadata, …) |
+| `staticCredentials(accessKey, secretKey)` | `StaticCredentialsProvider` with basic `Credentials` |
+| `sessionCredentials(accessKey, secretKey, token)` | `StaticCredentialsProvider` with session `Credentials` |
+| `profileCredentials(profile)` | `ProfileCredentialsProvider` for the named profile |
+| `from(Provider<PasswordCredentials>)` | `StaticCredentialsProvider`; maps `username` → `accessKeyId`, `password` → `secretAccessKey` |
+| `from(Provider<AwsCredentials>)` | `StaticCredentialsProvider`; maps Gradle `AwsCredentials` fields; uses session credentials when `sessionToken` is non-null |
+
+## `AbstractAwsKotlinClientBuildService<C, P>`
+
+Abstract base class for AWS Kotlin SDK client build services. Because the AWS Kotlin SDK exposes a service-specific
+DSL builder per client (rather than a shared fluent builder type), subclasses apply region and credentials by
+reading `resolveRegion()` and `resolveCredentialsProvider()` from inside their DSL block:
+
+```kotlin
+abstract class SqsClientBuildService :
+    AbstractAwsKotlinClientBuildService<SqsClient, AwsBuildServiceParams>() {
+    override fun createClient(): SqsClient = SqsClient {
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
+    }
+}
+```
+
+| Method | Description |
+|---|---|
+| `resolveRegion(): String?` | Returns the region identifier from `region`, or `null` if unset. |
+| `resolveCredentialsProvider(): CredentialsProvider?` | Constructs the credentials provider from `credentialSource` and its supporting fields. Returns `null` for `ANONYMOUS`/unset, in which case the caller should skip the `credentialsProvider` assignment. |
 
 ## Credential Extensions (`CredentialsProviderExtensions`)
+
+These extensions remain available for non-`BuildServiceParameters` use cases (e.g. constructing a
+`CredentialsProvider` directly for an `AwsClientInfo`-based registration).
 
 ### `Provider<AwsCredentials>.asCredentialsProvider`
 
 Converts a `Provider<org.gradle.api.credentials.AwsCredentials>` to a `Provider<CredentialsProvider>`:
 
 ```kotlin
-// Reads myClientAccessKey, myClientSecretKey, myClientSessionToken Gradle properties
 val gradleCreds = providers.credentials(AwsCredentials::class.java, "myClient")
-credentials.set(gradleCreds.asCredentialsProvider)
+val sdkCreds: Provider<CredentialsProvider> = gradleCreds.asCredentialsProvider
 ```
 
 The resulting `CredentialsProvider` resolves to a `StaticCredentialsProvider` backed by the Gradle credentials.
@@ -48,6 +104,20 @@ val gradleCreds: Provider<AwsCredentials> = sdkCreds.asGradleCredentials
 ```
 
 The returned `AwsCredentials` is immutable — calling any setter throws `UnsupportedOperationException`.
+
+## `AwsClientInfo<T>`
+
+Base interface for AWS Kotlin SDK client registrations in the `ClientsBaseService` container. Extends
+`ServiceClientInfo<T>` where `T : SdkClient`.
+
+| Property | Type | Description |
+|---|---|---|
+| `region` | `Property<String>` | AWS region string (e.g. `"us-east-1"`). Leave unset to use the SDK default chain. |
+| `credentials` | `Property<CredentialsProvider>` | Credentials provider. Leave unset to use the SDK default chain. |
+
+> `AwsClientInfo` is a Gradle extension contract (not a `BuildServiceParameters`), so its `Property<CredentialsProvider>`
+> field does not participate in configuration-cache serialization. For BuildService-based registrations, use
+> `AwsBuildServiceParams` (above) instead.
 
 ## See Also
 

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildService.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildService.kt
@@ -1,0 +1,82 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+import aws.sdk.kotlin.runtime.auth.credentials.DefaultChainCredentialsProvider
+import aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
+import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
+import aws.smithy.kotlin.runtime.client.SdkClient
+import com.kelvsyc.gradle.clients.AbstractClientBuildService
+
+/**
+ * Abstract base class for AWS Kotlin SDK client build services with config-cache-safe parameters.
+ *
+ * Because the AWS Kotlin SDK exposes a service-specific DSL builder per client (rather than a
+ * shared fluent builder type), subclasses apply region and credentials by reading
+ * [resolveRegion] and [resolveCredentialsProvider] from inside their DSL block:
+ *
+ * ```kotlin
+ * abstract class SqsClientBuildService :
+ *     AbstractAwsKotlinClientBuildService<SqsClient, AwsBuildServiceParams>() {
+ *     override fun createClient(): SqsClient = SqsClient {
+ *         resolveRegion()?.let { region = it }
+ *         resolveCredentialsProvider()?.let { credentialsProvider = it }
+ *     }
+ * }
+ * ```
+ *
+ * Configure the service at registration time using the extension functions on
+ * [AwsBuildServiceParams]:
+ *
+ * ```kotlin
+ * gradle.sharedServices.registerIfAbsent("sqs", SqsClientBuildService::class) {
+ *     parameters {
+ *         region.set("us-east-1")
+ *         defaultCredentials()
+ *     }
+ * }
+ * ```
+ *
+ * @param C The AWS Kotlin SDK client type managed by this build service
+ * @param P The [AwsBuildServiceParams] subtype; use [AwsBuildServiceParams] directly unless
+ *   additional parameters are needed
+ */
+abstract class AbstractAwsKotlinClientBuildService<C : SdkClient, P : AwsBuildServiceParams>
+    : AbstractClientBuildService<C, P>() {
+
+    /**
+     * Returns the region identifier from [AwsBuildServiceParams.region], or `null` if unset.
+     *
+     * When `null` is returned and not assigned to the client DSL builder's `region` property, the
+     * AWS SDK for Kotlin falls back to its default region provider chain.
+     */
+    protected fun resolveRegion(): String? = parameters.region.orNull
+
+    /**
+     * Constructs a [CredentialsProvider] from [AwsBuildServiceParams.credentialSource] and its
+     * supporting fields.
+     *
+     * | [AwsCredentialSource] | Result |
+     * |---|---|
+     * | `DEFAULT_CHAIN` | [DefaultChainCredentialsProvider] |
+     * | `STATIC` (no session token) | [StaticCredentialsProvider] with basic [Credentials] |
+     * | `STATIC` (with session token) | [StaticCredentialsProvider] with session [Credentials] |
+     * | `PROFILE` | [ProfileCredentialsProvider] for the named profile |
+     * | `ANONYMOUS` or unset | `null` — caller skips the `credentialsProvider` assignment |
+     */
+    protected fun resolveCredentialsProvider(): CredentialsProvider? =
+        when (parameters.credentialSource.orNull) {
+            AwsCredentialSource.DEFAULT_CHAIN -> DefaultChainCredentialsProvider()
+            AwsCredentialSource.STATIC -> {
+                val key = parameters.accessKeyId.get()
+                val secret = parameters.secretAccessKey.get()
+                val credentials = parameters.sessionToken.orNull
+                    ?.let { Credentials(key, secret, it) }
+                    ?: Credentials(key, secret)
+                StaticCredentialsProvider(credentials)
+            }
+            AwsCredentialSource.PROFILE ->
+                ProfileCredentialsProvider(profileName = parameters.credentialsProfile.get())
+            AwsCredentialSource.ANONYMOUS, null -> null
+        }
+}

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParams.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParams.kt
@@ -1,0 +1,60 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildServiceParameters
+
+/**
+ * Config-cache-safe [BuildServiceParameters] for AWS Kotlin SDK client build services.
+ *
+ * All properties are serializable primitives. Do not set [credentialSource] and its supporting
+ * fields directly; use the extension functions on this interface (e.g. [anonymous],
+ * [defaultCredentials], [staticCredentials], [from]) which atomically configure them together.
+ */
+interface AwsBuildServiceParams : BuildServiceParameters {
+    /**
+     * AWS region identifier, e.g. `"us-east-1"`.
+     *
+     * Leave unset to delegate region resolution to the AWS SDK for Kotlin's default region
+     * provider chain.
+     */
+    val region: Property<String>
+
+    /**
+     * Which credentials provider to construct. Leave unset for anonymous mode (no
+     * `credentialsProvider` is assigned to the client; the SDK falls back to its default).
+     *
+     * Use the extension functions rather than setting this directly.
+     */
+    val credentialSource: Property<AwsCredentialSource>
+
+    /**
+     * AWS access key ID. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     *
+     * Set via [staticCredentials], [sessionCredentials], or [from].
+     */
+    val accessKeyId: Property<String>
+
+    /**
+     * AWS secret access key. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     *
+     * Set via [staticCredentials], [sessionCredentials], or [from].
+     */
+    val secretAccessKey: Property<String>
+
+    /**
+     * AWS session token for temporary credentials. Optional; used when [credentialSource] is
+     * [AwsCredentialSource.STATIC]. When absent, the underlying
+     * [aws.smithy.kotlin.runtime.auth.awscredentials.Credentials] is constructed without a
+     * session token.
+     *
+     * Set via [sessionCredentials] or [from].
+     */
+    val sessionToken: Property<String>
+
+    /**
+     * Named AWS credentials profile. Used when [credentialSource] is [AwsCredentialSource.PROFILE].
+     *
+     * Set via [profileCredentials].
+     */
+    val credentialsProfile: Property<String>
+}

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensions.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensions.kt
@@ -1,0 +1,90 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.api.provider.Provider
+import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
+
+/**
+ * Configures these parameters for anonymous mode. The build service will not assign a
+ * `credentialsProvider` to the AWS Kotlin SDK client.
+ */
+fun AwsBuildServiceParams.anonymous() {
+    credentialSource.set(AwsCredentialSource.ANONYMOUS)
+}
+
+/**
+ * Configures these parameters to use
+ * [DefaultChainCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.DefaultChainCredentialsProvider],
+ * which resolves credentials from environment variables, `~/.aws/credentials`, EC2/ECS/EKS
+ * instance metadata, and other standard sources.
+ */
+fun AwsBuildServiceParams.defaultCredentials() {
+    credentialSource.set(AwsCredentialSource.DEFAULT_CHAIN)
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
+ * with [Credentials][aws.smithy.kotlin.runtime.auth.awscredentials.Credentials] built from the
+ * supplied access key and secret key.
+ */
+fun AwsBuildServiceParams.staticCredentials(accessKey: Provider<String>, secretKey: Provider<String>) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(accessKey)
+    secretAccessKey.set(secretKey)
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
+ * with session [Credentials][aws.smithy.kotlin.runtime.auth.awscredentials.Credentials] built
+ * from the supplied access key, secret key, and session token.
+ */
+fun AwsBuildServiceParams.sessionCredentials(
+    accessKey: Provider<String>,
+    secretKey: Provider<String>,
+    token: Provider<String>,
+) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(accessKey)
+    secretAccessKey.set(secretKey)
+    sessionToken.set(token)
+}
+
+/**
+ * Configures these parameters to use a
+ * [ProfileCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider]
+ * for the named profile.
+ */
+fun AwsBuildServiceParams.profileCredentials(profile: String) {
+    credentialSource.set(AwsCredentialSource.PROFILE)
+    credentialsProfile.set(profile)
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
+ * sourced from Gradle [PasswordCredentials], mapping [PasswordCredentials.getUsername] to the
+ * access key ID and [PasswordCredentials.getPassword] to the secret access key.
+ */
+@JvmName("fromPasswordCredentials")
+fun AwsBuildServiceParams.from(credentials: Provider<PasswordCredentials>) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(credentials.map { it.username })
+    secretAccessKey.set(credentials.map { it.password })
+}
+
+/**
+ * Configures these parameters to use a
+ * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
+ * sourced from Gradle [AwsCredentials][GradleAwsCredentials]. When
+ * [AwsCredentials.getSessionToken][GradleAwsCredentials.getSessionToken] is non-null, session
+ * credentials are used; otherwise basic credentials.
+ */
+@JvmName("fromAwsCredentials")
+fun AwsBuildServiceParams.from(credentials: Provider<GradleAwsCredentials>) {
+    credentialSource.set(AwsCredentialSource.STATIC)
+    accessKeyId.set(credentials.map { it.accessKey })
+    secretAccessKey.set(credentials.map { it.secretKey })
+    sessionToken.set(credentials.map { it.sessionToken ?: "" }.filter { it.isNotEmpty() })
+}

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsCredentialSource.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsCredentialSource.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+/**
+ * Discriminator for which AWS credentials provider to construct from [AwsBuildServiceParams].
+ *
+ * Set via the extension functions on [AwsBuildServiceParams] rather than directly.
+ */
+enum class AwsCredentialSource {
+    /**
+     * No credentials provider. The AWS SDK for Kotlin client receives no `credentialsProvider`
+     * assignment and falls back to its default behavior.
+     */
+    ANONYMOUS,
+
+    /**
+     * Use [aws.sdk.kotlin.runtime.auth.credentials.DefaultChainCredentialsProvider], which checks
+     * environment variables, `~/.aws/credentials`, EC2/ECS/EKS instance credentials, and other
+     * standard sources in order.
+     */
+    DEFAULT_CHAIN,
+
+    /**
+     * Use [aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider] built from
+     * [AwsBuildServiceParams.accessKeyId], [AwsBuildServiceParams.secretAccessKey], and
+     * optionally [AwsBuildServiceParams.sessionToken].
+     */
+    STATIC,
+
+    /**
+     * Use [aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider] for the profile
+     * named by [AwsBuildServiceParams.credentialsProfile].
+     */
+    PROFILE,
+}

--- a/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildServiceSpec.kt
+++ b/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildServiceSpec.kt
@@ -1,0 +1,107 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+import aws.sdk.kotlin.runtime.auth.credentials.DefaultChainCredentialsProvider
+import aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.smithy.kotlin.runtime.client.SdkClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.services.BuildServiceSpec
+import org.gradle.testfixtures.ProjectBuilder
+
+class AbstractAwsKotlinClientBuildServiceSpec : FunSpec() {
+    abstract class TestService : AbstractAwsKotlinClientBuildService<SdkClient, AwsBuildServiceParams>() {
+        fun testResolveRegion() = resolveRegion()
+        fun testResolveCredentialsProvider() = resolveCredentialsProvider()
+        override fun createClient(): SdkClient = error("not used in tests")
+    }
+
+    init {
+        test("resolveRegion - returns null when region is absent") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java)
+
+            service.get().testResolveRegion().shouldBeNull()
+        }
+
+        test("resolveRegion - returns the region identifier when set") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.region.set("us-east-1")
+            }
+
+            service.get().testResolveRegion() shouldBe "us-east-1"
+        }
+
+        test("resolveCredentialsProvider - returns null when credentialSource is absent") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java)
+
+            service.get().testResolveCredentialsProvider().shouldBeNull()
+        }
+
+        test("resolveCredentialsProvider - returns null when credentialSource is ANONYMOUS") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.ANONYMOUS)
+            }
+
+            service.get().testResolveCredentialsProvider().shouldBeNull()
+        }
+
+        test("resolveCredentialsProvider - returns DefaultChainCredentialsProvider when credentialSource is DEFAULT_CHAIN") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.DEFAULT_CHAIN)
+            }
+
+            service.get().testResolveCredentialsProvider().shouldBeInstanceOf<DefaultChainCredentialsProvider>()
+        }
+
+        test("resolveCredentialsProvider - returns StaticCredentialsProvider with basic Credentials when STATIC and no sessionToken") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
+                spec.parameters.accessKeyId.set("AKID")
+                spec.parameters.secretAccessKey.set("SECRET")
+            }
+
+            val provider = service.get().testResolveCredentialsProvider()
+            provider.shouldBeInstanceOf<StaticCredentialsProvider>()
+            val creds = runBlocking { provider.resolve() }
+            creds.accessKeyId shouldBe "AKID"
+            creds.secretAccessKey shouldBe "SECRET"
+            creds.sessionToken.shouldBeNull()
+        }
+
+        test("resolveCredentialsProvider - returns StaticCredentialsProvider with session Credentials when STATIC with sessionToken") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
+                spec.parameters.accessKeyId.set("AKID")
+                spec.parameters.secretAccessKey.set("SECRET")
+                spec.parameters.sessionToken.set("TOKEN")
+            }
+
+            val provider = service.get().testResolveCredentialsProvider()
+            provider.shouldBeInstanceOf<StaticCredentialsProvider>()
+            val creds = runBlocking { provider.resolve() }
+            creds.accessKeyId shouldBe "AKID"
+            creds.secretAccessKey shouldBe "SECRET"
+            creds.sessionToken shouldBe "TOKEN"
+        }
+
+        test("resolveCredentialsProvider - returns ProfileCredentialsProvider when credentialSource is PROFILE") {
+            val project = ProjectBuilder.builder().build()
+            val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
+                spec.parameters.credentialSource.set(AwsCredentialSource.PROFILE)
+                spec.parameters.credentialsProfile.set("my-profile")
+            }
+
+            service.get().testResolveCredentialsProvider().shouldBeInstanceOf<ProfileCredentialsProvider>()
+        }
+    }
+}

--- a/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensionsSpec.kt
+++ b/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensionsSpec.kt
@@ -1,0 +1,107 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.api.credentials.PasswordCredentials
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
+
+class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
+    init {
+        test("anonymous - sets credentialSource to ANONYMOUS") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.anonymous()
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.ANONYMOUS
+        }
+
+        test("defaultCredentials - sets credentialSource to DEFAULT_CHAIN") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.defaultCredentials()
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.DEFAULT_CHAIN
+        }
+
+        test("staticCredentials - sets credentialSource to STATIC and maps accessKey and secretKey") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.staticCredentials(project.provider { "AKID" }, project.provider { "SECRET" })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.isPresent.shouldBeFalse()
+        }
+
+        test("sessionCredentials - sets credentialSource to STATIC and maps all three fields") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.sessionCredentials(
+                project.provider { "AKID" },
+                project.provider { "SECRET" },
+                project.provider { "TOKEN" },
+            )
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.get() shouldBe "TOKEN"
+        }
+
+        test("profileCredentials - sets credentialSource to PROFILE and sets credentialsProfile") {
+            val project = ProjectBuilder.builder().build()
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.profileCredentials("my-profile")
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.PROFILE
+            params.credentialsProfile.get() shouldBe "my-profile"
+        }
+
+        test("from PasswordCredentials - sets STATIC and maps username and password") {
+            val project = ProjectBuilder.builder().build()
+            val creds = mockk<PasswordCredentials>()
+            every { creds.username } returns "AKID"
+            every { creds.password } returns "SECRET"
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.from(project.provider { creds })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.isPresent.shouldBeFalse()
+        }
+
+        test("from GradleAwsCredentials - sets STATIC and maps all fields when sessionToken is present") {
+            val project = ProjectBuilder.builder().build()
+            val creds = mockk<GradleAwsCredentials>()
+            every { creds.accessKey } returns "AKID"
+            every { creds.secretKey } returns "SECRET"
+            every { creds.sessionToken } returns "TOKEN"
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.from(project.provider { creds })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.accessKeyId.get() shouldBe "AKID"
+            params.secretAccessKey.get() shouldBe "SECRET"
+            params.sessionToken.get() shouldBe "TOKEN"
+        }
+
+        test("from GradleAwsCredentials - leaves sessionToken absent when sessionToken is null") {
+            val project = ProjectBuilder.builder().build()
+            val creds = mockk<GradleAwsCredentials>()
+            every { creds.accessKey } returns "AKID"
+            every { creds.secretKey } returns "SECRET"
+            every { creds.sessionToken } returns null
+            val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            params.from(project.provider { creds })
+
+            params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
+            params.sessionToken.isPresent.shouldBeFalse()
+        }
+    }
+}

--- a/cores/aws-lambda-kotlin-base/README.md
+++ b/cores/aws-lambda-kotlin-base/README.md
@@ -19,10 +19,17 @@ dependencies {
 
 ```kotlin
 val lambda = gradle.sharedServices.registerIfAbsent("lambda", LambdaClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "lambda").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "lambda"))
+    }
 }
 ```
+
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Sources
 

--- a/cores/aws-lambda-kotlin-base/build.gradle.kts
+++ b/cores/aws-lambda-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.lambda.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-lambda-kotlin-base/settings.gradle.kts
+++ b/cores/aws-lambda-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/LambdaClientBuildService.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/LambdaClientBuildService.kt
@@ -1,32 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.lambda
 
 import aws.sdk.kotlin.services.lambda.LambdaClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing a [LambdaClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
+ * tasks, work actions and value sources via a `Property<LambdaClientBuildService>` parameter.
  */
-abstract class LambdaClientBuildService : AbstractClientBuildService<LambdaClient, LambdaClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [LambdaClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<String>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class LambdaClientBuildService :
+    AbstractAwsKotlinClientBuildService<LambdaClient, AwsBuildServiceParams>() {
     override fun createClient(): LambdaClient = LambdaClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-s3-kotlin-base/README.md
+++ b/cores/aws-s3-kotlin-base/README.md
@@ -20,13 +20,17 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val s3 = gradle.sharedServices.registerIfAbsent("s3", S3ClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "s3").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "s3"))
+    }
 }
 ```
 
-Both parameters are optional. Leave `region` unset to fall back to the AWS SDK for Kotlin default region provider
-chain, and leave `credentials` unset to fall back to the default credentials provider chain.
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Source: `AbstractS3ValueSource`
 

--- a/cores/aws-s3-kotlin-base/build.gradle.kts
+++ b/cores/aws-s3-kotlin-base/build.gradle.kts
@@ -13,10 +13,10 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
     implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.s3.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.aws.core.kotlin)
     implementation(libs.aws.smithy.runtime.core)
     implementation(libs.kotlinx.coroutines.core)

--- a/cores/aws-s3-kotlin-base/settings.gradle.kts
+++ b/cores/aws-s3-kotlin-base/settings.gradle.kts
@@ -7,4 +7,5 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")
 includeBuild("../gradle-extensions")

--- a/cores/aws-s3-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/s3/S3ClientBuildService.kt
+++ b/cores/aws-s3-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/s3/S3ClientBuildService.kt
@@ -1,44 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.s3
 
 import aws.sdk.kotlin.services.s3.S3Client
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [S3Client] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
  * tasks, work actions and value sources via a `Property<S3ClientBuildService>` parameter.
  */
-abstract class S3ClientBuildService : AbstractClientBuildService<S3Client, S3ClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [S3ClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to identify the region using the default region provider chain of the AWS SDK for Kotlin.
-         */
-        val region: Property<String>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * Leave unset to identify credentials using the default credentials provider chain of the AWS SDK for Kotlin.
-         */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class S3ClientBuildService :
+    AbstractAwsKotlinClientBuildService<S3Client, AwsBuildServiceParams>() {
     override fun createClient(): S3Client = S3Client {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-secrets-manager-kotlin-base/README.md
+++ b/cores/aws-secrets-manager-kotlin-base/README.md
@@ -19,10 +19,17 @@ dependencies {
 
 ```kotlin
 val sm = gradle.sharedServices.registerIfAbsent("sm", SecretsManagerClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "sm").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "sm"))
+    }
 }
 ```
+
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Sources
 

--- a/cores/aws-secrets-manager-kotlin-base/build.gradle.kts
+++ b/cores/aws-secrets-manager-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.secrets.manager.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-secrets-manager-kotlin-base/settings.gradle.kts
+++ b/cores/aws-secrets-manager-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerClientBuildService.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerClientBuildService.kt
@@ -1,33 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.secretsmanager
 
 import aws.sdk.kotlin.services.secretsmanager.SecretsManagerClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing a [SecretsManagerClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
+ * tasks, work actions and value sources via a `Property<SecretsManagerClientBuildService>` parameter.
  */
 abstract class SecretsManagerClientBuildService :
-    AbstractClientBuildService<SecretsManagerClient, SecretsManagerClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SecretsManagerClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<String>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<CredentialsProvider>
-    }
-
+    AbstractAwsKotlinClientBuildService<SecretsManagerClient, AwsBuildServiceParams>() {
     override fun createClient(): SecretsManagerClient = SecretsManagerClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-ses-kotlin-base/README.md
+++ b/cores/aws-ses-kotlin-base/README.md
@@ -21,13 +21,17 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val ses = gradle.sharedServices.registerIfAbsent("ses", SesClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "ses").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "ses"))
+    }
 }
 ```
 
-Both parameters are optional. Leave `region` unset to fall back to the AWS SDK for Kotlin default region provider
-chain, and leave `credentials` unset to fall back to the default credentials provider chain.
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## WorkActions
 

--- a/cores/aws-ses-kotlin-base/build.gradle.kts
+++ b/cores/aws-ses-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.ses.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-ses-kotlin-base/settings.gradle.kts
+++ b/cores/aws-ses-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-ses-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ses/SesClientBuildService.kt
+++ b/cores/aws-ses-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ses/SesClientBuildService.kt
@@ -1,44 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.ses
 
 import aws.sdk.kotlin.services.ses.SesClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [SesClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
  * tasks and work actions via a `Property<SesClientBuildService>` parameter.
  */
-abstract class SesClientBuildService : AbstractClientBuildService<SesClient, SesClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SesClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to identify the region using the default region provider chain of the AWS SDK for Kotlin.
-         */
-        val region: Property<String>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * Leave unset to identify credentials using the default credentials provider chain of the AWS SDK for Kotlin.
-         */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class SesClientBuildService :
+    AbstractAwsKotlinClientBuildService<SesClient, AwsBuildServiceParams>() {
     override fun createClient(): SesClient = SesClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-sns-kotlin-base/README.md
+++ b/cores/aws-sns-kotlin-base/README.md
@@ -21,13 +21,17 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val sns = gradle.sharedServices.registerIfAbsent("sns", SnsClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "sns").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "sns"))
+    }
 }
 ```
 
-Both parameters are optional. Leave `region` unset to fall back to the AWS SDK for Kotlin default region provider
-chain, and leave `credentials` unset to fall back to the default credentials provider chain.
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## WorkAction: `PublishAction`
 

--- a/cores/aws-sns-kotlin-base/build.gradle.kts
+++ b/cores/aws-sns-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.sns.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-sns-kotlin-base/settings.gradle.kts
+++ b/cores/aws-sns-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-sns-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/SnsClientBuildService.kt
+++ b/cores/aws-sns-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/SnsClientBuildService.kt
@@ -1,44 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.sns
 
 import aws.sdk.kotlin.services.sns.SnsClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [SnsClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
  * tasks and work actions via a `Property<SnsClientBuildService>` parameter.
  */
-abstract class SnsClientBuildService : AbstractClientBuildService<SnsClient, SnsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SnsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to identify the region using the default region provider chain of the AWS SDK for Kotlin.
-         */
-        val region: Property<String>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * Leave unset to identify credentials using the default credentials provider chain of the AWS SDK for Kotlin.
-         */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class SnsClientBuildService :
+    AbstractAwsKotlinClientBuildService<SnsClient, AwsBuildServiceParams>() {
     override fun createClient(): SnsClient = SnsClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-sqs-kotlin-base/README.md
+++ b/cores/aws-sqs-kotlin-base/README.md
@@ -21,13 +21,17 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val sqs = gradle.sharedServices.registerIfAbsent("sqs", SqsClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "sqs").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "sqs"))
+    }
 }
 ```
 
-Both parameters are optional. Leave `region` unset to fall back to the AWS SDK for Kotlin default region provider
-chain, and leave `credentials` unset to fall back to the default credentials provider chain.
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## WorkAction: `SendMessageAction`
 

--- a/cores/aws-sqs-kotlin-base/build.gradle.kts
+++ b/cores/aws-sqs-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.sqs.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-sqs-kotlin-base/settings.gradle.kts
+++ b/cores/aws-sqs-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-sqs-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sqs/SqsClientBuildService.kt
+++ b/cores/aws-sqs-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sqs/SqsClientBuildService.kt
@@ -1,44 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.sqs
 
 import aws.sdk.kotlin.services.sqs.SqsClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [SqsClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
  * tasks and work actions via a `Property<SqsClientBuildService>` parameter.
  */
-abstract class SqsClientBuildService : AbstractClientBuildService<SqsClient, SqsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SqsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to identify the region using the default region provider chain of the AWS SDK for Kotlin.
-         */
-        val region: Property<String>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * Leave unset to identify credentials using the default credentials provider chain of the AWS SDK for Kotlin.
-         */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class SqsClientBuildService :
+    AbstractAwsKotlinClientBuildService<SqsClient, AwsBuildServiceParams>() {
     override fun createClient(): SqsClient = SqsClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-ssm-kotlin-base/README.md
+++ b/cores/aws-ssm-kotlin-base/README.md
@@ -19,10 +19,17 @@ dependencies {
 
 ```kotlin
 val ssm = gradle.sharedServices.registerIfAbsent("ssm", SsmClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "ssm").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "ssm"))
+    }
 }
 ```
+
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 ## Value Sources
 

--- a/cores/aws-ssm-kotlin-base/build.gradle.kts
+++ b/cores/aws-ssm-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.ssm.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-ssm-kotlin-base/settings.gradle.kts
+++ b/cores/aws-ssm-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/SsmClientBuildService.kt
+++ b/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/SsmClientBuildService.kt
@@ -1,32 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.ssm
 
 import aws.sdk.kotlin.services.ssm.SsmClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [SsmClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
+ * tasks, work actions and value sources via a `Property<SsmClientBuildService>` parameter.
  */
-abstract class SsmClientBuildService : AbstractClientBuildService<SsmClient, SsmClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [SsmClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /** The AWS region that the client communicates with. */
-        val region: Property<String>
-
-        /** The credentials provider used to authenticate with AWS. */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class SsmClientBuildService :
+    AbstractAwsKotlinClientBuildService<SsmClient, AwsBuildServiceParams>() {
     override fun createClient(): SsmClient = SsmClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }

--- a/cores/aws-sts-kotlin-base/README.md
+++ b/cores/aws-sts-kotlin-base/README.md
@@ -21,19 +21,23 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val sts = gradle.sharedServices.registerIfAbsent("sts", StsClientBuildService::class) {
-    parameters.region.set("us-east-1")
-    parameters.credentials.set(providers.credentials(AwsCredentials::class.java, "sts").asCredentialsProvider)
+    parameters {
+        region.set("us-east-1")
+        from(providers.credentials(AwsCredentials::class.java, "sts"))
+    }
 }
 ```
 
-Both parameters are optional. Leave `region` unset to fall back to the AWS SDK for Kotlin default region provider
-chain, and leave `credentials` unset to fall back to the default credentials provider chain.
+Both `region` and the credentials extension call are optional. Leave `region` unset to use the AWS SDK for Kotlin
+default region provider chain. Omit the credentials call to skip the `credentialsProvider` assignment, in which
+case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
+set of credential configuration functions.
 
 > [!NOTE]
 > For assume-role use cases, configure the AWS SDK's `StsAssumeRoleCredentialsProvider` and use it as the
-> `credentials` of the *target* client (e.g. an `S3ClientBuildService`) rather than going through this plugin.
-> Exposing raw temporary credentials via a `ValueSource` is not supported, since `ValueSource` results may be
-> cached or logged.
+> credentials provider of the *target* client (e.g. an `S3ClientBuildService`) rather than going through this
+> plugin. Exposing raw temporary credentials via a `ValueSource` is not supported, since `ValueSource` results
+> may be cached or logged.
 
 ## Value Sources
 

--- a/cores/aws-sts-kotlin-base/build.gradle.kts
+++ b/cores/aws-sts-kotlin-base/build.gradle.kts
@@ -13,9 +13,9 @@ configure<DokkaExtension> {
 
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
 
     api(libs.aws.sts.kotlin)
-    api(libs.aws.smithy.credentials)
     implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)

--- a/cores/aws-sts-kotlin-base/settings.gradle.kts
+++ b/cores/aws-sts-kotlin-base/settings.gradle.kts
@@ -7,3 +7,4 @@ plugins {
 }
 
 includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/StsClientBuildService.kt
+++ b/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/StsClientBuildService.kt
@@ -1,44 +1,22 @@
 package com.kelvsyc.gradle.aws.kotlin.sts
 
 import aws.sdk.kotlin.services.sts.StsClient
-import aws.smithy.kotlin.runtime.auth.awscredentials.CredentialsProvider
-import com.kelvsyc.gradle.clients.AbstractClientBuildService
-import org.gradle.api.provider.Property
-import org.gradle.api.services.BuildServiceParameters
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
 
 /**
  * Build service managing an [StsClient] instance.
  *
  * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
- * [Params.region] and [Params.credentials] as needed. The same registration can then be shared with
+ * the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared with
  * value sources and work actions via a `Property<StsClientBuildService>` parameter.
  */
-abstract class StsClientBuildService : AbstractClientBuildService<StsClient, StsClientBuildService.Params>() {
-    /**
-     * Configuration parameters for [StsClientBuildService].
-     */
-    interface Params : BuildServiceParameters {
-        /**
-         * The AWS region that the client communicates with.
-         *
-         * Leave unset to identify the region using the default region provider chain of the AWS SDK for Kotlin.
-         */
-        val region: Property<String>
-
-        /**
-         * The credentials provider used to authenticate with AWS.
-         *
-         * Leave unset to identify credentials using the default credentials provider chain of the AWS SDK for Kotlin.
-         */
-        val credentials: Property<CredentialsProvider>
-    }
-
+abstract class StsClientBuildService :
+    AbstractAwsKotlinClientBuildService<StsClient, AwsBuildServiceParams>() {
     override fun createClient(): StsClient = StsClient {
-        if (parameters.region.isPresent) {
-            region = parameters.region.get()
-        }
-        if (parameters.credentials.isPresent) {
-            credentialsProvider = parameters.credentials.get()
-        }
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
     }
 }


### PR DESCRIPTION
## Summary

Mirrors the Java-side fix from #539 for the Kotlin SDK family. Replaces the non-serializable `Property<CredentialsProvider>` on every `aws-*-kotlin-base` BuildService with a serializable `AwsBuildServiceParams` (region string + `AwsCredentialSource` enum + supporting string fields), reconstructing the SDK credentials provider inside `createClient()`. Adds `AbstractAwsKotlinClientBuildService` plus credential extension functions (`anonymous`, `defaultCredentials`, `staticCredentials`, `sessionCredentials`, `profileCredentials`, `from(...)`) to `aws-kotlin-extensions`, and migrates all 11 credential-bearing services; `aws-imds-kotlin-base` is out of scope.

## Test plan

- [x] `./gradlew :test` passes
- [x] Per-module detekt passes for all 12 affected modules
- [x] `./gradlew :aws-sqs-kotlin-base:test :aws-s3-kotlin-base:test --rerun-tasks --configuration-cache --configuration-cache-problems=fail` succeeds
- [x] `./gradlew :build -x :aws-sns-java-base:integrationTest` succeeds (the excluded integration test is a pre-existing failure on `main` from #539 referencing removed properties)

🤖 Generated with [Claude Code](https://claude.com/claude-code)