### PR TITLE
[Phase C] Add config-cache integration tests to 7 components

### DIFF
--- a/cores/artifactory-base/build.gradle.kts
+++ b/cores/artifactory-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,139 @@
+package com.kelvsyc.gradle.artifactory
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `ArtifactoryClientBuildService.Params`.
+ *
+ * `Params.credentials` is `Property<PasswordCredentials>`. Unlike the AWS and GCP params that were
+ * redesigned to hold only primitives, this property holds a Gradle interface type. Two questions are probed:
+ *
+ * 1. Does an `ObjectFactory`-managed `PasswordCredentials` instance round-trip cleanly? (Gradle managed
+ *    types participate in the CC codec via the managed-type serialization path.)
+ * 2. Does a plain non-managed implementation of `PasswordCredentials` (i.e. [FakePasswordCredentials])
+ *    survive the CC round-trip? (Expected: no — it is neither a Gradle managed type nor `Serializable`.)
+ *
+ * A failing "managed credentials" test would justify decomposing `Property<PasswordCredentials>` into
+ * `Property<String>` username + password fields (see Phase C decomposition PR). A failing "fake credentials"
+ * test confirms the decomposition is necessary for defensive correctness even if the managed path works.
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    test("ArtifactoryClientBuildService with no parameters survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "no-params",
+            credentialsBlock = ""
+        )
+    }
+
+    test("ArtifactoryClientBuildService with url-only survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "url-only",
+            credentialsBlock = """url.set("https://example.jfrog.io/artifactory")"""
+        )
+    }
+
+    test("ArtifactoryClientBuildService with ObjectFactory-managed PasswordCredentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "managed-credentials",
+            credentialsBlock = """
+                url.set("https://example.jfrog.io/artifactory")
+                credentials.set(project.objects.newInstance(org.gradle.api.credentials.PasswordCredentials::class.java).also {
+                    it.username = "user"
+                    it.password = "s3cr3t"
+                })
+            """.trimIndent()
+        )
+    }
+
+    test("ArtifactoryClientBuildService with non-managed PasswordCredentials fails config-cache") {
+        val projectDir = writeFakeCredentialsProject()
+        val outcome = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        // FINDING: a plain PasswordCredentials implementation that is not a Gradle managed type and
+        // does not implement Serializable cannot be serialized by Gradle's CC codec. Users must either
+        // use objects.newInstance(PasswordCredentials::class.java) or wait for the decomposition to
+        // Property<String> username + password (Phase C follow-up).
+        outcome.shouldBeInstanceOf<ProbeOutcome.Failed>()
+    }
+})
+
+private fun assertParamsRoundTripCleanly(name: String, credentialsBlock: String) {
+    val projectDir = writeConfigCacheProbeProject(name = name, credentialsBlock = credentialsBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeConfigCacheProbeProject(name: String, credentialsBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("artifactory-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.artifactory.ArtifactoryClientBuildService
+        import com.kelvsyc.gradle.artifactory.fixtures.ArtifactoryClientBuildServiceProbeTask
+
+        val artService = gradle.sharedServices.registerIfAbsent(
+            "artifactory",
+            ArtifactoryClientBuildService::class
+        ) {
+            parameters {
+                $credentialsBlock
+            }
+        }
+
+        tasks.register<ArtifactoryClientBuildServiceProbeTask>("probe") {
+            service.set(artService)
+            usesService(artService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}
+
+private fun writeFakeCredentialsProject(): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("artifactory-config-cache-fake-credentials")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.artifactory.ArtifactoryClientBuildService
+        import com.kelvsyc.gradle.artifactory.fixtures.ArtifactoryClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.artifactory.fixtures.FakePasswordCredentials
+
+        val artService = gradle.sharedServices.registerIfAbsent(
+            "artifactory",
+            ArtifactoryClientBuildService::class
+        ) {
+            parameters {
+                url.set("https://example.jfrog.io/artifactory")
+                credentials.set(FakePasswordCredentials("user", "s3cr3t"))
+            }
+        }
+
+        tasks.register<ArtifactoryClientBuildServiceProbeTask>("probe") {
+            service.set(artService)
+            usesService(artService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/IntegrationTestSupport.kt
+++ b/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/IntegrationTestSupport.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.artifactory
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+internal sealed interface ProbeOutcome {
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/fixtures/ArtifactoryClientBuildServiceProbeTask.kt
+++ b/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/fixtures/ArtifactoryClientBuildServiceProbeTask.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.artifactory.fixtures
+
+import com.kelvsyc.gradle.artifactory.ArtifactoryClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `ArtifactoryClientBuildService` parameters at task-execution time by querying
+ * the `service` property. The body never calls `getClient()` so the probe stays focused on the isolation
+ * boundary — in particular whether `Params.credentials: Property<PasswordCredentials>` survives the
+ * config-cache round-trip.
+ */
+abstract class ArtifactoryClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<ArtifactoryClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/fixtures/FakePasswordCredentials.kt
+++ b/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/fixtures/FakePasswordCredentials.kt
@@ -1,0 +1,23 @@
+package com.kelvsyc.gradle.artifactory.fixtures
+
+import org.gradle.api.credentials.PasswordCredentials
+
+/**
+ * A plain (non-Gradle-managed, non-`Serializable`) implementation of [PasswordCredentials], used to probe
+ * whether Gradle's config-cache codec can serialize `Property<PasswordCredentials>` when the value is a
+ * direct implementation rather than a managed instance created via `ObjectFactory`.
+ *
+ * The expected outcome is failure: Gradle's CC codec has no codec for arbitrary implementations of
+ * [PasswordCredentials] that are not managed types or `Serializable`. The corresponding test in
+ * [com.kelvsyc.gradle.artifactory.BuildServiceConfigurationCacheSpec] pins this expectation so that any
+ * future relaxation in Gradle's CC codec surfaces immediately.
+ */
+class FakePasswordCredentials(
+    private var username: String? = null,
+    private var password: String? = null,
+) : PasswordCredentials {
+    override fun getUsername(): String? = username
+    override fun setUsername(userName: String?) { username = userName }
+    override fun getPassword(): String? = password
+    override fun setPassword(password: String?) { this.password = password }
+}

--- a/cores/aws-imds-java-base/build.gradle.kts
+++ b/cores/aws-imds-java-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,157 @@
+package com.kelvsyc.gradle.aws.java.imds
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `ImdsClientBuildService.Params` and
+ * `ImdsAsyncClientBuildService.Params`.
+ *
+ * Both services share the same parameter shape:
+ * - `endpoint: Property<String>` — trivially CC-safe
+ * - `endpointMode: Property<EndpointMode>` — `EndpointMode` is a standard Java enum from the AWS SDK,
+ *   so Gradle's CC codec handles it via the built-in enum serialization path (by name). Expected to succeed.
+ *
+ * These tests confirm the expectation and serve as regression sentinels: if a future AWS SDK release changes
+ * `EndpointMode` away from a standard enum, one of these tests will go red.
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    // --- ImdsClientBuildService (sync) ---
+
+    test("ImdsClientBuildService with no parameters survives config-cache round-trip") {
+        assertImdsRoundTripCleanly(name = "no-params", parametersBlock = "")
+    }
+
+    test("ImdsClientBuildService with endpoint-only survives config-cache round-trip") {
+        assertImdsRoundTripCleanly(
+            name = "endpoint-only",
+            parametersBlock = """endpoint.set("http://169.254.169.254/")"""
+        )
+    }
+
+    test("ImdsClientBuildService with endpointMode enum survives config-cache round-trip") {
+        assertImdsRoundTripCleanly(
+            name = "endpoint-mode",
+            parametersBlock = "endpointMode.set(EndpointMode.IPV4)"
+        )
+    }
+
+    test("ImdsClientBuildService with endpoint and endpointMode together survives config-cache round-trip") {
+        assertImdsRoundTripCleanly(
+            name = "endpoint-and-mode",
+            parametersBlock = """
+                endpoint.set("http://169.254.169.254/")
+                endpointMode.set(EndpointMode.IPV6)
+            """.trimIndent()
+        )
+    }
+
+    // --- ImdsAsyncClientBuildService ---
+
+    test("ImdsAsyncClientBuildService with no parameters survives config-cache round-trip") {
+        assertImdsAsyncRoundTripCleanly(name = "no-params", parametersBlock = "")
+    }
+
+    test("ImdsAsyncClientBuildService with endpointMode enum survives config-cache round-trip") {
+        assertImdsAsyncRoundTripCleanly(
+            name = "endpoint-mode",
+            parametersBlock = "endpointMode.set(EndpointMode.IPV4)"
+        )
+    }
+})
+
+private fun assertImdsRoundTripCleanly(name: String, parametersBlock: String) {
+    val projectDir = writeImdsProbeProject(name = name, parametersBlock = parametersBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun assertImdsAsyncRoundTripCleanly(name: String, parametersBlock: String) {
+    val projectDir = writeImdsAsyncProbeProject(name = name, parametersBlock = parametersBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeImdsProbeProject(name: String, parametersBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("imds-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import software.amazon.awssdk.imds.EndpointMode
+        import com.kelvsyc.gradle.aws.java.imds.ImdsClientBuildService
+        import com.kelvsyc.gradle.aws.java.imds.fixtures.ImdsClientBuildServiceProbeTask
+
+        val imdsService = gradle.sharedServices.registerIfAbsent(
+            "imds",
+            ImdsClientBuildService::class
+        ) {
+            parameters {
+                $parametersBlock
+            }
+        }
+
+        tasks.register<ImdsClientBuildServiceProbeTask>("probe") {
+            service.set(imdsService)
+            usesService(imdsService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}
+
+private fun writeImdsAsyncProbeProject(name: String, parametersBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("imds-async-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import software.amazon.awssdk.imds.EndpointMode
+        import com.kelvsyc.gradle.aws.java.imds.ImdsAsyncClientBuildService
+        import com.kelvsyc.gradle.aws.java.imds.fixtures.ImdsAsyncClientBuildServiceProbeTask
+
+        val imdsService = gradle.sharedServices.registerIfAbsent(
+            "imds-async",
+            ImdsAsyncClientBuildService::class
+        ) {
+            parameters {
+                $parametersBlock
+            }
+        }
+
+        tasks.register<ImdsAsyncClientBuildServiceProbeTask>("probe") {
+            service.set(imdsService)
+            usesService(imdsService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/IntegrationTestSupport.kt
+++ b/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/IntegrationTestSupport.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.imds
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+internal sealed interface ProbeOutcome {
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/fixtures/ImdsAsyncClientBuildServiceProbeTask.kt
+++ b/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/fixtures/ImdsAsyncClientBuildServiceProbeTask.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.aws.java.imds.fixtures
+
+import com.kelvsyc.gradle.aws.java.imds.ImdsAsyncClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `ImdsAsyncClientBuildService` parameters at task-execution time by querying
+ * the `service` property. The body never calls `getClient()` so the probe stays focused on the isolation
+ * boundary — in particular whether `Params.endpointMode: Property<EndpointMode>` (an AWS SDK enum) survives
+ * the config-cache round-trip.
+ */
+abstract class ImdsAsyncClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<ImdsAsyncClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/fixtures/ImdsClientBuildServiceProbeTask.kt
+++ b/cores/aws-imds-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/imds/fixtures/ImdsClientBuildServiceProbeTask.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.aws.java.imds.fixtures
+
+import com.kelvsyc.gradle.aws.java.imds.ImdsClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `ImdsClientBuildService` parameters at task-execution time by querying the
+ * `service` property. The body never calls `getClient()` so the probe stays focused on the isolation
+ * boundary — in particular whether `Params.endpointMode: Property<EndpointMode>` (an AWS SDK enum) survives
+ * the config-cache round-trip.
+ */
+abstract class ImdsClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<ImdsClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/aws-s3-java-base/build.gradle.kts
+++ b/cores/aws-s3-java-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,82 @@
+package com.kelvsyc.gradle.aws.java.s3
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `S3ClientBuildService.Params` (a.k.a. `AwsBuildServiceParams`).
+ *
+ * `S3ClientBuildService` adds no extra parameters beyond `AwsBuildServiceParams`, making it the purest
+ * possible regression sentinel for the abstract base. A trimmed test matrix (empty params + static
+ * credentials) is sufficient to catch any per-component override that bypasses `AbstractAwsJavaClientBuildService`.
+ *
+ * For the full `AwsCredentialSource` branch matrix, see `aws-sns-java-base`'s `BuildServiceConfigurationCacheSpec`.
+ * For the nested `baseService` BuildService-reference case, see [S3TransferManagerConfigurationCacheSpec].
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    test("S3ClientBuildService with no parameter values survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(name = "no-params", parametersBlock = "")
+    }
+
+    test("S3ClientBuildService with static credentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "static-credentials",
+            parametersBlock = """
+                regionId.set("us-east-1")
+                credentialSource.set(AwsCredentialSource.STATIC)
+                accessKeyId.set("ak")
+                secretAccessKey.set("sk")
+            """.trimIndent()
+        )
+    }
+})
+
+private fun assertParamsRoundTripCleanly(name: String, parametersBlock: String) {
+    val projectDir = writeConfigCacheProbeProject(name = name, parametersBlock = parametersBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeConfigCacheProbeProject(name: String, parametersBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("s3-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.java.AwsCredentialSource
+        import com.kelvsyc.gradle.aws.java.s3.S3ClientBuildService
+        import com.kelvsyc.gradle.aws.java.s3.fixtures.S3ClientBuildServiceProbeTask
+
+        val s3Service = gradle.sharedServices.registerIfAbsent(
+            "s3",
+            S3ClientBuildService::class
+        ) {
+            parameters {
+                $parametersBlock
+            }
+        }
+
+        tasks.register<S3ClientBuildServiceProbeTask>("probe") {
+            service.set(s3Service)
+            usesService(s3Service)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/IntegrationTestSupport.kt
+++ b/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/IntegrationTestSupport.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.s3
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+internal sealed interface ProbeOutcome {
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/S3TransferManagerConfigurationCacheSpec.kt
+++ b/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/S3TransferManagerConfigurationCacheSpec.kt
@@ -1,0 +1,124 @@
+package com.kelvsyc.gradle.aws.java.s3
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `S3TransferManagerBuildService.Params`.
+ *
+ * `S3TransferManagerBuildService` introduces a `baseService: Property<S3AsyncClientBuildService>` parameter —
+ * a BuildService reference nested inside another BuildService's parameters. Gradle's config-cache codec can
+ * only serialize this reference when the value is the `Provider<S3AsyncClientBuildService>` obtained from
+ * `gradle.sharedServices.registerIfAbsent` (stored as the registration name). A raw `ObjectFactory`-managed
+ * instance bypasses the registry and cannot be serialized.
+ *
+ * ### Variant A — registered base service (expected to succeed)
+ *
+ * Both services are registered; the `Provider<S3AsyncClientBuildService>` from registration is set on
+ * `Params.baseService`. This is the correct usage pattern.
+ *
+ * ### Variant B — unregistered ObjectFactory instance (expected to fail)
+ *
+ * `baseService` is set to an instance created via `objects.newInstance()` rather than registered via
+ * `registerIfAbsent`. Gradle cannot locate this instance by service name when restoring the config-cache
+ * entry, so the build fails. This variant documents the constraint so that future changes in Gradle's CC
+ * codec surface immediately if the rule ever relaxes.
+ */
+class S3TransferManagerConfigurationCacheSpec : FunSpec({
+    test("Variant A - S3TransferManagerBuildService with registered base service survives config-cache round-trip") {
+        val projectDir = writeVariantAProject()
+
+        val first = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+        firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+        val second = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+        secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+        secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+    }
+
+    test("Variant B - S3TransferManagerBuildService with unregistered base service instance fails config-cache") {
+        val projectDir = writeVariantBProject()
+        val outcome = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        // FINDING: baseService must be set via the Provider<S3AsyncClientBuildService> from
+        // registerIfAbsent, not via an ObjectFactory-managed instance. The CC codec serializes
+        // BuildService references by registration name; an unregistered instance has no name.
+        outcome.shouldBeInstanceOf<ProbeOutcome.Failed>()
+    }
+})
+
+private fun writeVariantAProject(): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("s3-transfer-manager-variant-a")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.java.s3.S3AsyncClientBuildService
+        import com.kelvsyc.gradle.aws.java.s3.S3TransferManagerBuildService
+        import com.kelvsyc.gradle.aws.java.s3.fixtures.S3TransferManagerBuildServiceProbeTask
+
+        val s3AsyncService = gradle.sharedServices.registerIfAbsent(
+            "s3-async",
+            S3AsyncClientBuildService::class
+        ) { }
+
+        val transferManagerService = gradle.sharedServices.registerIfAbsent(
+            "s3-transfer-manager",
+            S3TransferManagerBuildService::class
+        ) {
+            parameters {
+                baseService.set(s3AsyncService)
+            }
+        }
+
+        tasks.register<S3TransferManagerBuildServiceProbeTask>("probe") {
+            service.set(transferManagerService)
+            usesService(transferManagerService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}
+
+private fun writeVariantBProject(): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("s3-transfer-manager-variant-b")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.java.s3.S3AsyncClientBuildService
+        import com.kelvsyc.gradle.aws.java.s3.S3TransferManagerBuildService
+        import com.kelvsyc.gradle.aws.java.s3.fixtures.S3TransferManagerBuildServiceProbeTask
+
+        val rawAsyncService = objects.newInstance(S3AsyncClientBuildService::class.java)
+
+        val transferManagerService = gradle.sharedServices.registerIfAbsent(
+            "s3-transfer-manager",
+            S3TransferManagerBuildService::class
+        ) {
+            parameters {
+                baseService.set(rawAsyncService)
+            }
+        }
+
+        tasks.register<S3TransferManagerBuildServiceProbeTask>("probe") {
+            service.set(transferManagerService)
+            usesService(transferManagerService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/fixtures/S3ClientBuildServiceProbeTask.kt
+++ b/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/fixtures/S3ClientBuildServiceProbeTask.kt
@@ -1,0 +1,24 @@
+package com.kelvsyc.gradle.aws.java.s3.fixtures
+
+import com.kelvsyc.gradle.aws.java.s3.S3ClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `S3ClientBuildService` parameters at task-execution time by querying the
+ * `service` property. The body never calls `getClient()` so that the probe stays focused on the isolation
+ * boundary, not on AWS SDK runtime concerns like default region resolution.
+ */
+abstract class S3ClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<S3ClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/fixtures/S3TransferManagerBuildServiceProbeTask.kt
+++ b/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/fixtures/S3TransferManagerBuildServiceProbeTask.kt
@@ -1,0 +1,24 @@
+package com.kelvsyc.gradle.aws.java.s3.fixtures
+
+import com.kelvsyc.gradle.aws.java.s3.S3TransferManagerBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `S3TransferManagerBuildService` parameters at task-execution time by querying
+ * the `service` property. The body never calls `getClient()` so the probe stays focused on the parameter
+ * isolation boundary, including the nested `baseService: Property<S3AsyncClientBuildService>` reference.
+ */
+abstract class S3TransferManagerBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<S3TransferManagerBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/aws-secrets-manager-java-base/build.gradle.kts
+++ b/cores/aws-secrets-manager-java-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,80 @@
+package com.kelvsyc.gradle.aws.java.secretsmanager
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `SecretsManagerClientBuildService.Params` (a.k.a. `AwsBuildServiceParams`).
+ *
+ * A trimmed matrix (empty params + static credentials) is sufficient to catch any per-component override
+ * that bypasses `AbstractAwsJavaClientBuildService`. For the full `AwsCredentialSource` branch matrix, see
+ * `aws-sns-java-base`'s `BuildServiceConfigurationCacheSpec`. For the nested `baseService` reference case,
+ * see [SecretCacheConfigurationCacheSpec].
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    test("SecretsManagerClientBuildService with no parameter values survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(name = "no-params", parametersBlock = "")
+    }
+
+    test("SecretsManagerClientBuildService with static credentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "static-credentials",
+            parametersBlock = """
+                regionId.set("us-east-1")
+                credentialSource.set(AwsCredentialSource.STATIC)
+                accessKeyId.set("ak")
+                secretAccessKey.set("sk")
+            """.trimIndent()
+        )
+    }
+})
+
+private fun assertParamsRoundTripCleanly(name: String, parametersBlock: String) {
+    val projectDir = writeConfigCacheProbeProject(name = name, parametersBlock = parametersBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeConfigCacheProbeProject(name: String, parametersBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("secrets-manager-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.java.AwsCredentialSource
+        import com.kelvsyc.gradle.aws.java.secretsmanager.SecretsManagerClientBuildService
+        import com.kelvsyc.gradle.aws.java.secretsmanager.fixtures.SecretsManagerClientBuildServiceProbeTask
+
+        val smService = gradle.sharedServices.registerIfAbsent(
+            "secretsManager",
+            SecretsManagerClientBuildService::class
+        ) {
+            parameters {
+                $parametersBlock
+            }
+        }
+
+        tasks.register<SecretsManagerClientBuildServiceProbeTask>("probe") {
+            service.set(smService)
+            usesService(smService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/IntegrationTestSupport.kt
+++ b/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/IntegrationTestSupport.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.secretsmanager
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+internal sealed interface ProbeOutcome {
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretCacheConfigurationCacheSpec.kt
+++ b/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretCacheConfigurationCacheSpec.kt
@@ -1,0 +1,124 @@
+package com.kelvsyc.gradle.aws.java.secretsmanager
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `SecretCacheBuildService.Params`.
+ *
+ * `SecretCacheBuildService` introduces a `baseService: Property<SecretsManagerClientBuildService>` parameter —
+ * a BuildService reference nested inside another BuildService's parameters. Gradle's config-cache codec can
+ * only serialize this reference when the value is the `Provider<SecretsManagerClientBuildService>` obtained
+ * from `gradle.sharedServices.registerIfAbsent` (stored as the registration name). A raw `ObjectFactory`-managed
+ * instance bypasses the registry and cannot be serialized.
+ *
+ * ### Variant A — registered base service (expected to succeed)
+ *
+ * Both services are registered; the `Provider<SecretsManagerClientBuildService>` from registration is set on
+ * `Params.baseService`. This is the correct usage pattern.
+ *
+ * ### Variant B — unregistered ObjectFactory instance (expected to fail)
+ *
+ * `baseService` is set to an instance created via `objects.newInstance()` rather than registered via
+ * `registerIfAbsent`. Gradle cannot locate this instance by service name when restoring the config-cache
+ * entry, so the build fails. This variant documents the constraint so that future changes in Gradle's CC
+ * codec surface immediately if the rule ever relaxes.
+ */
+class SecretCacheConfigurationCacheSpec : FunSpec({
+    test("Variant A - SecretCacheBuildService with registered base service survives config-cache round-trip") {
+        val projectDir = writeVariantAProject()
+
+        val first = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+        firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+        val second = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+        secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+        secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+    }
+
+    test("Variant B - SecretCacheBuildService with unregistered base service instance fails config-cache") {
+        val projectDir = writeVariantBProject()
+        val outcome = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        // FINDING: baseService must be set via the Provider<SecretsManagerClientBuildService> from
+        // registerIfAbsent, not via an ObjectFactory-managed instance. The CC codec serializes
+        // BuildService references by registration name; an unregistered instance has no name.
+        outcome.shouldBeInstanceOf<ProbeOutcome.Failed>()
+    }
+})
+
+private fun writeVariantAProject(): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("secret-cache-variant-a")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.java.secretsmanager.SecretCacheBuildService
+        import com.kelvsyc.gradle.aws.java.secretsmanager.SecretsManagerClientBuildService
+        import com.kelvsyc.gradle.aws.java.secretsmanager.fixtures.SecretCacheBuildServiceProbeTask
+
+        val smService = gradle.sharedServices.registerIfAbsent(
+            "secretsManager",
+            SecretsManagerClientBuildService::class
+        ) { }
+
+        val cacheService = gradle.sharedServices.registerIfAbsent(
+            "secretCache",
+            SecretCacheBuildService::class
+        ) {
+            parameters {
+                baseService.set(smService)
+            }
+        }
+
+        tasks.register<SecretCacheBuildServiceProbeTask>("probe") {
+            service.set(cacheService)
+            usesService(cacheService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}
+
+private fun writeVariantBProject(): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("secret-cache-variant-b")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.java.secretsmanager.SecretCacheBuildService
+        import com.kelvsyc.gradle.aws.java.secretsmanager.SecretsManagerClientBuildService
+        import com.kelvsyc.gradle.aws.java.secretsmanager.fixtures.SecretCacheBuildServiceProbeTask
+
+        val rawSmService = objects.newInstance(SecretsManagerClientBuildService::class.java)
+
+        val cacheService = gradle.sharedServices.registerIfAbsent(
+            "secretCache",
+            SecretCacheBuildService::class
+        ) {
+            parameters {
+                baseService.set(rawSmService)
+            }
+        }
+
+        tasks.register<SecretCacheBuildServiceProbeTask>("probe") {
+            service.set(cacheService)
+            usesService(cacheService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/fixtures/SecretCacheBuildServiceProbeTask.kt
+++ b/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/fixtures/SecretCacheBuildServiceProbeTask.kt
@@ -1,0 +1,24 @@
+package com.kelvsyc.gradle.aws.java.secretsmanager.fixtures
+
+import com.kelvsyc.gradle.aws.java.secretsmanager.SecretCacheBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `SecretCacheBuildService` parameters at task-execution time by querying the
+ * `service` property. The body never calls `getClient()` so the probe focuses on the parameter isolation
+ * boundary, including the nested `baseService: Property<SecretsManagerClientBuildService>` reference.
+ */
+abstract class SecretCacheBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<SecretCacheBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/fixtures/SecretsManagerClientBuildServiceProbeTask.kt
+++ b/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/fixtures/SecretsManagerClientBuildServiceProbeTask.kt
@@ -1,0 +1,24 @@
+package com.kelvsyc.gradle.aws.java.secretsmanager.fixtures
+
+import com.kelvsyc.gradle.aws.java.secretsmanager.SecretsManagerClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `SecretsManagerClientBuildService` parameters at task-execution time by
+ * querying the `service` property. The body never calls `getClient()` so that the probe stays focused on the
+ * isolation boundary, not on AWS SDK runtime concerns like default region resolution.
+ */
+abstract class SecretsManagerClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<SecretsManagerClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/aws-sns-kotlin-base/build.gradle.kts
+++ b/cores/aws-sns-kotlin-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,144 @@
+package com.kelvsyc.gradle.aws.kotlin.sns
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `SnsClientBuildService.Params` (a.k.a. `AwsBuildServiceParams`
+ * from `aws-kotlin-extensions`).
+ *
+ * Each test pins down the **observed** behavior of the parameter shape — `region: Property<String>`,
+ * `credentialSource: Property<AwsCredentialSource>`, `accessKeyId/secretAccessKey/sessionToken: Property<String>`,
+ * `credentialsProfile: Property<String>`. A failing test means either Gradle's config-cache serializer or the
+ * AWS Kotlin extensions have regressed; investigate before "fixing" the test.
+ *
+ * ### What this characterizes
+ *
+ * The AWS Kotlin SDK's `CredentialsProvider` is a suspending interface that is not serializable by Gradle's
+ * configuration-cache codec, so `AwsBuildServiceParams` exposes only serializable primitives and the SDK types
+ * are reconstructed inside `createClient()`. These tests exercise that contract: each branch of
+ * [com.kelvsyc.gradle.aws.kotlin.AwsCredentialSource] survives the BuildService parameter-isolation round-trip,
+ * region names round-trip, and a second invocation reuses the stored configuration cache entry rather than
+ * rebuilding it.
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    test("BuildService with no parameter values survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(name = "no-params", parametersBlock = "")
+    }
+
+    test("BuildService with region set survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "region",
+            parametersBlock = """region.set("us-east-1")"""
+        )
+    }
+
+    test("BuildService with anonymous credentialSource survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "anonymous",
+            parametersBlock = "credentialSource.set(AwsCredentialSource.ANONYMOUS)"
+        )
+    }
+
+    test("BuildService with static credentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "static-credentials",
+            parametersBlock = """
+                credentialSource.set(AwsCredentialSource.STATIC)
+                accessKeyId.set("ak")
+                secretAccessKey.set("sk")
+            """.trimIndent()
+        )
+    }
+
+    test("BuildService with session credentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "session-credentials",
+            parametersBlock = """
+                credentialSource.set(AwsCredentialSource.STATIC)
+                accessKeyId.set("ak")
+                secretAccessKey.set("sk")
+                sessionToken.set("tok")
+            """.trimIndent()
+        )
+    }
+
+    test("BuildService with profile credentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "profile-credentials",
+            parametersBlock = """
+                credentialSource.set(AwsCredentialSource.PROFILE)
+                credentialsProfile.set("default")
+            """.trimIndent()
+        )
+    }
+
+    test("BuildService with default credentials chain survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "default-chain",
+            parametersBlock = "credentialSource.set(AwsCredentialSource.DEFAULT_CHAIN)"
+        )
+    }
+
+    test("BuildService with region and static credentials together survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "region-and-static",
+            parametersBlock = """
+                region.set("us-east-1")
+                credentialSource.set(AwsCredentialSource.STATIC)
+                accessKeyId.set("ak")
+                secretAccessKey.set("sk")
+            """.trimIndent()
+        )
+    }
+})
+
+private fun assertParamsRoundTripCleanly(name: String, parametersBlock: String) {
+    val projectDir = writeConfigCacheProbeProject(name = name, parametersBlock = parametersBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeConfigCacheProbeProject(name: String, parametersBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("sns-kotlin-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.aws.kotlin.AwsCredentialSource
+        import com.kelvsyc.gradle.aws.kotlin.sns.SnsClientBuildService
+        import com.kelvsyc.gradle.aws.kotlin.sns.fixtures.SnsClientBuildServiceProbeTask
+
+        val snsService = gradle.sharedServices.registerIfAbsent(
+            "sns",
+            SnsClientBuildService::class
+        ) {
+            parameters {
+                $parametersBlock
+            }
+        }
+
+        tasks.register<SnsClientBuildServiceProbeTask>("probe") {
+            service.set(snsService)
+            usesService(snsService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/IntegrationTestSupport.kt
+++ b/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/IntegrationTestSupport.kt
@@ -1,0 +1,70 @@
+package com.kelvsyc.gradle.aws.kotlin.sns
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    /**
+     * Returns a Kotlin DSL `buildscript { }` block that puts the host component's runtime classpath onto the
+     * generated project's buildscript classpath, so type references in the generated `build.gradle.kts`
+     * resolve at script-compile time.
+     */
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    /** Creates a fresh temp directory whose lifetime spans the spec invocation. */
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    /**
+     * Runs a TestKit invocation with the supplied arguments, capturing whether it succeeded or failed and
+     * the relevant outcome details. Useful for observation-style probes where either result is a meaningful
+     * finding and we want to encode the *current* behavior so future changes in either direction surface.
+     */
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+/** Outcome of a TestKit probe: either it built or it failed with a captured message. */
+internal sealed interface ProbeOutcome {
+    /** The TestKit invocation built successfully. */
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+
+    /** The TestKit invocation failed with the captured error message from the Gradle reporter. */
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/fixtures/SnsClientBuildServiceProbeTask.kt
+++ b/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/fixtures/SnsClientBuildServiceProbeTask.kt
@@ -1,0 +1,24 @@
+package com.kelvsyc.gradle.aws.kotlin.sns.fixtures
+
+import com.kelvsyc.gradle.aws.kotlin.sns.SnsClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `SnsClientBuildService` parameters at task-execution time by querying the
+ * `service` property. The body never calls `getClient()` so that the probe stays focused on the isolation
+ * boundary, not on AWS SDK runtime concerns like default region resolution.
+ */
+abstract class SnsClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<SnsClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/bitbucket-cloud-base/build.gradle.kts
+++ b/cores/bitbucket-cloud-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,137 @@
+package com.kelvsyc.gradle.bitbucket.cloud
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `BitbucketCloudClientBuildService.Params`.
+ *
+ * `Params.credentials` is `Property<PasswordCredentials>`. Unlike the AWS and GCP params that hold only
+ * primitives, this property holds a Gradle interface type. Two questions are probed:
+ *
+ * 1. Does an `ObjectFactory`-managed `PasswordCredentials` instance round-trip cleanly? (Gradle managed
+ *    types participate in the CC codec via the managed-type serialization path.)
+ * 2. Does a plain non-managed implementation of `PasswordCredentials` (i.e. [FakePasswordCredentials])
+ *    survive the CC round-trip? (Expected: no — it is neither a Gradle managed type nor `Serializable`.)
+ *
+ * A failing "managed credentials" test would justify decomposing `Property<PasswordCredentials>` into
+ * `Property<String>` username + password fields. A failing "fake credentials" test confirms the decomposition
+ * is necessary for defensive correctness even if the managed path works.
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    test("BitbucketCloudClientBuildService with no parameters survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "no-params",
+            credentialsBlock = ""
+        )
+    }
+
+    test("BitbucketCloudClientBuildService with baseUrl-only survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "base-url-only",
+            credentialsBlock = """baseUrl.set("https://api.bitbucket.org/2.0/")"""
+        )
+    }
+
+    test("BitbucketCloudClientBuildService with ObjectFactory-managed PasswordCredentials survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "managed-credentials",
+            credentialsBlock = """
+                credentials.set(project.objects.newInstance(org.gradle.api.credentials.PasswordCredentials::class.java).also {
+                    it.username = "user"
+                    it.password = "apppassword"
+                })
+            """.trimIndent()
+        )
+    }
+
+    test("BitbucketCloudClientBuildService with non-managed PasswordCredentials fails config-cache") {
+        val projectDir = writeFakeCredentialsProject()
+        val outcome = IntegrationTestSupport.runProbe(
+            projectDir, "probe", "--configuration-cache", "--stacktrace"
+        )
+        // FINDING: a plain PasswordCredentials implementation that is not a Gradle managed type and
+        // does not implement Serializable cannot be serialized by Gradle's CC codec. Users must either
+        // use objects.newInstance(PasswordCredentials::class.java) or wait for the decomposition to
+        // Property<String> username + password (Phase C follow-up).
+        outcome.shouldBeInstanceOf<ProbeOutcome.Failed>()
+    }
+})
+
+private fun assertParamsRoundTripCleanly(name: String, credentialsBlock: String) {
+    val projectDir = writeConfigCacheProbeProject(name = name, credentialsBlock = credentialsBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeConfigCacheProbeProject(name: String, credentialsBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("bitbucket-cloud-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.bitbucket.cloud.BitbucketCloudClientBuildService
+        import com.kelvsyc.gradle.bitbucket.cloud.fixtures.BitbucketCloudClientBuildServiceProbeTask
+
+        val bbService = gradle.sharedServices.registerIfAbsent(
+            "bitbucketCloud",
+            BitbucketCloudClientBuildService::class
+        ) {
+            parameters {
+                $credentialsBlock
+            }
+        }
+
+        tasks.register<BitbucketCloudClientBuildServiceProbeTask>("probe") {
+            service.set(bbService)
+            usesService(bbService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}
+
+private fun writeFakeCredentialsProject(): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("bitbucket-cloud-config-cache-fake-credentials")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.bitbucket.cloud.BitbucketCloudClientBuildService
+        import com.kelvsyc.gradle.bitbucket.cloud.fixtures.BitbucketCloudClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.bitbucket.cloud.fixtures.FakePasswordCredentials
+
+        val bbService = gradle.sharedServices.registerIfAbsent(
+            "bitbucketCloud",
+            BitbucketCloudClientBuildService::class
+        ) {
+            parameters {
+                credentials.set(FakePasswordCredentials("user", "apppassword"))
+            }
+        }
+
+        tasks.register<BitbucketCloudClientBuildServiceProbeTask>("probe") {
+            service.set(bbService)
+            usesService(bbService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/IntegrationTestSupport.kt
+++ b/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/IntegrationTestSupport.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.bitbucket.cloud
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+internal sealed interface ProbeOutcome {
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/fixtures/BitbucketCloudClientBuildServiceProbeTask.kt
+++ b/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/fixtures/BitbucketCloudClientBuildServiceProbeTask.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.bitbucket.cloud.fixtures
+
+import com.kelvsyc.gradle.bitbucket.cloud.BitbucketCloudClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `BitbucketCloudClientBuildService` parameters at task-execution time by
+ * querying the `service` property. The body never calls `getClient()` so the probe stays focused on the
+ * isolation boundary — in particular whether `Params.credentials: Property<PasswordCredentials>` survives
+ * the config-cache round-trip.
+ */
+abstract class BitbucketCloudClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<BitbucketCloudClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}

--- a/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/fixtures/FakePasswordCredentials.kt
+++ b/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/fixtures/FakePasswordCredentials.kt
@@ -1,0 +1,23 @@
+package com.kelvsyc.gradle.bitbucket.cloud.fixtures
+
+import org.gradle.api.credentials.PasswordCredentials
+
+/**
+ * A plain (non-Gradle-managed, non-`Serializable`) implementation of [PasswordCredentials], used to probe
+ * whether Gradle's config-cache codec can serialize `Property<PasswordCredentials>` when the value is a
+ * direct implementation rather than a managed instance created via `ObjectFactory`.
+ *
+ * The expected outcome is failure: Gradle's CC codec has no codec for arbitrary implementations of
+ * [PasswordCredentials] that are not managed types or `Serializable`. The corresponding test in
+ * [com.kelvsyc.gradle.bitbucket.cloud.BuildServiceConfigurationCacheSpec] pins this expectation so that any
+ * future relaxation in Gradle's CC codec surfaces immediately.
+ */
+class FakePasswordCredentials(
+    private var username: String? = null,
+    private var password: String? = null,
+) : PasswordCredentials {
+    override fun getUsername(): String? = username
+    override fun setUsername(userName: String?) { username = userName }
+    override fun getPassword(): String? = password
+    override fun setPassword(password: String?) { this.password = password }
+}

--- a/cores/bitbucket-data-center-base/build.gradle.kts
+++ b/cores/bitbucket-data-center-base/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.kelvsyc.internal.dokka")
     id("com.kelvsyc.internal.jacoco")
     id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.gradle-integration-test")
     id("com.kelvsyc.internal.github-publishing")
 }
 

--- a/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/BuildServiceConfigurationCacheSpec.kt
@@ -1,0 +1,83 @@
+package com.kelvsyc.gradle.bitbucket.server
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+/**
+ * Probe: configuration-cache round-trip of `BitbucketServerClientBuildService.Params`.
+ *
+ * All parameters are `Property<String>` (`baseUrl`, `token`), so the CC codec trivially handles them.
+ * This spec serves as a baseline regression sentinel: if any future change to the params shape introduces
+ * a non-serializable type, at least one test here will go red.
+ */
+class BuildServiceConfigurationCacheSpec : FunSpec({
+    test("BitbucketServerClientBuildService with no parameters survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(name = "no-params", parametersBlock = "")
+    }
+
+    test("BitbucketServerClientBuildService with token-only survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "token-only",
+            parametersBlock = """token.set("mytoken")"""
+        )
+    }
+
+    test("BitbucketServerClientBuildService with baseUrl and token survives config-cache round-trip") {
+        assertParamsRoundTripCleanly(
+            name = "base-url-and-token",
+            parametersBlock = """
+                baseUrl.set("https://bitbucket.example.com/")
+                token.set("mytoken")
+            """.trimIndent()
+        )
+    }
+})
+
+private fun assertParamsRoundTripCleanly(name: String, parametersBlock: String) {
+    val projectDir = writeConfigCacheProbeProject(name = name, parametersBlock = parametersBlock)
+
+    val first = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val firstSucceeded = first.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    firstSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+
+    val second = IntegrationTestSupport.runProbe(
+        projectDir, "probe", "--configuration-cache", "--stacktrace"
+    )
+    val secondSucceeded = second.shouldBeInstanceOf<ProbeOutcome.Succeeded>()
+    secondSucceeded.result.task(":probe")?.outcome shouldBe TaskOutcome.SUCCESS
+    secondSucceeded.result.output shouldContain "Configuration cache entry reused"
+}
+
+private fun writeConfigCacheProbeProject(name: String, parametersBlock: String): File {
+    val projectDir = IntegrationTestSupport.newProjectDir("bitbucket-server-config-cache-$name")
+    File(projectDir, "settings.gradle.kts").writeText("")
+    File(projectDir, "build.gradle.kts").writeText(
+        """
+        ${IntegrationTestSupport.buildscriptBlock()}
+
+        import com.kelvsyc.gradle.bitbucket.server.BitbucketServerClientBuildService
+        import com.kelvsyc.gradle.bitbucket.server.fixtures.BitbucketServerClientBuildServiceProbeTask
+
+        val bbService = gradle.sharedServices.registerIfAbsent(
+            "bitbucketServer",
+            BitbucketServerClientBuildService::class
+        ) {
+            parameters {
+                $parametersBlock
+            }
+        }
+
+        tasks.register<BitbucketServerClientBuildServiceProbeTask>("probe") {
+            service.set(bbService)
+            usesService(bbService)
+        }
+        """.trimIndent()
+    )
+    return projectDir
+}

--- a/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/IntegrationTestSupport.kt
+++ b/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/IntegrationTestSupport.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.bitbucket.server
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+/**
+ * Utilities shared by the integration-test specs in this module.
+ *
+ * The convention plugin `com.kelvsyc.internal.gradle-integration-test` exposes the host component's runtime
+ * classpath (plus the `integrationTest` source set output) via the `integration-test.host-classpath` system
+ * property. Specs emit that classpath into the generated TestKit project's `buildscript { }` block so the
+ * daemon can resolve the host component's types and the synthetic fixture classes living in this source set.
+ */
+internal object IntegrationTestSupport {
+    private val hostClasspath: String
+        get() = requireNotNull(System.getProperty("integration-test.host-classpath")) {
+            "integration-test.host-classpath system property not set; convention plugin not applied?"
+        }
+
+    fun buildscriptBlock(): String {
+        val entries = hostClasspath.split(File.pathSeparator).joinToString(",\n            ") { path ->
+            "\"" + path.replace("\\", "\\\\") + "\""
+        }
+        return """
+            buildscript {
+                dependencies {
+                    classpath(files(
+                        $entries
+                    ))
+                }
+            }
+        """.trimIndent()
+    }
+
+    fun newProjectDir(prefix: String): File =
+        createTempDirectory(prefix).toFile().apply { deleteOnExit() }
+
+    fun runProbe(projectDir: File, vararg args: String): ProbeOutcome {
+        val runner = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(*args)
+            .forwardOutput()
+        return runCatching { runner.build() }.fold(
+            onSuccess = { ProbeOutcome.Succeeded(it) },
+            onFailure = { ProbeOutcome.Failed(it.message.orEmpty()) }
+        )
+    }
+}
+
+internal sealed interface ProbeOutcome {
+    data class Succeeded(val result: BuildResult) : ProbeOutcome
+    data class Failed(val message: String) : ProbeOutcome
+}

--- a/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/fixtures/BitbucketServerClientBuildServiceProbeTask.kt
+++ b/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/fixtures/BitbucketServerClientBuildServiceProbeTask.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.bitbucket.server.fixtures
+
+import com.kelvsyc.gradle.bitbucket.server.BitbucketServerClientBuildService
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Forces Gradle to isolate the `BitbucketServerClientBuildService` parameters at task-execution time by
+ * querying the `service` property. The body never calls `getClient()` so the probe stays focused on the
+ * isolation boundary. All params are `Property<String>` so this should always succeed; the probe serves as
+ * a baseline regression sentinel.
+ */
+abstract class BitbucketServerClientBuildServiceProbeTask : DefaultTask() {
+    /** The BuildService whose parameters are under serialization probe. */
+    @get:Internal
+    abstract val service: Property<BitbucketServerClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val s = service.get()
+        logger.lifecycle("service-class={}", s::class.qualifiedName)
+    }
+}


### PR DESCRIPTION
## Summary

- **`aws-sns-kotlin-base`**: Full 8-branch `BuildServiceConfigurationCacheSpec` proving `AbstractAwsKotlinClientBuildService` survives Gradle's parameter-isolation boundary for every `AwsCredentialSource` variant — the Kotlin-side parallel of the existing Java SNS spec.
- **`aws-s3-java-base`**: Lightweight `S3ClientBuildService` spot-check (empty + static credentials) plus a two-variant `S3TransferManagerBuildService` probe — Variant A (registered base via `Provider`) passes; Variant B (`ObjectFactory`-managed raw instance) documents the constraint that only registered service providers are CC-serializable.
- **`aws-secrets-manager-java-base`**: `SecretsManagerClientBuildService` spot-check plus the same Variant A/B probe for `SecretCacheBuildService`, which holds a nested `Property<SecretsManagerClientBuildService>`.
- **`artifactory-base`**: Characterizes `Property<PasswordCredentials>` — empty and url-only cases pass; `ObjectFactory`-managed instance probed; `FakePasswordCredentials` (non-`Serializable` direct impl) asserted to fail, motivating the follow-up decomposition PR (C8).
- **`bitbucket-cloud-base`**: Same `PasswordCredentials` characterization, with its own `FakePasswordCredentials` fixture.
- **`bitbucket-data-center-base`**: All-primitive (`String`) params baseline (empty, token-only, `baseUrl`+token) — regression sentinel confirming no CC risk.
- **`aws-imds-java-base`**: `Property<EndpointMode>` enum probe for both `ImdsClientBuildService` and `ImdsAsyncClientBuildService` — confirms Java enums round-trip through Gradle's CC codec without issue.

All 7 suites pass; `detektIntegrationTest` clean across all new source sets.

## Test plan

- [ ] `./gradlew :aws-sns-kotlin-base:integrationTest` — 8 tests green
- [ ] `./gradlew :aws-s3-java-base:integrationTest` — S3 spot-check + TransferManager Variant A/B green
- [ ] `./gradlew :aws-secrets-manager-java-base:integrationTest` — SM spot-check + SecretCache Variant A/B green
- [ ] `./gradlew :artifactory-base:integrationTest` — empty/url/managed-credentials pass; fake-credentials fails as expected
- [ ] `./gradlew :bitbucket-cloud-base:integrationTest` — same pattern as above
- [ ] `./gradlew :bitbucket-data-center-base:integrationTest` — all-primitive cases green
- [ ] `./gradlew :aws-imds-java-base:integrationTest` — enum cases green

🤖 Generated with [Claude Code](https://claude.com/claude-code)