### PR TITLE
[Phase D/E] Expand CI integration-test coverage and document CC conventions

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -55,7 +55,21 @@ jobs:
       - name: Integration Tests
         # Blocking step: TestKit probes for configuration-cache and WorkerExecutor serialization
         # boundaries. Runs after :build so unit-test feedback comes first.
-        run: ./gradlew :aws-sns-java-base:integrationTest :google-cloud-storage-base:integrationTest :azure-blob-storage-base:integrationTest :aggregation:testing:collectIntegrationTestReports
+        # When adding a new *-base component with a BuildService, also add it here and to the
+        # integrationTestComponents set in aggregation/testing/build.gradle.kts.
+        run: >-
+          ./gradlew
+          :artifactory-base:integrationTest
+          :aws-imds-java-base:integrationTest
+          :aws-s3-java-base:integrationTest
+          :aws-secrets-manager-java-base:integrationTest
+          :aws-sns-java-base:integrationTest
+          :aws-sns-kotlin-base:integrationTest
+          :azure-blob-storage-base:integrationTest
+          :bitbucket-cloud-base:integrationTest
+          :bitbucket-data-center-base:integrationTest
+          :google-cloud-storage-base:integrationTest
+          :aggregation:testing:collectIntegrationTestReports
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,41 @@ includeBuild("../clients-base")  // if needed
 
 Do not modify these — they wire up the composite build correctly.
 
+## Configuration Cache (CC) Rules for BuildService Components ⚠️
+
+These rules apply whenever you create or modify a `*-base` component that contains a `BuildService`.
+
+### Rule 1 — `BuildServiceParameters` must be CC-serializable
+
+Only `Property<T>` where T is a primitive, `String`, enum, or `java.io.Serializable` type is safe. **Never place SDK types directly on parameters** — they are not CC-serializable:
+
+| Forbidden | Replacement |
+|---|---|
+| `Property<PasswordCredentials>` | `Property<String>` username + `Property<String>` password |
+| `Property<Region>` (AWS) | `Property<String>` regionId |
+| `Property<CredentialsProvider>` | `Property<String>` accessKeyId + secretAccessKey + sessionToken + `Property<AwsCredentialSource>` |
+| `Property<Credentials>` (GCP) | `Property<String>` credentialsJson, or use a `CredentialSource` enum |
+| `Property<TokenCredential>` (Azure) | `Property<String>` clientId + tenantId + clientSecret / clientCertificate |
+
+Reconstruct the SDK object inside `createClient()` using the stored string parameters.
+
+### Rule 2 — Nested `BuildService` refs must be registered providers
+
+When a `WorkAction` or task parameter holds a `Property<SomeBuildService>`, it **must** be set via the provider returned from `gradle.sharedServices.registerIfAbsent(...)`. Passing an instance created via `ObjectFactory.newInstance()` bypasses registration and breaks CC because Gradle stores the service name to re-resolve it across cache hits.
+
+### Rule 3 — Every new `*-base` component with a BuildService must ship a CC probe
+
+When adding a new `*-base` component that defines a `BuildService`:
+
+1. Apply `id("com.kelvsyc.internal.gradle-integration-test")` in the component's `build.gradle.kts`.
+2. Create `src/integrationTest/kotlin/.../fixtures/<Service>ProbeTask.kt` — a minimal `DefaultTask` that holds `@get:Internal abstract val service: Property<YourBuildService>` and calls `service.get()` in its `@TaskAction`.
+3. Create `src/integrationTest/kotlin/.../BuildServiceConfigurationCacheSpec.kt` — at minimum, one test case with no parameters to prove the empty-params round-trip works. Follow the pattern established in `artifactory-base` and `bitbucket-cloud-base`.
+4. Add the component name to **both**:
+   - The `integrationTestComponents` set in `aggregation/testing/build.gradle.kts`
+   - The `Integration Tests` step in `.github/workflows/gradle-build.yml`
+
+Skipping any of these four steps means CC breakage will be invisible in CI.
+
 ## Quick Navigation
 
 - **Architecture & detailed build hierarchy**: See `CLAUDE.md`

--- a/aggregation/testing/build.gradle.kts
+++ b/aggregation/testing/build.gradle.kts
@@ -24,10 +24,19 @@ reporting {
 // surfaced separately as a copy task. The `test-report-aggregation` plugin's variant resolution does not
 // gracefully handle a testsuite name that only some dependencies expose, so we collect the raw JUnit XML
 // files directly from each opted-in core. CI globs the same locations independently for JUnit annotation.
+// When adding a new *-base component with a BuildService, also add it here and to the
+// Integration Tests step in .github/workflows/gradle-build.yml.
 val integrationTestComponents = setOf(
+    "artifactory-base",
+    "aws-imds-java-base",
+    "aws-s3-java-base",
+    "aws-secrets-manager-java-base",
     "aws-sns-java-base",
-    "google-cloud-storage-base",
+    "aws-sns-kotlin-base",
     "azure-blob-storage-base",
+    "bitbucket-cloud-base",
+    "bitbucket-data-center-base",
+    "google-cloud-storage-base",
 )
 
 val collectIntegrationTestReports = tasks.register<Sync>("collectIntegrationTestReports") {


### PR DESCRIPTION
## Summary

- Expands the CI `Integration Tests` step from 3 hardcoded component tasks to all 10 components that now carry `BuildServiceConfigurationCacheSpec` probes, wiring the full set of CC-safety checks into every PR build.
- Updates `aggregation/testing/build.gradle.kts` to collect integration-test reports from the same 10 components (was 3), keeping the report artifact consistent with what CI actually runs.
- Adds a "Configuration Cache (CC) Rules for BuildService Components" section to `AGENTS.md` codifying the three rules — serializable parameter types, registered-provider requirement for nested service refs, and the four-step checklist for any new `*-base` component — so future contributors and agents follow the convention without needing prior context.

## Test plan
- [ ] CI `Integration Tests` step runs and all 10 component probes pass
- [ ] `aggregation/testing:collectIntegrationTestReports` collects JUnit XML from all 10 components
- [ ] No functional code changes; verify no regressions in `build` or `test` jobs