### PR TITLE
[bitbucket] Make model classes Serializable for config-cache compatibility

### DIFF
--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Account.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Account.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Cloud user or team account.
@@ -28,4 +30,9 @@ data class Account(
      * The account's username (may not be present for all account types).
      */
     val nickname: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Branch.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Branch.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A branch reference in a Bitbucket Cloud repository.
@@ -16,4 +18,9 @@ data class Branch(
      * The object type, typically `branch`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/CommitStatus.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/CommitStatus.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A build status attached to a commit in Bitbucket Cloud.
@@ -49,4 +51,9 @@ data class CommitStatus(
      * The object type, typically `build`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/CommitSummary.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/CommitSummary.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A lightweight commit reference used in nested contexts such as pull request endpoints and merge commits.
@@ -16,4 +18,9 @@ data class CommitSummary(
      * The object type, typically `commit`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Project.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Project.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Cloud project that groups repositories within a workspace.
@@ -26,4 +28,9 @@ data class Project(
      * The object type, typically `project`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/PullRequest.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/PullRequest.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Cloud pull request.
@@ -76,4 +78,9 @@ data class PullRequest(
      * The object type, typically `pullrequest`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/PullRequestComment.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/PullRequestComment.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A comment on a Bitbucket Cloud pull request.
@@ -39,7 +41,12 @@ data class PullRequestComment(
      * The object type, typically `pullrequest_comment`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}
 
 /**
  * The content body of a pull request comment, available in multiple markup formats.
@@ -60,4 +67,9 @@ data class CommentContent(
      * The plain-text content with markup stripped.
      */
     val markup: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/PullRequestEndpoint.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/PullRequestEndpoint.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A pull request endpoint representing either the source or destination of a pull request.
@@ -21,4 +23,9 @@ data class PullRequestEndpoint(
      * The commit at the tip of this endpoint.
      */
     val commit: CommitSummary? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Repository.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/Repository.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Cloud repository.
@@ -77,4 +79,9 @@ data class Repository(
      * The object type, typically `repository`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/RepositorySummary.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/model/RepositorySummary.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.cloud.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A lightweight repository reference used in nested contexts such as pull request endpoints.
@@ -28,4 +30,9 @@ data class RepositorySummary(
      * The object type, typically `repository`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/BuildStatus.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/BuildStatus.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A build status attached to a commit in Bitbucket Data Center.
@@ -38,4 +40,9 @@ data class BuildStatus(
      */
     @Json(name = "dateAdded")
     val dateAdded: Long? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/Comment.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/Comment.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A comment on a pull request in Bitbucket Data Center.
@@ -39,4 +41,9 @@ data class Comment(
      * The comment version, used for optimistic locking on updates.
      */
     val version: Int? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/Project.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/Project.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Data Center project.
@@ -36,4 +38,9 @@ data class Project(
      * The object type, typically `NORMAL`.
      */
     val type: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/PullRequest.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/PullRequest.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Data Center pull request.
@@ -76,4 +78,9 @@ data class PullRequest(
      */
     @Json(name = "updatedDate")
     val updatedDate: Long? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/PullRequestParticipant.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/PullRequestParticipant.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A participant (author, reviewer, or observer) of a pull request in Bitbucket Data Center.
@@ -26,4 +28,9 @@ data class PullRequestParticipant(
      * The participant's review status: `UNAPPROVED`, `APPROVED`, or `NEEDS_WORK`.
      */
     val status: String? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/PullRequestRef.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/PullRequestRef.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A ref (branch) endpoint of a pull request in Bitbucket Data Center.
@@ -29,4 +31,9 @@ data class PullRequestRef(
      * The repository containing this ref.
      */
     val repository: Repository? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/Repository.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/Repository.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Data Center repository.
@@ -53,4 +55,9 @@ data class Repository(
      * The project this repository belongs to.
      */
     val project: Project? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/User.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/model/User.kt
@@ -2,6 +2,8 @@ package com.kelvsyc.gradle.bitbucket.server.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
+import java.io.Serial
+import java.io.Serializable
 
 /**
  * A Bitbucket Data Center user account.
@@ -44,4 +46,9 @@ data class User(
      * Whether the user account is active.
      */
     val active: Boolean? = null,
-)
+) : Serializable {
+    companion object {
+        @Serial
+        private const val serialVersionUID: Long = 1L
+    }
+}


### PR DESCRIPTION
## Summary

- Gradle's configuration cache requires `ValueSource` results to be serializable; the Bitbucket Cloud and Data Center model classes were plain Kotlin data classes with no `Serializable` implementation, causing failures under `--configuration-cache`
- Adds `Serializable`, a `companion object` with an `@Serial`-annotated `serialVersionUID = 1L` to all 19 model classes across `bitbucket-cloud-base` and `bitbucket-data-center-base`
- Covers the complete transitive object graph reachable from every `ValueSource` return type (`Repository`, `PullRequest`, `CommitStatus`, `BuildStatus`) as well as `PullRequestComment`/`CommentContent`

## Test plan

- [ ] `./gradlew :bitbucket-cloud-base:test :bitbucket-cloud-base:detekt` passes
- [ ] `./gradlew :bitbucket-data-center-base:test :bitbucket-data-center-base:detekt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)