### PR TITLE
Fix config-cache serialization: kotlin-tools 0.4.0 + @get:Internal gap

### DIFF
--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetGenericAssetValueSource.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetGenericAssetValueSource.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * Base class for [ValueSource] implementations that provide a value by reading an asset located in a CodeArtifact
@@ -25,6 +26,7 @@ abstract class AbstractGetGenericAssetValueSource<T : Any, P : AbstractGetGeneri
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the CodeArtifact client. */
+        @get:Internal
         val service: Property<CodeArtifactClientBuildService>
 
         /** The CodeArtifact domain name. */

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetAuthorizationTokenValueSource.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation retrieving an authorization token from AWS CodeArtifact.
@@ -17,6 +18,7 @@ abstract class GetAuthorizationTokenValueSource : ValueSource<String, GetAuthori
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the CodeArtifact client. */
+        @get:Internal
         val service: Property<CodeArtifactClientBuildService>
 
         /** The CodeArtifact domain name. */

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetGenericPackageVersionAssetAction.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetGenericPackageVersionAssetAction.kt
@@ -6,6 +6,7 @@ import aws.smithy.kotlin.runtime.content.writeToFile
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -18,6 +19,7 @@ abstract class GetGenericPackageVersionAssetAction : WorkAction<GetGenericPackag
      */
     interface Parameters : WorkParameters {
         /** The build service managing the CodeArtifact client. */
+        @get:Internal
         val service: Property<CodeArtifactClientBuildService>
 
         /** The CodeArtifact domain name. */

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetRepositoryEndpointValueSource.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetRepositoryEndpointValueSource.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation providing an AWS CodeArtifact repository endpoint URL.
@@ -19,6 +20,7 @@ abstract class GetRepositoryEndpointValueSource : ValueSource<String, GetReposit
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the CodeArtifact client. */
+        @get:Internal
         val service: Property<CodeArtifactClientBuildService>
 
         /** The CodeArtifact domain name. */

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/ListPackageVersionsValueSource.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/ListPackageVersionsValueSource.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation providing a list of package version strings from a CodeArtifact repository.
@@ -19,6 +20,7 @@ abstract class ListPackageVersionsValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the CodeArtifact client. */
+        @get:Internal
         val service: Property<CodeArtifactClientBuildService>
 
         /** The CodeArtifact domain name. */

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/PublishPackageVersionAction.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/PublishPackageVersionAction.kt
@@ -6,6 +6,7 @@ import aws.smithy.kotlin.runtime.content.asByteStream
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -18,6 +19,7 @@ abstract class PublishPackageVersionAction : WorkAction<PublishPackageVersionAct
      */
     interface Parameters : WorkParameters {
         /** The build service managing the CodeArtifact client. */
+        @get:Internal
         val service: Property<CodeArtifactClientBuildService>
 
         /** The CodeArtifact domain name. */

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/BatchDeleteImageAction.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/BatchDeleteImageAction.kt
@@ -5,6 +5,7 @@ import aws.sdk.kotlin.services.ecr.model.ImageIdentifier
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -20,6 +21,7 @@ abstract class BatchDeleteImageAction : WorkAction<BatchDeleteImageAction.Parame
      */
     interface Parameters : WorkParameters {
         /** The build service managing the ECR client. */
+        @get:Internal
         val service: Property<EcrClientBuildService>
 
         /** The repository to delete images from. */

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/DescribeRepositoriesValueSource.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/DescribeRepositoriesValueSource.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that lists ECR repositories visible to the configured client, returned as a
@@ -25,6 +26,7 @@ abstract class DescribeRepositoriesValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the ECR client. */
+        @get:Internal
         val service: Property<EcrClientBuildService>
     }
 

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSource.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation retrieving an authorization token from AWS ECR for the caller's default
@@ -19,6 +20,7 @@ abstract class GetAuthorizationTokenValueSource : ValueSource<String, GetAuthori
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the ECR client. */
+        @get:Internal
         val service: Property<EcrClientBuildService>
     }
 

--- a/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractImdsValueSource.kt
+++ b/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractImdsValueSource.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * Base class for [ValueSource]s providing values retrieved from the
@@ -22,6 +23,7 @@ abstract class AbstractImdsValueSource<T : Any, P : AbstractImdsValueSource.Para
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the IMDS client. */
+        @get:Internal
         val service: Property<ImdsClientBuildService>
 
         /** The IMDS metadata path to query. */

--- a/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractInstanceIdentityValueSource.kt
+++ b/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractInstanceIdentityValueSource.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * Base class for [ValueSource]s providing values retrieved from the
@@ -26,6 +27,7 @@ abstract class AbstractInstanceIdentityValueSource<T : Any, P : AbstractInstance
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the IMDS client. */
+        @get:Internal
         val service: Property<ImdsClientBuildService>
     }
 

--- a/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/DecryptAction.kt
+++ b/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/DecryptAction.kt
@@ -2,6 +2,7 @@ package com.kelvsyc.gradle.aws.java.kms
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.core.SdkBytes
@@ -20,6 +21,7 @@ abstract class DecryptAction : WorkAction<DecryptAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
 
         /** Optional key ID, ARN, or alias name. Required only for asymmetric keys. */

--- a/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/DescribeKeyValueSource.kt
+++ b/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/DescribeKeyValueSource.kt
@@ -5,6 +5,7 @@ import com.kelvsyc.gradle.logging.warn
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.kms.model.DescribeKeyRequest
 import software.amazon.awssdk.services.kms.model.KmsException
 
@@ -24,6 +25,7 @@ abstract class DescribeKeyValueSource : ValueSource<String, DescribeKeyValueSour
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
 
         /** The key ID, ARN, or alias name (e.g. `alias/my-key`) to describe. */

--- a/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/EncryptAction.kt
+++ b/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/EncryptAction.kt
@@ -2,6 +2,7 @@ package com.kelvsyc.gradle.aws.java.kms
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.core.SdkBytes
@@ -20,6 +21,7 @@ abstract class EncryptAction : WorkAction<EncryptAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
 
         /** Key ID, ARN, or alias name (e.g. `alias/my-key`) to encrypt under. */

--- a/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/ListKeysValueSource.kt
+++ b/cores/aws-kms-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/kms/ListKeysValueSource.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.java.kms
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.kms.model.ListKeysRequest
 import kotlin.streams.asSequence
 
@@ -18,6 +19,7 @@ abstract class ListKeysValueSource : ValueSource<Map<String, String>, ListKeysVa
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
     }
 

--- a/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/DecryptAction.kt
+++ b/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/DecryptAction.kt
@@ -4,6 +4,7 @@ import aws.sdk.kotlin.services.kms.model.DecryptRequest
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -20,6 +21,7 @@ abstract class DecryptAction : WorkAction<DecryptAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
 
         /** Optional key ID, ARN, or alias name. Required only for asymmetric keys. */

--- a/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/DescribeKeyValueSource.kt
+++ b/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/DescribeKeyValueSource.kt
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that retrieves the ARN of a KMS key from its ID, ARN, or alias name.
@@ -20,6 +21,7 @@ abstract class DescribeKeyValueSource : ValueSource<String, DescribeKeyValueSour
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
 
         /** The key ID, ARN, or alias name (e.g. `alias/my-key`) to describe. */

--- a/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/EncryptAction.kt
+++ b/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/EncryptAction.kt
@@ -4,6 +4,7 @@ import aws.sdk.kotlin.services.kms.model.EncryptRequest
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -20,6 +21,7 @@ abstract class EncryptAction : WorkAction<EncryptAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
 
         /** Key ID, ARN, or alias name (e.g. `alias/my-key`) to encrypt under. */

--- a/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/ListKeysValueSource.kt
+++ b/cores/aws-kms-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/kms/ListKeysValueSource.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that lists all KMS keys visible to the configured client, returned as a [Map]
@@ -24,6 +25,7 @@ abstract class ListKeysValueSource : ValueSource<Map<String, String>, ListKeysVa
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the KMS client. */
+        @get:Internal
         val service: Property<KmsClientBuildService>
     }
 

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/GetFunctionConfigurationValueSource.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/GetFunctionConfigurationValueSource.kt
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that retrieves the ARN of a Lambda function's published configuration.
@@ -21,6 +22,7 @@ abstract class GetFunctionConfigurationValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Lambda client. */
+        @get:Internal
         val service: Property<LambdaClientBuildService>
 
         /** The function name, ARN, or partial ARN. */

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/InvokeFunctionAction.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/InvokeFunctionAction.kt
@@ -4,6 +4,7 @@ import aws.sdk.kotlin.services.lambda.model.InvocationType
 import aws.sdk.kotlin.services.lambda.model.InvokeRequest
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -20,6 +21,7 @@ abstract class InvokeFunctionAction : WorkAction<InvokeFunctionAction.Parameters
      */
     interface Parameters : WorkParameters {
         /** The build service managing the Lambda client. */
+        @get:Internal
         val service: Property<LambdaClientBuildService>
 
         /** The function name, ARN, or partial ARN to invoke. */

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/ListFunctionsValueSource.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/ListFunctionsValueSource.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that lists all Lambda functions visible to the configured client, returned as a
@@ -24,6 +25,7 @@ abstract class ListFunctionsValueSource : ValueSource<Map<String, String>, ListF
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Lambda client. */
+        @get:Internal
         val service: Property<LambdaClientBuildService>
     }
 

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/UpdateFunctionCodeAction.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/UpdateFunctionCodeAction.kt
@@ -4,6 +4,7 @@ import aws.sdk.kotlin.services.lambda.model.UpdateFunctionCodeRequest
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -19,6 +20,7 @@ abstract class UpdateFunctionCodeAction : WorkAction<UpdateFunctionCodeAction.Pa
      */
     interface Parameters : WorkParameters {
         /** The build service managing the Lambda client. */
+        @get:Internal
         val service: Property<LambdaClientBuildService>
 
         /** The function name, ARN, or partial ARN to update. */

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractListObjectsValueSource.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractListObjectsValueSource.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.java.s3
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import software.amazon.awssdk.services.s3.model.S3Object
 
@@ -21,6 +22,7 @@ abstract class AbstractListObjectsValueSource<T : Any, P : AbstractListObjectsVa
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the S3 client. */
+        @get:Internal
         val service: Property<S3ClientBuildService>
 
         /** S3 bucket name. */

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractS3ValueSource.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractS3ValueSource.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.java.s3
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.core.ResponseBytes
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.GetObjectResponse
@@ -21,6 +22,7 @@ abstract class AbstractS3ValueSource<T : Any, P : AbstractS3ValueSource.Paramete
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the S3 client. */
+        @get:Internal
         val service: Property<S3ClientBuildService>
 
         /** S3 bucket name. */

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/CopyObjectAction.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/CopyObjectAction.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.aws.java.s3
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
@@ -16,6 +17,7 @@ abstract class CopyObjectAction : WorkAction<CopyObjectAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the S3 client. */
+        @get:Internal
         val service: Property<S3ClientBuildService>
 
         /** Source bucket name. */

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/DeleteObjectAction.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/DeleteObjectAction.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.aws.java.s3
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
@@ -18,6 +19,7 @@ abstract class DeleteObjectAction : WorkAction<DeleteObjectAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the S3 client. */
+        @get:Internal
         val service: Property<S3ClientBuildService>
 
         /** S3 bucket name. */

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/DownloadFileAction.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/DownloadFileAction.kt
@@ -2,6 +2,7 @@ package com.kelvsyc.gradle.aws.java.s3
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.core.sync.ResponseTransformer
@@ -20,6 +21,7 @@ abstract class DownloadFileAction : WorkAction<DownloadFileAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the S3 client. */
+        @get:Internal
         val service: Property<S3ClientBuildService>
 
         /** S3 bucket name. */

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/UploadFileAction.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/UploadFileAction.kt
@@ -2,6 +2,7 @@ package com.kelvsyc.gradle.aws.java.s3
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.core.sync.RequestBody
@@ -20,6 +21,7 @@ abstract class UploadFileAction : WorkAction<UploadFileAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the S3 client. */
+        @get:Internal
         val service: Property<S3ClientBuildService>
 
         /** S3 bucket name. */

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/PutSecretValueAction.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/PutSecretValueAction.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.aws.java.secretsmanager
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRequest
@@ -16,6 +17,7 @@ abstract class PutSecretValueAction : WorkAction<PutSecretValueAction.Parameters
      */
     interface Parameters : WorkParameters {
         /** The build service managing the Secrets Manager client. */
+        @get:Internal
         val service: Property<SecretsManagerClientBuildService>
 
         /** The name or ARN of the secret to update. */

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSource.kt
@@ -4,6 +4,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueRequest
 import kotlin.streams.asSequence
 
@@ -18,6 +19,7 @@ abstract class SecretBatchValueSource : ValueSource<Map<String, String>, SecretB
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Secrets Manager client. */
+        @get:Internal
         val service: Property<SecretsManagerClientBuildService>
 
         /** Set of secret IDs (names or ARNs) to retrieve. */

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSource.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.java.secretsmanager
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation backed by retrieving a secret from an in-memory Secrets Manager cache.
@@ -15,6 +16,7 @@ abstract class SecretFromCacheValueSource : ValueSource<String, SecretFromCacheV
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the secret cache. */
+        @get:Internal
         val service: Property<SecretCacheBuildService>
 
         /** The name or ARN of the secret to retrieve. */

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSource.kt
@@ -5,6 +5,7 @@ import com.kelvsyc.gradle.logging.warn
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
 import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException
 
@@ -23,6 +24,7 @@ abstract class SecretsManagerValueSource : ValueSource<String, SecretsManagerVal
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Secrets Manager client. */
+        @get:Internal
         val service: Property<SecretsManagerClientBuildService>
 
         /** The name or ARN of the secret to retrieve. */

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/PutSecretValueAction.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/PutSecretValueAction.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.kotlin.secretsmanager
 import aws.sdk.kotlin.services.secretsmanager.model.PutSecretValueRequest
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -17,6 +18,7 @@ abstract class PutSecretValueAction : WorkAction<PutSecretValueAction.Parameters
      */
     interface Parameters : WorkParameters {
         /** The build service managing the Secrets Manager client. */
+        @get:Internal
         val service: Property<SecretsManagerClientBuildService>
 
         /** The name or ARN of the secret to update. */

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSource.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSource.kt
@@ -12,6 +12,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that retrieves a set of secrets, by their IDs, from Secrets Manager.
@@ -24,6 +25,7 @@ abstract class SecretBatchValueSource : ValueSource<Map<String, String>, SecretB
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Secrets Manager client. */
+        @get:Internal
         val service: Property<SecretsManagerClientBuildService>
 
         /** Set of secret IDs (names or ARNs) to retrieve. */

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSource.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSource.kt
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation backed by retrieving a secret from Secrets Manager.
@@ -19,6 +20,7 @@ abstract class SecretsManagerValueSource : ValueSource<String, SecretsManagerVal
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Secrets Manager client. */
+        @get:Internal
         val service: Property<SecretsManagerClientBuildService>
 
         /** The name or ARN of the secret to retrieve. */

--- a/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/GetParameterValueSource.kt
+++ b/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/GetParameterValueSource.kt
@@ -5,6 +5,7 @@ import com.kelvsyc.gradle.logging.warn
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest
 import software.amazon.awssdk.services.ssm.model.SsmException
 
@@ -24,6 +25,7 @@ abstract class GetParameterValueSource : ValueSource<String, GetParameterValueSo
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the SSM client. */
+        @get:Internal
         val service: Property<SsmClientBuildService>
 
         /** The name (or ARN) of the parameter to retrieve. */

--- a/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/GetParametersByPathValueSource.kt
+++ b/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/GetParametersByPathValueSource.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.java.ssm
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
 import kotlin.streams.asSequence
 
@@ -20,6 +21,7 @@ abstract class GetParametersByPathValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the SSM client. */
+        @get:Internal
         val service: Property<SsmClientBuildService>
 
         /** The hierarchy path under which parameters are retrieved (e.g. `/my/app/`). */

--- a/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/PutParameterAction.kt
+++ b/cores/aws-ssm-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ssm/PutParameterAction.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.aws.java.ssm
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import software.amazon.awssdk.services.ssm.model.ParameterType
@@ -18,6 +19,7 @@ abstract class PutParameterAction : WorkAction<PutParameterAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the SSM client. */
+        @get:Internal
         val service: Property<SsmClientBuildService>
 
         /** The name of the parameter to create or update. */

--- a/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/GetParameterValueSource.kt
+++ b/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/GetParameterValueSource.kt
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation backed by retrieving a single parameter from SSM Parameter Store.
@@ -20,6 +21,7 @@ abstract class GetParameterValueSource : ValueSource<String, GetParameterValueSo
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the SSM client. */
+        @get:Internal
         val service: Property<SsmClientBuildService>
 
         /** The name (or ARN) of the parameter to retrieve. */

--- a/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/GetParametersByPathValueSource.kt
+++ b/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/GetParametersByPathValueSource.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that retrieves all SSM parameters under a given hierarchy [Parameters.path],
@@ -26,6 +27,7 @@ abstract class GetParametersByPathValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the SSM client. */
+        @get:Internal
         val service: Property<SsmClientBuildService>
 
         /** The hierarchy path under which parameters are retrieved (e.g. `/my/app/`). */

--- a/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/PutParameterAction.kt
+++ b/cores/aws-ssm-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ssm/PutParameterAction.kt
@@ -4,6 +4,7 @@ import aws.sdk.kotlin.services.ssm.model.ParameterType
 import aws.sdk.kotlin.services.ssm.model.PutParameterRequest
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -19,6 +20,7 @@ abstract class PutParameterAction : WorkAction<PutParameterAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the SSM client. */
+        @get:Internal
         val service: Property<SsmClientBuildService>
 
         /** The name of the parameter to create or update. */

--- a/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/DecodeAuthorizationMessageValueSource.kt
+++ b/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/DecodeAuthorizationMessageValueSource.kt
@@ -5,6 +5,7 @@ import com.kelvsyc.gradle.logging.warn
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.sts.model.DecodeAuthorizationMessageRequest
 import software.amazon.awssdk.services.sts.model.StsException
 
@@ -22,6 +23,7 @@ abstract class DecodeAuthorizationMessageValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the STS client. */
+        @get:Internal
         val service: Property<StsClientBuildService>
 
         /** The encoded authorization message to decode. */

--- a/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/GetCallerIdentityValueSource.kt
+++ b/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/GetCallerIdentityValueSource.kt
@@ -3,6 +3,7 @@ package com.kelvsyc.gradle.aws.java.sts
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.sts.model.GetCallerIdentityRequest
 
 /**
@@ -18,6 +19,7 @@ abstract class GetCallerIdentityValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the STS client. */
+        @get:Internal
         val service: Property<StsClientBuildService>
     }
 

--- a/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/DecodeAuthorizationMessageValueSource.kt
+++ b/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/DecodeAuthorizationMessageValueSource.kt
@@ -7,6 +7,7 @@ import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that decodes an STS-encoded authorization failure message into a JSON document
@@ -22,6 +23,7 @@ abstract class DecodeAuthorizationMessageValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the STS client. */
+        @get:Internal
         val service: Property<StsClientBuildService>
 
         /** The encoded authorization message to decode. */

--- a/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/GetCallerIdentityValueSource.kt
+++ b/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/GetCallerIdentityValueSource.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * [ValueSource] implementation that returns the calling identity for the configured client as a [Map] with the
@@ -19,6 +20,7 @@ abstract class GetCallerIdentityValueSource :
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the STS client. */
+        @get:Internal
         val service: Property<StsClientBuildService>
     }
 

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractBlobStorageValueSource.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractBlobStorageValueSource.kt
@@ -4,6 +4,7 @@ import com.azure.core.util.BinaryData
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * Base class for [ValueSource] implementations that provide a value by reading a blob from Azure Blob Storage.
@@ -20,6 +21,7 @@ abstract class AbstractBlobStorageValueSource<T : Any, P : AbstractBlobStorageVa
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the account-scoped Blob Service client. */
+        @get:Internal
         val service: Property<BlobServiceClientBuildService>
 
         /** The name of the blob container. */

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractListBlobsValueSource.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractListBlobsValueSource.kt
@@ -5,6 +5,7 @@ import com.azure.storage.blob.models.ListBlobsOptions
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
 
 /**
  * Base class for [ValueSource] implementations that produce a value by listing blobs in an Azure Blob Storage
@@ -22,6 +23,7 @@ abstract class AbstractListBlobsValueSource<T : Any, P : AbstractListBlobsValueS
      */
     interface Parameters : ValueSourceParameters {
         /** The build service managing the account-scoped Blob Service client. */
+        @get:Internal
         val service: Property<BlobServiceClientBuildService>
 
         /** The name of the blob container. */

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/CopyBlobAction.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/CopyBlobAction.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.azure.storage.blob
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -18,6 +19,7 @@ abstract class CopyBlobAction : WorkAction<CopyBlobAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the account-scoped Blob Service client. */
+        @get:Internal
         val service: Property<BlobServiceClientBuildService>
 
         /** Source container name. */

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/DeleteBlobAction.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/DeleteBlobAction.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.azure.storage.blob
 
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -17,6 +18,7 @@ abstract class DeleteBlobAction : WorkAction<DeleteBlobAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the account-scoped Blob Service client. */
+        @get:Internal
         val service: Property<BlobServiceClientBuildService>
 
         /** The name of the blob container. */

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/DownloadBlobAction.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/DownloadBlobAction.kt
@@ -2,6 +2,7 @@ package com.kelvsyc.gradle.azure.storage.blob
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -17,6 +18,7 @@ abstract class DownloadBlobAction : WorkAction<DownloadBlobAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the account-scoped Blob Service client. */
+        @get:Internal
         val service: Property<BlobServiceClientBuildService>
 
         /** The name of the blob container. */

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/UploadBlobAction.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/UploadBlobAction.kt
@@ -2,6 +2,7 @@ package com.kelvsyc.gradle.azure.storage.blob
 
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 
@@ -17,6 +18,7 @@ abstract class UploadBlobAction : WorkAction<UploadBlobAction.Parameters> {
      */
     interface Parameters : WorkParameters {
         /** The build service managing the account-scoped Blob Service client. */
+        @get:Internal
         val service: Property<BlobServiceClientBuildService>
 
         /** The name of the blob container. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 dokka = "2.2.0"
 dokkatoo = "2.4.0"
 kotlin = "2.3.0"
-kotlin-tools = "0.3.0"
+kotlin-tools = "0.4.0"
 moshi = "1.15.2"
 
 [libraries]


### PR DESCRIPTION
## Summary

- Bumps `kotlin-tools` to `0.4.0`, making `JsonValue` and `XmlElement` `Serializable` so `JsonValueSource` and `XmlValueSource` return types are configuration cache compatible
- Adds missing `@get:Internal` to `val service: Property<BuildService>` declarations in `ValueSourceParameters` and `WorkParameters` interfaces across 52 files in 14 modules (AWS KMS, SSM, STS, ECR, IMDS, Lambda, S3 Java SDK, Secrets Manager, CodeArtifact Kotlin SDK; Azure Blob Storage), closing the remaining configuration cache fingerprinting gap for BuildService references

## Test plan

- [x] `./gradlew :test` passes across all components
- [x] `./gradlew :detekt` passes across all components

🤖 Generated with [Claude Code](https://claude.com/claude-code)