### PR TITLE
New component: snakeyaml-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,56 +18,57 @@ Standalone Gradle plugins that solve a specific build problem. Apply them direct
 | `git-core` | `com.kelvsyc.gradle.git-core` | Git archival tasks and JGit extensions for remote repositories |
 | `jfrog-cli-core` | `com.kelvsyc.gradle.jfrog-cli-core` | Gradle tasks wrapping the JFrog CLI |
 
-### Bases
-
-Bases provide managed SDK client infrastructure for a specific cloud service. Each ships an
-`AbstractClientBuildService` subclass so that downstream plugins and tasks can access
-pre-configured SDK clients without managing their lifecycle. All bases are published as Kotlin
-libraries.
-
-**AWS** bases come in **Java SDK** and **Kotlin SDK** variants with mirrored APIs, since
-the two AWS SDKs are distinct libraries:
-
-| AWS Service | Java | Kotlin |
-|-------------|------|--------|
-| S3 | `aws-s3-java-base` (library) | `aws-s3-kotlin-base` (library) |
-| SQS | `aws-sqs-java-base` (library) | `aws-sqs-kotlin-base` (library) |
-| SNS | `aws-sns-java-base` (library) | `aws-sns-kotlin-base` (library) |
-| SES | `aws-ses-java-base` (library) | `aws-ses-kotlin-base` (library) |
-| Secrets Manager | `aws-secrets-manager-java-base` (library) | `aws-secrets-manager-kotlin-base` (library) |
-| CodeArtifact | `aws-codeartifact-java-base` (library) | `aws-codeartifact-kotlin-base` (library) |
-| ECR | `aws-ecr-java-base` (library) | `aws-ecr-kotlin-base` (library) |
-| IMDS | `aws-imds-java-base` (library) | `aws-imds-kotlin-base` (library) |
-| KMS | `aws-kms-java-base` (library) | `aws-kms-kotlin-base` (library) |
-| Lambda | `aws-lambda-java-base` (library) | `aws-lambda-kotlin-base` (library) |
-| SSM Parameter Store | `aws-ssm-java-base` (library) | `aws-ssm-kotlin-base` (library) |
-| STS | `aws-sts-java-base` (library) | `aws-sts-kotlin-base` (library) |
-
-**Other** bases:
-
-| Component | Description | Form |
-|-----------|-------------|------|
-| `google-cloud-artifact-registry-base` | GCP Artifact Registry | library |
-| `google-cloud-storage-base` | GCP Cloud Storage | library |
-| `google-cloud-secret-manager-base` | GCP Secret Manager | library |
-| `google-cloud-pubsub-base` | GCP Pub/Sub | library |
-| `google-cloud-kms-base` | GCP Cloud KMS | library |
-| `azure-blob-storage-base` | Azure Blob Storage | library |
-| `azure-key-vault-base` | Azure Key Vault | library |
-| `artifactory-base` | JFrog Artifactory | library |
-| `bitbucket-cloud-base` | Bitbucket Cloud REST API | library |
-| `bitbucket-data-center-base` | Bitbucket Data Center REST API | library |
-
 All plugin IDs are prefixed with `com.kelvsyc.gradle.`.
-
-The shared client registry itself is provided by **`clients-base`**
-(`com.kelvsyc.gradle.clients-base`). End users typically do not apply this plugin directly;
-it is pulled in as a dependency by the service-specific bases.
 
 ### Extensions
 
-Kotlin libraries with no plugin code. Add them as regular dependencies when writing your own
-Gradle plugins or build logic:
+Kotlin libraries to add as dependencies when writing your own Gradle plugins or build logic.
+All are published under the group `com.kelvsyc.gradle`.
+
+#### Client extensions
+
+The shared client infrastructure is provided by **`clients-base`**
+(`com.kelvsyc.gradle:clients-base`). End users typically do not depend on this library
+directly; it is pulled in as a dependency by the service-specific client extensions.
+
+**AWS** client extensions come in **Java SDK** and **Kotlin SDK** variants with mirrored APIs,
+since the two AWS SDKs are distinct libraries:
+
+| AWS Service | Java | Kotlin |
+|-------------|------|--------|
+| S3 | `aws-s3-java-base` | `aws-s3-kotlin-base` |
+| SQS | `aws-sqs-java-base` | `aws-sqs-kotlin-base` |
+| SNS | `aws-sns-java-base` | `aws-sns-kotlin-base` |
+| SES | `aws-ses-java-base` | `aws-ses-kotlin-base` |
+| Secrets Manager | `aws-secrets-manager-java-base` | `aws-secrets-manager-kotlin-base` |
+| CodeArtifact | `aws-codeartifact-java-base` | `aws-codeartifact-kotlin-base` |
+| ECR | `aws-ecr-java-base` | `aws-ecr-kotlin-base` |
+| IMDS | `aws-imds-java-base` | `aws-imds-kotlin-base` |
+| KMS | `aws-kms-java-base` | `aws-kms-kotlin-base` |
+| Lambda | `aws-lambda-java-base` | `aws-lambda-kotlin-base` |
+| SSM Parameter Store | `aws-ssm-java-base` | `aws-ssm-kotlin-base` |
+| STS | `aws-sts-java-base` | `aws-sts-kotlin-base` |
+
+**Other** client extensions:
+
+| Component | Description |
+|-----------|-------------|
+| `google-cloud-artifact-registry-base` | GCP Artifact Registry |
+| `google-cloud-storage-base` | GCP Cloud Storage |
+| `google-cloud-secret-manager-base` | GCP Secret Manager |
+| `google-cloud-pubsub-base` | GCP Pub/Sub |
+| `google-cloud-kms-base` | GCP Cloud KMS |
+| `azure-blob-storage-base` | Azure Blob Storage |
+| `azure-key-vault-base` | Azure Key Vault |
+| `azure-managed-identity-base` | Azure Managed Identity / IMDS |
+| `artifactory-base` | JFrog Artifactory |
+| `bitbucket-cloud-base` | Bitbucket Cloud REST API |
+| `bitbucket-data-center-base` | Bitbucket Data Center REST API |
+
+#### Utility extensions
+
+**`gradle-extensions`** is the foundation for writing Gradle plugins in this suite. Add it as
+a dependency when building plugins or custom build logic:
 
 ```kotlin
 dependencies {
@@ -77,13 +78,13 @@ dependencies {
 
 | Library | Description |
 |---------|-------------|
-| `gradle-extensions` | Kotlin DSL extensions and utility types for Gradle plugin development |
 | `aws-java-extensions` | Config-cache-safe BuildService base class, `AwsBuildServiceParams`, and credential adapters for the AWS SDK for Java |
 | `aws-kotlin-extensions` | Base client info interface and credential extensions for the AWS SDK for Kotlin |
 | `google-cloud-extensions` | Config-cache-safe BuildService base class and `GcpBuildServiceParams` for the Google Cloud SDK |
 | `azure-extensions` | Config-cache-safe BuildService base class and `AzureBuildServiceParams` for the Azure SDK |
 | `moshi-extensions` | `ValueSource` implementations and `Provider` extensions for Moshi JSON parsing |
 | `pkl-extensions` | `ValueSource` implementations for evaluating Pkl configuration files |
+| `snakeyaml-extensions` | `ValueSource` implementation and typed `Provider` extensions for YAML parsing |
 | `xml-extensions` | XPath query engine, `ValueSource` implementations, and migration helpers for XML |
 
 ## Installation

--- a/cores/snakeyaml-extensions/README.md
+++ b/cores/snakeyaml-extensions/README.md
@@ -1,0 +1,74 @@
+# snakeyaml-extensions
+
+Gradle `ValueSource` implementations and `Provider` extensions for YAML parsing, backed by
+[kotlin-tools `snakeyaml-extensions`](https://github.com/kelvSYC/kotlin-tools).
+
+## Usage
+
+### Parsing a YAML file
+
+Use `ProviderFactory.yamlFile()` to parse a YAML file into a `Provider<YamlValue>` tree.
+The provider is evaluated lazily and is configuration-cache safe.
+
+```kotlin
+val config: Provider<YamlValue> = providers.yamlFile(layout.projectDirectory.file("config.yaml"))
+```
+
+### Extracting typed values
+
+Use the typed extension functions on `Provider<YamlValue>` to extract scalars and navigate nested
+structures. Each extension takes vararg path segments — one per level of nesting — and returns
+absent when the path does not resolve or the value is the wrong type.
+
+```kotlin
+val host: Provider<String> = config.stringAt("server", "host")
+val port: Provider<Int>    = config.intAt("server", "port")
+val debug: Provider<Boolean> = config.booleanAt("server", "debug")
+val ratio: Provider<Double> = config.doubleAt("server", "ratio")
+```
+
+Sequence elements are addressed by their index as a string segment:
+
+```kotlin
+val first: Provider<String> = config.stringAt("items", "0")
+```
+
+Sub-trees can be extracted as `YamlMapping` or `YamlSequence`:
+
+```kotlin
+val serverBlock: Provider<YamlMapping> = config.mappingAt("server")
+val items: Provider<YamlSequence>      = config.sequenceAt("items")
+```
+
+### Parse-once, navigate-many
+
+`yamlFile()` parses the file once via a single `ValueSource`. All typed extractions are lazy
+`Provider.map()` chains on the result — the file is not re-read for each accessor.
+
+```kotlin
+val config = providers.yamlFile(layout.projectDirectory.file("config.yaml"))
+
+tasks.register("printConfig") {
+    val host = config.stringAt("server", "host")
+    val port = config.intAt("server", "port")
+    doLast {
+        println("${host.get()}:${port.get()}")
+    }
+}
+```
+
+### Parsing a YAML string
+
+To parse a `Provider<String>` as YAML:
+
+```kotlin
+val value: Provider<YamlValue> = someStringProvider.parseYaml()
+```
+
+## Installation
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:snakeyaml-extensions")
+}
+```

--- a/cores/snakeyaml-extensions/build.gradle.kts
+++ b/cores/snakeyaml-extensions/build.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("SnakeYAML Extensions")
+}
+
+dependencies {
+    api(libs.kotlin.tools.snakeyaml.extensions)
+
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/snakeyaml-extensions/settings.gradle.kts
+++ b/cores/snakeyaml-extensions/settings.gradle.kts
@@ -1,0 +1,7 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}

--- a/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/ProviderExtensions.kt
+++ b/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/ProviderExtensions.kt
@@ -1,0 +1,68 @@
+package com.kelvsyc.gradle.snakeyaml
+
+import com.kelvsyc.kotlin.snakeyaml.YamlMapping
+import com.kelvsyc.kotlin.snakeyaml.YamlSequence
+import com.kelvsyc.kotlin.snakeyaml.YamlValue
+import com.kelvsyc.kotlin.snakeyaml.booleanAt
+import com.kelvsyc.kotlin.snakeyaml.doubleAt
+import com.kelvsyc.kotlin.snakeyaml.intAt
+import com.kelvsyc.kotlin.snakeyaml.longAt
+import com.kelvsyc.kotlin.snakeyaml.mappingAt
+import com.kelvsyc.kotlin.snakeyaml.parseYaml
+import com.kelvsyc.kotlin.snakeyaml.sequenceAt
+import com.kelvsyc.kotlin.snakeyaml.stringAt
+import org.gradle.api.provider.Provider
+
+/**
+ * Returns a [Provider] that lazily parses this string provider's value as a [YamlValue] tree.
+ */
+fun Provider<String>.parseYaml(): Provider<YamlValue> = map { it.parseYaml() }
+
+/**
+ * Returns a [Provider] providing the string value at the given path segments, or absent if the
+ * path does not resolve to a scalar.
+ */
+fun Provider<YamlValue>.stringAt(vararg segments: String): Provider<String> =
+    map { it.stringAt(*segments) }
+
+/**
+ * Returns a [Provider] providing the integer value at the given path segments, or absent if the
+ * path does not resolve to a parseable integer.
+ */
+fun Provider<YamlValue>.intAt(vararg segments: String): Provider<Int> =
+    map { it.intAt(*segments) }
+
+/**
+ * Returns a [Provider] providing the long value at the given path segments, or absent if the
+ * path does not resolve to a parseable long.
+ */
+fun Provider<YamlValue>.longAt(vararg segments: String): Provider<Long> =
+    map { it.longAt(*segments) }
+
+/**
+ * Returns a [Provider] providing the double value at the given path segments, or absent if the
+ * path does not resolve to a parseable double.
+ */
+fun Provider<YamlValue>.doubleAt(vararg segments: String): Provider<Double> =
+    map { it.doubleAt(*segments) }
+
+/**
+ * Returns a [Provider] providing the boolean value at the given path segments, or absent if the
+ * path does not resolve to a recognized YAML boolean.
+ */
+fun Provider<YamlValue>.booleanAt(vararg segments: String): Provider<Boolean> =
+    map { it.booleanAt(*segments) }
+
+/**
+ * Returns a [Provider] providing the [YamlMapping] at the given path segments, or absent if the
+ * path does not resolve to a mapping.
+ */
+fun Provider<YamlValue>.mappingAt(vararg segments: String): Provider<YamlMapping> =
+    map { it.mappingAt(*segments) }
+
+/**
+ * Returns a [Provider] providing the [YamlSequence] at the given path segments, or absent if the
+ * path does not resolve to a sequence.
+ */
+fun Provider<YamlValue>.sequenceAt(vararg segments: String): Provider<YamlSequence> =
+    map { it.sequenceAt(*segments) }

--- a/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/ProviderFactoryExtensions.kt
+++ b/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/ProviderFactoryExtensions.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.snakeyaml
+
+import com.kelvsyc.kotlin.snakeyaml.YamlValue
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+private fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit
+) = of(valueSourceType, configuration)
+
+/**
+ * Returns a [Provider] providing a [YamlValue] tree parsed from a YAML file.
+ *
+ * @param file the YAML file to parse
+ * @see YamlValueSource
+ */
+fun ProviderFactory.yamlFile(file: RegularFile): Provider<YamlValue> = ofKt(YamlValueSource::class) {
+    parameters.inputFile.set(file)
+}
+
+/**
+ * Returns a [Provider] providing a [YamlValue] tree parsed from a YAML file.
+ *
+ * @param file a provider for the YAML file to parse
+ * @see YamlValueSource
+ */
+fun ProviderFactory.yamlFile(file: Provider<RegularFile>): Provider<YamlValue> = ofKt(YamlValueSource::class) {
+    parameters.inputFile.set(file)
+}

--- a/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/YamlValueSource.kt
+++ b/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/YamlValueSource.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.snakeyaml
+
+import com.kelvsyc.kotlin.snakeyaml.YamlValue
+import com.kelvsyc.kotlin.snakeyaml.parseYaml
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.snakeyaml.engine.v2.exceptions.YamlEngineException
+import java.io.IOException
+
+/**
+ * Gradle [ValueSource] that provides a [YamlValue] tree parsed from a YAML file.
+ *
+ * If the input file is not found, cannot be read, or cannot be parsed, no value will be provided.
+ */
+abstract class YamlValueSource : ValueSource<YamlValue, YamlValueSource.Parameters> {
+    /**
+     * Parameters for [YamlValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The YAML input file.
+         */
+        val inputFile: RegularFileProperty
+    }
+
+    override fun obtain(): YamlValue? {
+        return try {
+            parameters.inputFile.get().asFile.inputStream().use { it.parseYaml() }
+        } catch (_: IOException) {
+            null
+        } catch (_: YamlEngineException) {
+            null
+        }
+    }
+}

--- a/cores/snakeyaml-extensions/src/test/kotlin/com/kelvsyc/gradle/snakeyaml/ProviderExtensionsSpec.kt
+++ b/cores/snakeyaml-extensions/src/test/kotlin/com/kelvsyc/gradle/snakeyaml/ProviderExtensionsSpec.kt
@@ -1,0 +1,121 @@
+package com.kelvsyc.gradle.snakeyaml
+
+import com.kelvsyc.kotlin.snakeyaml.YamlMapping
+import com.kelvsyc.kotlin.snakeyaml.YamlSequence
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testfixtures.ProjectBuilder
+
+class ProviderExtensionsSpec : FunSpec() {
+    private val yaml = """
+        server:
+          host: localhost
+          port: "8080"
+          debug: "true"
+          ratio: "1.5"
+        items:
+          - alpha
+          - beta
+        nested:
+          inner:
+            value: deep
+    """.trimIndent()
+
+    init {
+        test("Provider<String>.parseYaml() lazily parses YAML") {
+            val project = ProjectBuilder.builder().build()
+            val stringProvider = project.providers.provider { yaml }
+
+            val yamlProvider = stringProvider.parseYaml()
+            val value = yamlProvider.get()
+
+            value.shouldBeInstanceOf<YamlMapping>()
+        }
+
+        test("stringAt returns string at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.stringAt("server", "host").get() shouldBe "localhost"
+        }
+
+        test("intAt returns integer at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.intAt("server", "port").get() shouldBe 8080
+        }
+
+        test("longAt returns long at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.longAt("server", "port").get() shouldBe 8080L
+        }
+
+        test("doubleAt returns double at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.doubleAt("server", "ratio").get() shouldBe 1.5
+        }
+
+        test("booleanAt returns boolean at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.booleanAt("server", "debug").get() shouldBe true
+        }
+
+        test("mappingAt returns mapping at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.mappingAt("server").get().shouldBeInstanceOf<YamlMapping>()
+        }
+
+        test("sequenceAt returns sequence at path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.sequenceAt("items").get().shouldBeInstanceOf<YamlSequence>()
+        }
+
+        test("stringAt returns absent for missing path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.stringAt("server", "missing").orNull.shouldBeNull()
+        }
+
+        test("intAt returns absent for non-integer scalar") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.intAt("server", "host").orNull.shouldBeNull()
+        }
+
+        test("stringAt returns absent for non-scalar path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.stringAt("server").orNull.shouldBeNull()
+        }
+
+        test("navigates multi-level nested path") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.stringAt("nested", "inner", "value").get() shouldBe "deep"
+        }
+
+        test("sequenceAt supports index navigation") {
+            val project = ProjectBuilder.builder().build()
+            val provider = project.providers.provider { yaml }.parseYaml()
+
+            provider.stringAt("items", "0").get() shouldBe "alpha"
+        }
+    }
+}

--- a/cores/snakeyaml-extensions/src/test/kotlin/com/kelvsyc/gradle/snakeyaml/YamlValueSourceSpec.kt
+++ b/cores/snakeyaml-extensions/src/test/kotlin/com/kelvsyc/gradle/snakeyaml/YamlValueSourceSpec.kt
@@ -1,0 +1,79 @@
+package com.kelvsyc.gradle.snakeyaml
+
+import com.kelvsyc.kotlin.snakeyaml.YamlMapping
+import com.kelvsyc.kotlin.snakeyaml.YamlScalar
+import com.kelvsyc.kotlin.snakeyaml.YamlSequence
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testfixtures.ProjectBuilder
+import java.io.File
+
+class YamlValueSourceSpec : FunSpec() {
+    init {
+        test("parses YAML mapping from file") {
+            val project = ProjectBuilder.builder().build()
+            val baseFile = tempfile()
+            baseFile.writeText(
+                """
+                name: Alice
+                age: "30"
+                """.trimIndent()
+            )
+            val file = project.layout.file(project.providers.provider { baseFile })
+
+            val result = project.providers.yamlFile(file)
+            val value = result.get()
+
+            value.shouldBeInstanceOf<YamlMapping>()
+            value["name"] shouldBe YamlScalar("Alice")
+        }
+
+        test("parses YAML sequence from file") {
+            val project = ProjectBuilder.builder().build()
+            val baseFile = tempfile()
+            baseFile.writeText(
+                """
+                - alpha
+                - beta
+                - gamma
+                """.trimIndent()
+            )
+            val file = project.layout.file(project.providers.provider { baseFile })
+
+            val result = project.providers.yamlFile(file)
+            val value = result.get()
+
+            value.shouldBeInstanceOf<YamlSequence>()
+            value.shouldBeInstanceOf<YamlSequence>().elements[1] shouldBe YamlScalar("beta")
+        }
+
+        test("returns absent for missing file") {
+            val project = ProjectBuilder.builder().build()
+            val baseDir = tempdir()
+            val file = project.layout.file(project.providers.provider { File(baseDir, "missing.yaml") })
+
+            val result = project.providers.yamlFile(file)
+
+            result.orNull.shouldBeNull()
+        }
+
+        test("returns absent for invalid YAML") {
+            val project = ProjectBuilder.builder().build()
+            val baseFile = tempfile()
+            baseFile.writeText(
+                """
+                key: [unclosed
+                """.trimIndent()
+            )
+            val file = project.layout.file(project.providers.provider { baseFile })
+
+            val result = project.providers.yamlFile(file)
+
+            result.orNull.shouldBeNull()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -93,6 +93,7 @@ google-gax = { module = "com.google.api:gax" } # version from BOM 'google-cloud-
 google-protobuf-java = { module = "com.google.protobuf:protobuf-java" } # version from BOM 'google-cloud-libraries-bom'
 gson = "com.google.code.gson:gson:2.14.0"
 kotlin-tools-moshi-extensions = { module = "com.kelvsyc.kotlin:moshi-extensions" } # version from BOM 'kotlin-tools-bom'
+kotlin-tools-snakeyaml-extensions = { module = "com.kelvsyc.kotlin:snakeyaml-extensions" } # version from BOM 'kotlin-tools-bom'
 kotlin-tools-xml-extensions = { module = "com.kelvsyc.kotlin:xml-extensions" } # version from BOM 'kotlin-tools-bom'
 jgit = "org.eclipse.jgit:org.eclipse.jgit:7.6.0.202603022253-r"
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core" } # version from BOM 'kotest-bom'


### PR DESCRIPTION
## Summary

- Adds `cores/snakeyaml-extensions`, a Gradle library wrapping `com.kelvsyc.kotlin:snakeyaml-extensions` from kotlin-tools 0.4.0
- Provides `YamlValueSource` for config-cache-safe YAML file parsing into a `Provider<YamlValue>` tree, plus `ProviderFactory.yamlFile()` convenience extensions
- Exposes typed `Provider<YamlValue>` navigation extensions (`stringAt`, `intAt`, `booleanAt`, `longAt`, `doubleAt`, `mappingAt`, `sequenceAt`) using vararg path segments — no invented path DSL, matching the library's native API directly; parse-once-navigate-many pattern avoids re-parsing the file per extraction
- Root README updated to match the restructured `#### Utility extensions` layout from main (#555) with `snakeyaml-extensions` added to the table

## Test plan

- [ ] `./gradlew :snakeyaml-extensions:test` — 16 test cases covering full tree parse, all typed accessors, missing file, invalid YAML, path not found, type mismatch, and sequence index navigation
- [ ] `./gradlew :snakeyaml-extensions:detekt` — lint passes clean
- [ ] `./gradlew :build` — full composite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)