### PR TITLE
security: keep credentials out of the Gradle configuration cache

### DIFF
--- a/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/BuildServiceConfigurationCacheSpec.kt
@@ -10,9 +10,10 @@ import java.io.File
 /**
  * Probe: configuration-cache round-trip of `ArtifactoryClientBuildService.Params`.
  *
- * All parameters are `Property<String>` (`url`, `username`, `password`) so the CC codec trivially handles
- * them. Each test verifies that a first invocation stores the configuration cache entry and a second
- * invocation reuses it without re-executing task configuration.
+ * `url` and `username` are `Property<String>`; `passwordRef` is `Property<CredentialReference>` which stores
+ * only the lookup key (an env-var name or system-property name), never the credential value. All three types
+ * are Gradle config-cache serializable. Each test verifies that a first invocation stores the configuration
+ * cache entry and a second invocation reuses it without re-executing task configuration.
  */
 class BuildServiceConfigurationCacheSpec : FunSpec({
     test("ArtifactoryClientBuildService with no parameters survives config-cache round-trip") {
@@ -32,7 +33,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 url.set("https://example.jfrog.io/artifactory")
                 username.set("user")
-                password.set("s3cr3t")
+                passwordRef.set(CredentialReference.EnvironmentVariable("ARTIFACTORY_PASSWORD"))
             """.trimIndent()
         )
     }
@@ -64,6 +65,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
 
         import com.kelvsyc.gradle.artifactory.ArtifactoryClientBuildService
         import com.kelvsyc.gradle.artifactory.fixtures.ArtifactoryClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val artService = gradle.sharedServices.registerIfAbsent(
             "artifactory",

--- a/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/fixtures/ArtifactoryClientBuildServiceProbeTask.kt
+++ b/cores/artifactory-base/src/integrationTest/kotlin/com/kelvsyc/gradle/artifactory/fixtures/ArtifactoryClientBuildServiceProbeTask.kt
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.TaskAction
 /**
  * Forces Gradle to isolate the `ArtifactoryClientBuildService` parameters at task-execution time by querying
  * the `service` property. The body never calls `getClient()` so the probe stays focused on the isolation
- * boundary — in particular whether `Params.credentials: Property<PasswordCredentials>` survives the
+ * boundary — in particular whether `Params.passwordRef: Property<CredentialReference>` survives the
  * config-cache round-trip.
  */
 abstract class ArtifactoryClientBuildServiceProbeTask : DefaultTask() {

--- a/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/ArtifactoryClientBuildService.kt
+++ b/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/ArtifactoryClientBuildService.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.artifactory
 
 import com.kelvsyc.gradle.clients.AbstractClientBuildService
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildServiceParameters
 import org.jfrog.artifactory.client.Artifactory
@@ -30,14 +31,18 @@ abstract class ArtifactoryClientBuildService :
         val username: Property<String>
 
         /**
-         * The Artifactory password or API token. Leave unset for anonymous access.
+         * Reference to where the Artifactory password or API token can be found. Leave unset for
+         * anonymous access.
+         *
+         * Stores a [CredentialReference] pointing to an environment variable or system property
+         * whose value is the password or token. Set via the [basicAuth] extension function.
          */
-        val password: Property<String>
+        val passwordRef: Property<CredentialReference>
     }
 
     override fun createClient(): Artifactory = ArtifactoryClientBuilder.create().apply {
         url = parameters.url.get()
         username = parameters.username.orNull
-        password = parameters.password.orNull
+        password = parameters.passwordRef.orNull?.resolve()
     }.build()
 }

--- a/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/ArtifactoryClientBuildServiceParamsExtensions.kt
+++ b/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/ArtifactoryClientBuildServiceParamsExtensions.kt
@@ -1,0 +1,28 @@
+package com.kelvsyc.gradle.artifactory
+
+import com.kelvsyc.gradle.clients.CredentialReference
+
+/**
+ * Configures anonymous (unauthenticated) access. This is the default when [ArtifactoryClientBuildService.Params.passwordRef]
+ * is not set.
+ */
+fun ArtifactoryClientBuildService.Params.anonymous() {
+    // no-op: anonymous is the default when passwordRef is unset
+}
+
+/**
+ * Configures basic-auth access with a fixed [username] and a [CredentialReference] for the
+ * password or API token.
+ *
+ * [username] is a non-sensitive identifier stored as a plain string. [password] is a
+ * [CredentialReference] pointing to an environment variable or system property whose value is
+ * the password or API token — by default `ARTIFACTORY_PASSWORD`. The credential value is resolved
+ * at build execution time and never enters the Gradle configuration cache.
+ */
+fun ArtifactoryClientBuildService.Params.basicAuth(
+    username: String,
+    password: CredentialReference = CredentialReference.EnvironmentVariable("ARTIFACTORY_PASSWORD"),
+) {
+    this.username.set(username)
+    this.passwordRef.set(password)
+}

--- a/cores/aws-codeartifact-java-base/README.md
+++ b/cores/aws-codeartifact-java-base/README.md
@@ -22,8 +22,10 @@ Register a build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val codeartifact = gradle.sharedServices.registerIfAbsent("codeartifact", CodeArtifactClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 
@@ -32,9 +34,11 @@ and leave `credentials` unset to fall back to anonymous credentials.
 
 ## Value Sources
 
-### `GetAuthorizationTokenValueSource`
+### **Deprecated.** `GetAuthorizationTokenValueSource`
 
 Retrieves a temporary authorization token for a CodeArtifact domain:
+
+> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
 
 ```kotlin
 val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/GetAuthorizationTokenValueSource.kt
@@ -8,10 +8,25 @@ import software.amazon.awssdk.services.codeartifact.model.CodeartifactException
 import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. An authorization token
+ * returned here will be stored in `.gradle/configuration-cache/`. For task-execution use cases
+ * (e.g. `docker login`), retrieve the token inside a [org.gradle.workers.WorkAction] instead.
+ * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
+ * be aware of the cache-storage implication.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS CodeArtifact.
  *
  * The value is obtained from a request to AWS CodeArtifact.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; authorization tokens " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "For task-execution use cases such as docker login, retrieve the token inside a " +
+        "WorkAction instead. If the token is required at configuration time (e.g. for repository " +
+        "authentication), be aware that the token value will be cached.",
+    level = DeprecationLevel.WARNING
+)
 abstract class GetAuthorizationTokenValueSource : ValueSource<String, GetAuthorizationTokenValueSource.Parameters> {
     /**
      * Parameters for [GetAuthorizationTokenValueSource].

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/GetAuthorizationTokenValueSource.kt
@@ -15,6 +15,14 @@ import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenR
  * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
  * be aware of the cache-storage implication.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * token to be stored on disk. For task-execution use cases, use this `ValueSource` only entirely
+ * within a `WorkAction.execute()` body; calling the build service client directly there is
+ * simpler and avoids the `ValueSource` abstraction overhead.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS CodeArtifact.
  *
  * The value is obtained from a request to AWS CodeArtifact.

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/GetAuthorizationTokenValueSourceSpec.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/GetAuthorizationTokenValueSourceSpec.kt
@@ -25,6 +25,7 @@ class GetAuthorizationTokenValueSourceSpec : FunSpec() {
             every { response.authorizationToken() } returns "token-value"
             every { client.getAuthorizationToken(capture(slot)) } returns response
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(GetAuthorizationTokenValueSource::class) {
                 parameters.service.set(service)
                 parameters.domain.set("my-domain")
@@ -46,6 +47,7 @@ class GetAuthorizationTokenValueSourceSpec : FunSpec() {
             every { client.getAuthorizationToken(any<GetAuthorizationTokenRequest>()) } throws
                 CodeartifactException.builder().message("Unauthorized").build()
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(GetAuthorizationTokenValueSource::class) {
                 parameters.service.set(service)
                 parameters.domain.set("my-domain")

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetAuthorizationTokenValueSource.kt
@@ -8,10 +8,33 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. An authorization token
+ * returned here will be stored in `.gradle/configuration-cache/`. For task-execution use cases
+ * (e.g. `docker login`), retrieve the token inside a [org.gradle.workers.WorkAction] instead.
+ * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
+ * be aware of the cache-storage implication.
+ *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * token to be stored on disk. For task-execution use cases, use this `ValueSource` only entirely
+ * within a `WorkAction.execute()` body; calling the build service client directly there is
+ * simpler and avoids the `ValueSource` abstraction overhead.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS CodeArtifact.
  *
  * The value is obtained from a request to AWS CodeArtifact.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; authorization tokens " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "For task-execution use cases such as docker login, retrieve the token inside a " +
+        "WorkAction instead. If the token is required at configuration time (e.g. for repository " +
+        "authentication), be aware that the token value will be cached.",
+    level = DeprecationLevel.WARNING
+)
 abstract class GetAuthorizationTokenValueSource : ValueSource<String, GetAuthorizationTokenValueSource.Parameters> {
     /**
      * Parameters for [GetAuthorizationTokenValueSource].

--- a/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetAuthorizationTokenValueSourceSpec.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/GetAuthorizationTokenValueSourceSpec.kt
@@ -12,6 +12,7 @@ import io.mockk.slot
 import org.gradle.kotlin.dsl.registerIfAbsent
 import org.gradle.testfixtures.ProjectBuilder
 
+@Suppress("DEPRECATION")
 class GetAuthorizationTokenValueSourceSpec : FunSpec() {
     init {
         test("obtain - returns authorization token") {

--- a/cores/aws-ecr-java-base/README.md
+++ b/cores/aws-ecr-java-base/README.md
@@ -21,8 +21,10 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val ecr = gradle.sharedServices.registerIfAbsent("ecr", EcrClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 
@@ -31,9 +33,11 @@ and leave `credentials` unset to fall back to anonymous credentials.
 
 ## Value Sources
 
-### `GetAuthorizationTokenValueSource`
+### **Deprecated.** `GetAuthorizationTokenValueSource`
 
 Returns the base64-encoded `user:password` ECR authorization token for the caller's default registry:
+
+> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
 
 ```kotlin
 val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {

--- a/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/GetAuthorizationTokenValueSource.kt
@@ -7,12 +7,27 @@ import org.gradle.api.tasks.Internal
 import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. An authorization token
+ * returned here will be stored in `.gradle/configuration-cache/`. For task-execution use cases
+ * (e.g. `docker login`), retrieve the token inside a [org.gradle.workers.WorkAction] instead.
+ * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
+ * be aware of the cache-storage implication.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS ECR for the caller's default
  * registry.
  *
  * Returns the base64-encoded `user:password` token suitable for `docker login`. The result is the first entry
  * of [software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenResponse.authorizationData].
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; authorization tokens " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "For task-execution use cases such as docker login, retrieve the token inside a " +
+        "WorkAction instead. If the token is required at configuration time (e.g. for repository " +
+        "authentication), be aware that the token value will be cached.",
+    level = DeprecationLevel.WARNING
+)
 abstract class GetAuthorizationTokenValueSource : ValueSource<String, GetAuthorizationTokenValueSource.Parameters> {
     interface Parameters : ValueSourceParameters {
         /** The build service managing the ECR client. */

--- a/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/GetAuthorizationTokenValueSource.kt
@@ -14,6 +14,14 @@ import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest
  * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
  * be aware of the cache-storage implication.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * token to be stored on disk. For task-execution use cases, use this `ValueSource` only entirely
+ * within a `WorkAction.execute()` body; calling the build service client directly there is
+ * simpler and avoids the `ValueSource` abstraction overhead.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS ECR for the caller's default
  * registry.
  *

--- a/cores/aws-ecr-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/ecr/GetAuthorizationTokenValueSourceSpec.kt
+++ b/cores/aws-ecr-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/ecr/GetAuthorizationTokenValueSourceSpec.kt
@@ -27,6 +27,7 @@ class GetAuthorizationTokenValueSourceSpec : FunSpec() {
 
             every { client.getAuthorizationToken(any<GetAuthorizationTokenRequest>()) } returns response
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(GetAuthorizationTokenValueSource::class) {
                 parameters.service.set(service)
             }

--- a/cores/aws-ecr-kotlin-base/README.md
+++ b/cores/aws-ecr-kotlin-base/README.md
@@ -21,7 +21,7 @@ dependencies {
 val ecr = gradle.sharedServices.registerIfAbsent("ecr", EcrClientBuildService::class) {
     parameters {
         region.set("us-east-1")
-        from(providers.credentials(AwsCredentials::class.java, "ecr"))
+        defaultCredentials()
     }
 }
 ```
@@ -33,10 +33,12 @@ set of credential configuration functions.
 
 ## Value Sources
 
-### `GetAuthorizationTokenValueSource`
+### **Deprecated.** `GetAuthorizationTokenValueSource`
 
 Retrieves the base64-encoded `user:password` authorization token for the caller's default ECR registry, suitable
 for `docker login`:
+
+> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
 
 ```kotlin
 val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSource.kt
@@ -15,6 +15,14 @@ import org.gradle.api.tasks.Internal
  * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
  * be aware of the cache-storage implication.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * token to be stored on disk. For task-execution use cases, use this `ValueSource` only entirely
+ * within a `WorkAction.execute()` body; calling the build service client directly there is
+ * simpler and avoids the `ValueSource` abstraction overhead.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS ECR for the caller's default
  * registry.
  *

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSource.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSource.kt
@@ -8,12 +8,27 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. An authorization token
+ * returned here will be stored in `.gradle/configuration-cache/`. For task-execution use cases
+ * (e.g. `docker login`), retrieve the token inside a [org.gradle.workers.WorkAction] instead.
+ * If the token is genuinely needed at configuration time (e.g. for Maven repository authentication),
+ * be aware of the cache-storage implication.
+ *
  * [ValueSource] implementation retrieving an authorization token from AWS ECR for the caller's default
  * registry.
  *
  * Returns the base64-encoded `user:password` token suitable for `docker login`. The result is the first entry
  * of [aws.sdk.kotlin.services.ecr.model.GetAuthorizationTokenResponse.authorizationData].
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; authorization tokens " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "For task-execution use cases such as docker login, retrieve the token inside a " +
+        "WorkAction instead. If the token is required at configuration time (e.g. for repository " +
+        "authentication), be aware that the token value will be cached.",
+    level = DeprecationLevel.WARNING
+)
 abstract class GetAuthorizationTokenValueSource : ValueSource<String, GetAuthorizationTokenValueSource.Parameters> {
     /**
      * Parameters for [GetAuthorizationTokenValueSource].

--- a/cores/aws-ecr-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSourceSpec.kt
+++ b/cores/aws-ecr-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/GetAuthorizationTokenValueSourceSpec.kt
@@ -29,6 +29,7 @@ class GetAuthorizationTokenValueSourceSpec : FunSpec() {
                 )
             }
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(GetAuthorizationTokenValueSource::class) {
                 parameters.service.set(service)
             }

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildService.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildService.kt
@@ -66,10 +66,10 @@ abstract class AbstractAwsJavaClientBuildService<C : AwsClient, P : AwsBuildServ
         when (parameters.credentialSource.orNull) {
             AwsCredentialSource.DEFAULT_CHAIN -> DefaultCredentialsProvider.create()
             AwsCredentialSource.STATIC -> {
-                val key = parameters.accessKeyId.get()
-                val secret = parameters.secretAccessKey.get()
-                parameters.sessionToken.orNull
-                    ?.let { StaticCredentialsProvider.create(AwsSessionCredentials.create(key, secret, it)) }
+                val key = parameters.accessKeyIdRef.get().resolve()
+                val secret = parameters.secretAccessKeyRef.get().resolve()
+                parameters.sessionTokenRef.orNull
+                    ?.let { StaticCredentialsProvider.create(AwsSessionCredentials.create(key, secret, it.resolve())) }
                     ?: StaticCredentialsProvider.create(AwsBasicCredentials.create(key, secret))
             }
             AwsCredentialSource.PROFILE ->

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParams.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParams.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.java
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildServiceParameters
 
@@ -9,6 +10,10 @@ import org.gradle.api.services.BuildServiceParameters
  * All properties are serializable primitives. Do not set them directly; use the extension functions
  * on this interface (e.g. [anonymous], [defaultCredentials], [staticCredentials], [from]) which
  * atomically set [credentialSource] and its supporting fields together.
+ *
+ * Credential fields (`accessKeyIdRef`, `secretAccessKeyRef`, `sessionTokenRef`) use [CredentialReference]
+ * rather than plain strings to ensure that only lookup metadata — not secret values — is serialized to the
+ * Gradle configuration cache.
  */
 interface AwsBuildServiceParams : BuildServiceParameters {
     /**
@@ -28,27 +33,30 @@ interface AwsBuildServiceParams : BuildServiceParameters {
     val credentialSource: Property<AwsCredentialSource>
 
     /**
-     * AWS access key ID. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     * AWS access key ID reference. Used when [credentialSource] is [AwsCredentialSource.STATIC].
      *
+     * Stores a [CredentialReference] pointing to where the access key ID can be found at execution time.
      * Set via [staticCredentials], [sessionCredentials], or [from].
      */
-    val accessKeyId: Property<String>
+    val accessKeyIdRef: Property<CredentialReference>
 
     /**
-     * AWS secret access key. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     * AWS secret access key reference. Used when [credentialSource] is [AwsCredentialSource.STATIC].
      *
+     * Stores a [CredentialReference] pointing to where the secret access key can be found at execution time.
      * Set via [staticCredentials], [sessionCredentials], or [from].
      */
-    val secretAccessKey: Property<String>
+    val secretAccessKeyRef: Property<CredentialReference>
 
     /**
-     * AWS session token for temporary credentials. Optional; used when [credentialSource] is
+     * AWS session token reference for temporary credentials. Optional; used when [credentialSource] is
      * [AwsCredentialSource.STATIC]. When absent, [AwsBasicCredentials][software.amazon.awssdk.auth.credentials.AwsBasicCredentials]
      * is used instead of [AwsSessionCredentials][software.amazon.awssdk.auth.credentials.AwsSessionCredentials].
      *
+     * Stores a [CredentialReference] pointing to where the session token can be found at execution time.
      * Set via [sessionCredentials] or [from].
      */
-    val sessionToken: Property<String>
+    val sessionTokenRef: Property<CredentialReference>
 
     /**
      * Named AWS credentials profile. Used when [credentialSource] is [AwsCredentialSource.PROFILE].

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensions.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensions.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.java
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.provider.Provider
 import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
@@ -26,27 +27,36 @@ fun AwsBuildServiceParams.defaultCredentials() {
  * Configures these parameters to use a
  * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
  * with [AwsBasicCredentials][software.amazon.awssdk.auth.credentials.AwsBasicCredentials].
+ *
+ * By default, credentials are resolved from the standard AWS environment variables. Callers may
+ * provide explicit [CredentialReference] instances to override this behavior.
  */
-fun AwsBuildServiceParams.staticCredentials(accessKey: Provider<String>, secretKey: Provider<String>) {
+fun AwsBuildServiceParams.staticCredentials(
+    accessKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"),
+    secretKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"),
+) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(accessKey)
-    secretAccessKey.set(secretKey)
+    accessKeyIdRef.set(accessKey)
+    secretAccessKeyRef.set(secretKey)
 }
 
 /**
  * Configures these parameters to use a
  * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
  * with [AwsSessionCredentials][software.amazon.awssdk.auth.credentials.AwsSessionCredentials].
+ *
+ * By default, credentials are resolved from the standard AWS environment variables. Callers may
+ * provide explicit [CredentialReference] instances to override this behavior.
  */
 fun AwsBuildServiceParams.sessionCredentials(
-    accessKey: Provider<String>,
-    secretKey: Provider<String>,
-    token: Provider<String>,
+    accessKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"),
+    secretKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"),
+    token: CredentialReference = CredentialReference.EnvironmentVariable("AWS_SESSION_TOKEN"),
 ) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(accessKey)
-    secretAccessKey.set(secretKey)
-    sessionToken.set(token)
+    accessKeyIdRef.set(accessKey)
+    secretAccessKeyRef.set(secretKey)
+    sessionTokenRef.set(token)
 }
 
 /**
@@ -64,12 +74,29 @@ fun AwsBuildServiceParams.profileCredentials(profile: String) {
  * [StaticCredentialsProvider][software.amazon.awssdk.auth.credentials.StaticCredentialsProvider]
  * sourced from Gradle [PasswordCredentials], mapping [PasswordCredentials.getUsername] to the
  * access key ID and [PasswordCredentials.getPassword] to the secret access key.
+ *
+ * **Deprecated — configuration cache unsafe.** [PasswordCredentials] is a configuration-time
+ * construct designed for Gradle repository authentication (dependency resolution). It is not
+ * intended to supply credentials to services that authenticate during task execution. Calling
+ * this function resolves the provider during the configuration phase, which causes the actual
+ * credential values to be stored in the Gradle configuration cache in plaintext.
+ *
+ * **Prefer** [staticCredentials] with [CredentialReference.EnvironmentVariable] for CI/CD, or
+ * [CredentialReference.SystemProperty] for `gradle.properties`-backed credentials using the
+ * `systemProp.` convention (see [CredentialReference.SystemProperty] for details).
  */
+@Deprecated(
+    "PasswordCredentials is a configuration-phase construct designed for repository auth, not " +
+        "for build services that run at task execution time. Resolving it here stores the actual " +
+        "credential values in the Gradle configuration cache. Prefer staticCredentials() with " +
+        "CredentialReference.EnvironmentVariable or CredentialReference.SystemProperty instead.",
+    level = DeprecationLevel.WARNING,
+)
 @JvmName("fromPasswordCredentials")
 fun AwsBuildServiceParams.from(credentials: Provider<PasswordCredentials>) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(credentials.map { it.username })
-    secretAccessKey.set(credentials.map { it.password })
+    accessKeyIdRef.set(credentials.map { CredentialReference.Literal(it.username ?: "") }.get())
+    secretAccessKeyRef.set(credentials.map { CredentialReference.Literal(it.password ?: "") }.get())
 }
 
 /**
@@ -79,11 +106,33 @@ fun AwsBuildServiceParams.from(credentials: Provider<PasswordCredentials>) {
  * [AwsCredentials.getSessionToken][GradleAwsCredentials.getSessionToken] is non-null,
  * [AwsSessionCredentials][software.amazon.awssdk.auth.credentials.AwsSessionCredentials] are
  * used; otherwise [AwsBasicCredentials][software.amazon.awssdk.auth.credentials.AwsBasicCredentials].
+ *
+ * **Deprecated — configuration cache unsafe.** [GradleAwsCredentials] is a configuration-time
+ * construct designed for Gradle repository authentication (dependency resolution). It is not
+ * intended to supply credentials to services that authenticate during task execution. Calling
+ * this function resolves the provider during the configuration phase, which causes the actual
+ * credential values to be stored in the Gradle configuration cache in plaintext.
+ *
+ * **Prefer** [staticCredentials] or [sessionCredentials] with [CredentialReference.EnvironmentVariable]
+ * for CI/CD, or [CredentialReference.SystemProperty] for `gradle.properties`-backed credentials
+ * using the `systemProp.` convention (see [CredentialReference.SystemProperty] for details).
  */
+@Deprecated(
+    "AwsCredentials is a configuration-phase construct designed for repository auth, not " +
+        "for build services that run at task execution time. Resolving it here stores the actual " +
+        "credential values in the Gradle configuration cache. Prefer staticCredentials() or " +
+        "sessionCredentials() with CredentialReference.EnvironmentVariable or " +
+        "CredentialReference.SystemProperty instead.",
+    level = DeprecationLevel.WARNING,
+)
 @JvmName("fromAwsCredentials")
 fun AwsBuildServiceParams.from(credentials: Provider<GradleAwsCredentials>) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(credentials.map { it.accessKey })
-    secretAccessKey.set(credentials.map { it.secretKey })
-    sessionToken.set(credentials.map { it.sessionToken ?: "" }.filter { it.isNotEmpty() })
+    val creds = credentials.get()
+    accessKeyIdRef.set(CredentialReference.Literal(creds.accessKey ?: ""))
+    secretAccessKeyRef.set(CredentialReference.Literal(creds.secretKey ?: ""))
+    val token = creds.sessionToken
+    if (token != null && token.isNotEmpty()) {
+        sessionTokenRef.set(CredentialReference.Literal(token))
+    }
 }

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsCredentialSource.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsCredentialSource.kt
@@ -18,8 +18,8 @@ enum class AwsCredentialSource {
 
     /**
      * Use [software.amazon.awssdk.auth.credentials.StaticCredentialsProvider] built from
-     * [AwsBuildServiceParams.accessKeyId], [AwsBuildServiceParams.secretAccessKey], and
-     * optionally [AwsBuildServiceParams.sessionToken].
+     * [AwsBuildServiceParams.accessKeyIdRef], [AwsBuildServiceParams.secretAccessKeyRef], and
+     * optionally [AwsBuildServiceParams.sessionTokenRef].
      */
     STATIC,
 

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/GradleCredentialsProviders.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/GradleCredentialsProviders.kt
@@ -10,7 +10,20 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
  * [AwsCredentialsProvider] implementation backed by a [Provider] of [PasswordCredentials].
  *
  * The resolved credentials is of type [AwsBasicCredentials].
+ *
+ * **Deprecated.** [PasswordCredentials] is a configuration-phase abstraction designed for Gradle
+ * repository authentication (dependency resolution). It is not intended to supply credentials to
+ * AWS SDK clients that authenticate during task execution. Prefer building an AWS build service
+ * with [CredentialReference.EnvironmentVariable][com.kelvsyc.gradle.clients.CredentialReference.EnvironmentVariable]
+ * or [CredentialReference.SystemProperty][com.kelvsyc.gradle.clients.CredentialReference.SystemProperty]
+ * parameters instead.
  */
+@Deprecated(
+    "PasswordCredentials is a configuration-phase abstraction designed for repository auth, not " +
+        "for AWS SDK clients that authenticate at task execution time. Prefer a build service " +
+        "configured with CredentialReference.EnvironmentVariable or CredentialReference.SystemProperty.",
+    level = DeprecationLevel.WARNING,
+)
 class GradleCredentialsProviders(credentials: Provider<PasswordCredentials>) : AwsCredentialsProvider {
     private val credentialsInternal = credentials.map {
         AwsBasicCredentials.builder().apply {

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/GradleSessionCredentialsProvider.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/GradleSessionCredentialsProvider.kt
@@ -7,10 +7,25 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
 import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
 
 /**
- * [AwsCredentialsProvider] implementation backed by a [Provider] of [Gradle AwsCredentials][GradleAwsCredentials].
+ * [AwsCredentialsProvider] implementation backed by a [Provider] of
+ * [Gradle AwsCredentials][GradleAwsCredentials].
  *
  * The resolved credentials is of type [AwsSessionCredentials].
+ *
+ * **Deprecated.** [GradleAwsCredentials][org.gradle.api.credentials.AwsCredentials] is a
+ * configuration-phase abstraction designed for Gradle repository authentication (dependency
+ * resolution). It is not intended to supply credentials to AWS SDK clients that authenticate
+ * during task execution. Prefer building an AWS build service with
+ * [CredentialReference.EnvironmentVariable][com.kelvsyc.gradle.clients.CredentialReference.EnvironmentVariable]
+ * or [CredentialReference.SystemProperty][com.kelvsyc.gradle.clients.CredentialReference.SystemProperty]
+ * parameters instead.
  */
+@Deprecated(
+    "AwsCredentials (Gradle) is a configuration-phase abstraction designed for repository auth, not " +
+        "for AWS SDK clients that authenticate at task execution time. Prefer a build service " +
+        "configured with CredentialReference.EnvironmentVariable or CredentialReference.SystemProperty.",
+    level = DeprecationLevel.WARNING,
+)
 class GradleSessionCredentialsProvider(credentials: Provider<GradleAwsCredentials>) : AwsCredentialsProvider {
     private val credentialsInternal = credentials.map {
         AwsSessionCredentials.builder().apply {

--- a/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildServiceSpec.kt
+++ b/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AbstractAwsJavaClientBuildServiceSpec.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.java
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -68,8 +69,8 @@ class AbstractAwsJavaClientBuildServiceSpec : FunSpec() {
             val project = ProjectBuilder.builder().build()
             val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
                 spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
-                spec.parameters.accessKeyId.set("AKID")
-                spec.parameters.secretAccessKey.set("SECRET")
+                spec.parameters.accessKeyIdRef.set(CredentialReference.Literal("AKID"))
+                spec.parameters.secretAccessKeyRef.set(CredentialReference.Literal("SECRET"))
             }
 
             val provider = service.get().testResolveCredentialsProvider()
@@ -83,9 +84,9 @@ class AbstractAwsJavaClientBuildServiceSpec : FunSpec() {
             val project = ProjectBuilder.builder().build()
             val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
                 spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
-                spec.parameters.accessKeyId.set("AKID")
-                spec.parameters.secretAccessKey.set("SECRET")
-                spec.parameters.sessionToken.set("TOKEN")
+                spec.parameters.accessKeyIdRef.set(CredentialReference.Literal("AKID"))
+                spec.parameters.secretAccessKeyRef.set(CredentialReference.Literal("SECRET"))
+                spec.parameters.sessionTokenRef.set(CredentialReference.Literal("TOKEN"))
             }
 
             val provider = service.get().testResolveCredentialsProvider()

--- a/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensionsSpec.kt
+++ b/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/AwsBuildServiceParamsExtensionsSpec.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.java
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.shouldBe
@@ -30,27 +31,30 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
         test("staticCredentials - sets credentialSource to STATIC and maps accessKey and secretKey") {
             val project = ProjectBuilder.builder().build()
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
-            params.staticCredentials(project.provider { "AKID" }, project.provider { "SECRET" })
+            params.staticCredentials(
+                CredentialReference.Literal("AKID"),
+                CredentialReference.Literal("SECRET"),
+            )
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.isPresent.shouldBeFalse()
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.isPresent.shouldBeFalse()
         }
 
         test("sessionCredentials - sets credentialSource to STATIC and maps all three fields") {
             val project = ProjectBuilder.builder().build()
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
             params.sessionCredentials(
-                project.provider { "AKID" },
-                project.provider { "SECRET" },
-                project.provider { "TOKEN" },
+                CredentialReference.Literal("AKID"),
+                CredentialReference.Literal("SECRET"),
+                CredentialReference.Literal("TOKEN"),
             )
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.get() shouldBe "TOKEN"
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.get() shouldBe CredentialReference.Literal("TOKEN")
         }
 
         test("profileCredentials - sets credentialSource to PROFILE and sets credentialsProfile") {
@@ -68,12 +72,13 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
             every { creds.username } returns "AKID"
             every { creds.password } returns "SECRET"
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            @Suppress("DEPRECATION")
             params.from(project.provider { creds })
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.isPresent.shouldBeFalse()
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.isPresent.shouldBeFalse()
         }
 
         test("from GradleAwsCredentials - sets STATIC and maps all fields when sessionToken is present") {
@@ -83,12 +88,13 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
             every { creds.secretKey } returns "SECRET"
             every { creds.sessionToken } returns "TOKEN"
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            @Suppress("DEPRECATION")
             params.from(project.provider { creds })
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.get() shouldBe "TOKEN"
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.get() shouldBe CredentialReference.Literal("TOKEN")
         }
 
         test("from GradleAwsCredentials - leaves sessionToken absent when sessionToken is null") {
@@ -98,10 +104,11 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
             every { creds.secretKey } returns "SECRET"
             every { creds.sessionToken } returns null
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            @Suppress("DEPRECATION")
             params.from(project.provider { creds })
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.sessionToken.isPresent.shouldBeFalse()
+            params.sessionTokenRef.isPresent.shouldBeFalse()
         }
     }
 }

--- a/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/GradleCredentialsProvidersSpec.kt
+++ b/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/GradleCredentialsProvidersSpec.kt
@@ -25,6 +25,7 @@ class GradleCredentialsProvidersSpec : FunSpec() {
             every { provider.map<AwsCredentials>(capture(transformerSlot)) } returns mappedProvider
             every { mappedProvider.get() } answers { transformerSlot.captured.transform(passwordCredentials) }
 
+            @Suppress("DEPRECATION")
             val sut = GradleCredentialsProviders(provider)
             val resolved = sut.resolveCredentials() as AwsBasicCredentials
 

--- a/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/GradleSessionCredentialsProviderSpec.kt
+++ b/cores/aws-java-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/java/GradleSessionCredentialsProviderSpec.kt
@@ -26,6 +26,7 @@ class GradleSessionCredentialsProviderSpec : FunSpec() {
             every { provider.map<AwsCredentials>(capture(transformerSlot)) } returns mappedProvider
             every { mappedProvider.get() } answers { transformerSlot.captured.transform(gradleCredentials) }
 
+            @Suppress("DEPRECATION")
             val sut = GradleSessionCredentialsProvider(provider)
             val resolved = sut.resolveCredentials() as AwsSessionCredentials
 

--- a/cores/aws-kms-java-base/README.md
+++ b/cores/aws-kms-java-base/README.md
@@ -19,8 +19,10 @@ dependencies {
 
 ```kotlin
 val kms = gradle.sharedServices.registerIfAbsent("kms", KmsClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildService.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildService.kt
@@ -68,10 +68,10 @@ abstract class AbstractAwsKotlinClientBuildService<C : SdkClient, P : AwsBuildSe
         when (parameters.credentialSource.orNull) {
             AwsCredentialSource.DEFAULT_CHAIN -> DefaultChainCredentialsProvider()
             AwsCredentialSource.STATIC -> {
-                val key = parameters.accessKeyId.get()
-                val secret = parameters.secretAccessKey.get()
-                val credentials = parameters.sessionToken.orNull
-                    ?.let { Credentials(key, secret, it) }
+                val key = parameters.accessKeyIdRef.get().resolve()
+                val secret = parameters.secretAccessKeyRef.get().resolve()
+                val credentials = parameters.sessionTokenRef.orNull
+                    ?.let { Credentials(key, secret, it.resolve()) }
                     ?: Credentials(key, secret)
                 StaticCredentialsProvider(credentials)
             }

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParams.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParams.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.kotlin
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildServiceParameters
 
@@ -9,6 +10,10 @@ import org.gradle.api.services.BuildServiceParameters
  * All properties are serializable primitives. Do not set [credentialSource] and its supporting
  * fields directly; use the extension functions on this interface (e.g. [anonymous],
  * [defaultCredentials], [staticCredentials], [from]) which atomically configure them together.
+ *
+ * Credential fields (`accessKeyIdRef`, `secretAccessKeyRef`, `sessionTokenRef`) use [CredentialReference]
+ * rather than plain strings to ensure that only lookup metadata — not secret values — is serialized to the
+ * Gradle configuration cache.
  */
 interface AwsBuildServiceParams : BuildServiceParameters {
     /**
@@ -28,28 +33,31 @@ interface AwsBuildServiceParams : BuildServiceParameters {
     val credentialSource: Property<AwsCredentialSource>
 
     /**
-     * AWS access key ID. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     * AWS access key ID reference. Used when [credentialSource] is [AwsCredentialSource.STATIC].
      *
+     * Stores a [CredentialReference] pointing to where the access key ID can be found at execution time.
      * Set via [staticCredentials], [sessionCredentials], or [from].
      */
-    val accessKeyId: Property<String>
+    val accessKeyIdRef: Property<CredentialReference>
 
     /**
-     * AWS secret access key. Used when [credentialSource] is [AwsCredentialSource.STATIC].
+     * AWS secret access key reference. Used when [credentialSource] is [AwsCredentialSource.STATIC].
      *
+     * Stores a [CredentialReference] pointing to where the secret access key can be found at execution time.
      * Set via [staticCredentials], [sessionCredentials], or [from].
      */
-    val secretAccessKey: Property<String>
+    val secretAccessKeyRef: Property<CredentialReference>
 
     /**
-     * AWS session token for temporary credentials. Optional; used when [credentialSource] is
+     * AWS session token reference for temporary credentials. Optional; used when [credentialSource] is
      * [AwsCredentialSource.STATIC]. When absent, the underlying
      * [aws.smithy.kotlin.runtime.auth.awscredentials.Credentials] is constructed without a
      * session token.
      *
+     * Stores a [CredentialReference] pointing to where the session token can be found at execution time.
      * Set via [sessionCredentials] or [from].
      */
-    val sessionToken: Property<String>
+    val sessionTokenRef: Property<CredentialReference>
 
     /**
      * Named AWS credentials profile. Used when [credentialSource] is [AwsCredentialSource.PROFILE].

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensions.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensions.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.kotlin
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.credentials.PasswordCredentials
 import org.gradle.api.provider.Provider
 import org.gradle.api.credentials.AwsCredentials as GradleAwsCredentials
@@ -27,11 +28,17 @@ fun AwsBuildServiceParams.defaultCredentials() {
  * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
  * with [Credentials][aws.smithy.kotlin.runtime.auth.awscredentials.Credentials] built from the
  * supplied access key and secret key.
+ *
+ * By default, credentials are resolved from the standard AWS environment variables. Callers may
+ * provide explicit [CredentialReference] instances to override this behavior.
  */
-fun AwsBuildServiceParams.staticCredentials(accessKey: Provider<String>, secretKey: Provider<String>) {
+fun AwsBuildServiceParams.staticCredentials(
+    accessKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"),
+    secretKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"),
+) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(accessKey)
-    secretAccessKey.set(secretKey)
+    accessKeyIdRef.set(accessKey)
+    secretAccessKeyRef.set(secretKey)
 }
 
 /**
@@ -39,16 +46,19 @@ fun AwsBuildServiceParams.staticCredentials(accessKey: Provider<String>, secretK
  * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
  * with session [Credentials][aws.smithy.kotlin.runtime.auth.awscredentials.Credentials] built
  * from the supplied access key, secret key, and session token.
+ *
+ * By default, credentials are resolved from the standard AWS environment variables. Callers may
+ * provide explicit [CredentialReference] instances to override this behavior.
  */
 fun AwsBuildServiceParams.sessionCredentials(
-    accessKey: Provider<String>,
-    secretKey: Provider<String>,
-    token: Provider<String>,
+    accessKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"),
+    secretKey: CredentialReference = CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"),
+    token: CredentialReference = CredentialReference.EnvironmentVariable("AWS_SESSION_TOKEN"),
 ) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(accessKey)
-    secretAccessKey.set(secretKey)
-    sessionToken.set(token)
+    accessKeyIdRef.set(accessKey)
+    secretAccessKeyRef.set(secretKey)
+    sessionTokenRef.set(token)
 }
 
 /**
@@ -66,12 +76,29 @@ fun AwsBuildServiceParams.profileCredentials(profile: String) {
  * [StaticCredentialsProvider][aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider]
  * sourced from Gradle [PasswordCredentials], mapping [PasswordCredentials.getUsername] to the
  * access key ID and [PasswordCredentials.getPassword] to the secret access key.
+ *
+ * **Deprecated — configuration cache unsafe.** [PasswordCredentials] is a configuration-time
+ * construct designed for Gradle repository authentication (dependency resolution). It is not
+ * intended to supply credentials to services that authenticate during task execution. Calling
+ * this function resolves the provider during the configuration phase, which causes the actual
+ * credential values to be stored in the Gradle configuration cache in plaintext.
+ *
+ * **Prefer** [staticCredentials] with [CredentialReference.EnvironmentVariable] for CI/CD, or
+ * [CredentialReference.SystemProperty] for `gradle.properties`-backed credentials using the
+ * `systemProp.` convention (see [CredentialReference.SystemProperty] for details).
  */
+@Deprecated(
+    "PasswordCredentials is a configuration-phase construct designed for repository auth, not " +
+        "for build services that run at task execution time. Resolving it here stores the actual " +
+        "credential values in the Gradle configuration cache. Prefer staticCredentials() with " +
+        "CredentialReference.EnvironmentVariable or CredentialReference.SystemProperty instead.",
+    level = DeprecationLevel.WARNING,
+)
 @JvmName("fromPasswordCredentials")
 fun AwsBuildServiceParams.from(credentials: Provider<PasswordCredentials>) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(credentials.map { it.username })
-    secretAccessKey.set(credentials.map { it.password })
+    accessKeyIdRef.set(credentials.map { CredentialReference.Literal(it.username ?: "") }.get())
+    secretAccessKeyRef.set(credentials.map { CredentialReference.Literal(it.password ?: "") }.get())
 }
 
 /**
@@ -80,11 +107,33 @@ fun AwsBuildServiceParams.from(credentials: Provider<PasswordCredentials>) {
  * sourced from Gradle [AwsCredentials][GradleAwsCredentials]. When
  * [AwsCredentials.getSessionToken][GradleAwsCredentials.getSessionToken] is non-null, session
  * credentials are used; otherwise basic credentials.
+ *
+ * **Deprecated — configuration cache unsafe.** [GradleAwsCredentials] is a configuration-time
+ * construct designed for Gradle repository authentication (dependency resolution). It is not
+ * intended to supply credentials to services that authenticate during task execution. Calling
+ * this function resolves the provider during the configuration phase, which causes the actual
+ * credential values to be stored in the Gradle configuration cache in plaintext.
+ *
+ * **Prefer** [staticCredentials] or [sessionCredentials] with [CredentialReference.EnvironmentVariable]
+ * for CI/CD, or [CredentialReference.SystemProperty] for `gradle.properties`-backed credentials
+ * using the `systemProp.` convention (see [CredentialReference.SystemProperty] for details).
  */
+@Deprecated(
+    "AwsCredentials is a configuration-phase construct designed for repository auth, not " +
+        "for build services that run at task execution time. Resolving it here stores the actual " +
+        "credential values in the Gradle configuration cache. Prefer staticCredentials() or " +
+        "sessionCredentials() with CredentialReference.EnvironmentVariable or " +
+        "CredentialReference.SystemProperty instead.",
+    level = DeprecationLevel.WARNING,
+)
 @JvmName("fromAwsCredentials")
 fun AwsBuildServiceParams.from(credentials: Provider<GradleAwsCredentials>) {
     credentialSource.set(AwsCredentialSource.STATIC)
-    accessKeyId.set(credentials.map { it.accessKey })
-    secretAccessKey.set(credentials.map { it.secretKey })
-    sessionToken.set(credentials.map { it.sessionToken ?: "" }.filter { it.isNotEmpty() })
+    val creds = credentials.get()
+    accessKeyIdRef.set(CredentialReference.Literal(creds.accessKey ?: ""))
+    secretAccessKeyRef.set(CredentialReference.Literal(creds.secretKey ?: ""))
+    val token = creds.sessionToken
+    if (token != null && token.isNotEmpty()) {
+        sessionTokenRef.set(CredentialReference.Literal(token))
+    }
 }

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsCredentialSource.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsCredentialSource.kt
@@ -21,8 +21,8 @@ enum class AwsCredentialSource {
 
     /**
      * Use [aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider] built from
-     * [AwsBuildServiceParams.accessKeyId], [AwsBuildServiceParams.secretAccessKey], and
-     * optionally [AwsBuildServiceParams.sessionToken].
+     * [AwsBuildServiceParams.accessKeyIdRef], [AwsBuildServiceParams.secretAccessKeyRef], and
+     * optionally [AwsBuildServiceParams.sessionTokenRef].
      */
     STATIC,
 

--- a/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildServiceSpec.kt
+++ b/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AbstractAwsKotlinClientBuildServiceSpec.kt
@@ -4,6 +4,7 @@ import aws.sdk.kotlin.runtime.auth.credentials.DefaultChainCredentialsProvider
 import aws.sdk.kotlin.runtime.auth.credentials.ProfileCredentialsProvider
 import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
 import aws.smithy.kotlin.runtime.client.SdkClient
+import com.kelvsyc.gradle.clients.CredentialReference
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -65,8 +66,8 @@ class AbstractAwsKotlinClientBuildServiceSpec : FunSpec() {
             val project = ProjectBuilder.builder().build()
             val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
                 spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
-                spec.parameters.accessKeyId.set("AKID")
-                spec.parameters.secretAccessKey.set("SECRET")
+                spec.parameters.accessKeyIdRef.set(CredentialReference.Literal("AKID"))
+                spec.parameters.secretAccessKeyRef.set(CredentialReference.Literal("SECRET"))
             }
 
             val provider = service.get().testResolveCredentialsProvider()
@@ -81,9 +82,9 @@ class AbstractAwsKotlinClientBuildServiceSpec : FunSpec() {
             val project = ProjectBuilder.builder().build()
             val service = project.gradle.sharedServices.registerIfAbsent("test", TestService::class.java) { spec: BuildServiceSpec<AwsBuildServiceParams> ->
                 spec.parameters.credentialSource.set(AwsCredentialSource.STATIC)
-                spec.parameters.accessKeyId.set("AKID")
-                spec.parameters.secretAccessKey.set("SECRET")
-                spec.parameters.sessionToken.set("TOKEN")
+                spec.parameters.accessKeyIdRef.set(CredentialReference.Literal("AKID"))
+                spec.parameters.secretAccessKeyRef.set(CredentialReference.Literal("SECRET"))
+                spec.parameters.sessionTokenRef.set(CredentialReference.Literal("TOKEN"))
             }
 
             val provider = service.get().testResolveCredentialsProvider()

--- a/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensionsSpec.kt
+++ b/cores/aws-kotlin-extensions/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsBuildServiceParamsExtensionsSpec.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.aws.kotlin
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.shouldBe
@@ -30,27 +31,30 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
         test("staticCredentials - sets credentialSource to STATIC and maps accessKey and secretKey") {
             val project = ProjectBuilder.builder().build()
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
-            params.staticCredentials(project.provider { "AKID" }, project.provider { "SECRET" })
+            params.staticCredentials(
+                CredentialReference.Literal("AKID"),
+                CredentialReference.Literal("SECRET"),
+            )
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.isPresent.shouldBeFalse()
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.isPresent.shouldBeFalse()
         }
 
         test("sessionCredentials - sets credentialSource to STATIC and maps all three fields") {
             val project = ProjectBuilder.builder().build()
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
             params.sessionCredentials(
-                project.provider { "AKID" },
-                project.provider { "SECRET" },
-                project.provider { "TOKEN" },
+                CredentialReference.Literal("AKID"),
+                CredentialReference.Literal("SECRET"),
+                CredentialReference.Literal("TOKEN"),
             )
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.get() shouldBe "TOKEN"
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.get() shouldBe CredentialReference.Literal("TOKEN")
         }
 
         test("profileCredentials - sets credentialSource to PROFILE and sets credentialsProfile") {
@@ -68,12 +72,13 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
             every { creds.username } returns "AKID"
             every { creds.password } returns "SECRET"
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            @Suppress("DEPRECATION")
             params.from(project.provider { creds })
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.isPresent.shouldBeFalse()
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.isPresent.shouldBeFalse()
         }
 
         test("from GradleAwsCredentials - sets STATIC and maps all fields when sessionToken is present") {
@@ -83,12 +88,13 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
             every { creds.secretKey } returns "SECRET"
             every { creds.sessionToken } returns "TOKEN"
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            @Suppress("DEPRECATION")
             params.from(project.provider { creds })
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.accessKeyId.get() shouldBe "AKID"
-            params.secretAccessKey.get() shouldBe "SECRET"
-            params.sessionToken.get() shouldBe "TOKEN"
+            params.accessKeyIdRef.get() shouldBe CredentialReference.Literal("AKID")
+            params.secretAccessKeyRef.get() shouldBe CredentialReference.Literal("SECRET")
+            params.sessionTokenRef.get() shouldBe CredentialReference.Literal("TOKEN")
         }
 
         test("from GradleAwsCredentials - leaves sessionToken absent when sessionToken is null") {
@@ -98,10 +104,11 @@ class AwsBuildServiceParamsExtensionsSpec : FunSpec() {
             every { creds.secretKey } returns "SECRET"
             every { creds.sessionToken } returns null
             val params = project.objects.newInstance(AwsBuildServiceParams::class.java)
+            @Suppress("DEPRECATION")
             params.from(project.provider { creds })
 
             params.credentialSource.get() shouldBe AwsCredentialSource.STATIC
-            params.sessionToken.isPresent.shouldBeFalse()
+            params.sessionTokenRef.isPresent.shouldBeFalse()
         }
     }
 }

--- a/cores/aws-lambda-java-base/README.md
+++ b/cores/aws-lambda-java-base/README.md
@@ -21,8 +21,10 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val lambda = gradle.sharedServices.registerIfAbsent("lambda", LambdaClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-s3-java-base/README.md
+++ b/cores/aws-s3-java-base/README.md
@@ -23,13 +23,17 @@ dependencies {
 
 ```kotlin
 val s3 = gradle.sharedServices.registerIfAbsent("s3", S3ClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 
 val s3Async = gradle.sharedServices.registerIfAbsent("s3-async", S3AsyncClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-s3-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/s3/BuildServiceConfigurationCacheSpec.kt
@@ -28,8 +28,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 regionId.set("us-east-1")
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
+                accessKeyIdRef.set(CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"))
+                secretAccessKeyRef.set(CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"))
             """.trimIndent()
         )
     }
@@ -62,6 +62,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
         import com.kelvsyc.gradle.aws.java.AwsCredentialSource
         import com.kelvsyc.gradle.aws.java.s3.S3ClientBuildService
         import com.kelvsyc.gradle.aws.java.s3.fixtures.S3ClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val s3Service = gradle.sharedServices.registerIfAbsent(
             "s3",

--- a/cores/aws-secrets-manager-java-base/README.md
+++ b/cores/aws-secrets-manager-java-base/README.md
@@ -23,13 +23,17 @@ dependencies {
 
 ```kotlin
 val sm = gradle.sharedServices.registerIfAbsent("sm", SecretsManagerClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 
 val smAsync = gradle.sharedServices.registerIfAbsent("sm-async", SecretsManagerAsyncClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 
@@ -57,7 +61,9 @@ lazily — the underlying service is not instantiated until the cache itself is 
 
 ## Value Sources
 
-### `SecretsManagerValueSource`
+**Note on configuration cache safety:** Gradle serializes the result of every `ValueSource.obtain()` call to the configuration cache in plaintext. Any credential or secret value returned by a `ValueSource` will be stored in `.gradle/configuration-cache/` and is readable by any process with access to the build directory. The `ValueSource` implementations in this component that retrieve credentials or secrets are deprecated for this reason. Retrieve sensitive values inside a `WorkAction` at task execution time instead — the value is resolved after the cache has been read and is never written to it.
+
+### **Deprecated.** `SecretsManagerValueSource`
 
 Retrieves a single string secret directly from Secrets Manager:
 
@@ -72,7 +78,7 @@ val secret: Provider<String> = providers.of(SecretsManagerValueSource::class) {
 
 Returns `null` and logs a warning if the call throws `SecretsManagerException`. Only string secrets are supported.
 
-### `SecretFromCacheValueSource`
+### **Deprecated.** `SecretFromCacheValueSource`
 
 Retrieves a single string secret from the in-memory cache:
 
@@ -85,7 +91,7 @@ val secret: Provider<String> = providers.of(SecretFromCacheValueSource::class) {
 }
 ```
 
-### `SecretBatchValueSource`
+### **Deprecated.** `SecretBatchValueSource`
 
 Retrieves multiple secrets in a single paginated batch call, returning a `Map<String, String>` keyed by secret
 name:

--- a/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-secrets-manager-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/BuildServiceConfigurationCacheSpec.kt
@@ -26,8 +26,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 regionId.set("us-east-1")
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
+                accessKeyIdRef.set(CredentialReference.Literal("ak"))
+                secretAccessKeyRef.set(CredentialReference.Literal("sk"))
             """.trimIndent()
         )
     }
@@ -58,6 +58,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
         ${IntegrationTestSupport.buildscriptBlock()}
 
         import com.kelvsyc.gradle.aws.java.AwsCredentialSource
+        import com.kelvsyc.gradle.clients.CredentialReference
         import com.kelvsyc.gradle.aws.java.secretsmanager.SecretsManagerClientBuildService
         import com.kelvsyc.gradle.aws.java.secretsmanager.fixtures.SecretsManagerClientBuildServiceProbeTask
 

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSource.kt
@@ -16,6 +16,15 @@ import kotlin.streams.asSequence
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secrets to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation that retrieves a set of secrets, by their IDs, from Secrets Manager.
  *
  * Only string secrets are supported.

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSource.kt
@@ -9,10 +9,24 @@ import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueR
 import kotlin.streams.asSequence
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. Secret values returned
+ * here will be stored in `.gradle/configuration-cache/` and are readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation that retrieves a set of secrets, by their IDs, from Secrets Manager.
  *
  * Only string secrets are supported.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; secret values " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class SecretBatchValueSource : ValueSource<Map<String, String>, SecretBatchValueSource.Parameters> {
     /**
      * Parameters for [SecretBatchValueSource].

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSource.kt
@@ -13,6 +13,15 @@ import org.gradle.api.tasks.Internal
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secret to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation backed by retrieving a secret from an in-memory Secrets Manager cache.
  *
  * Only string secrets are supported.

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSource.kt
@@ -6,10 +6,24 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. A secret value returned
+ * here will be stored in `.gradle/configuration-cache/` and is readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation backed by retrieving a secret from an in-memory Secrets Manager cache.
  *
  * Only string secrets are supported.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; the secret value " +
+        "returned by obtain() is stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class SecretFromCacheValueSource : ValueSource<String, SecretFromCacheValueSource.Parameters> {
     /**
      * Parameters for [SecretFromCacheValueSource].

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSource.kt
@@ -17,6 +17,15 @@ import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerExcept
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secret to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation backed by retrieving a secret from Secrets Manager.
  *
  * Only string secrets are supported.

--- a/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSource.kt
+++ b/cores/aws-secrets-manager-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSource.kt
@@ -10,10 +10,24 @@ import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueReques
 import software.amazon.awssdk.services.secretsmanager.model.SecretsManagerException
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. A secret value returned
+ * here will be stored in `.gradle/configuration-cache/` and is readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation backed by retrieving a secret from Secrets Manager.
  *
  * Only string secrets are supported.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; the secret value " +
+        "returned by obtain() is stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class SecretsManagerValueSource : ValueSource<String, SecretsManagerValueSource.Parameters> {
     companion object {
         val logger by GradleLoggerDelegate

--- a/cores/aws-secrets-manager-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSourceSpec.kt
+++ b/cores/aws-secrets-manager-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretBatchValueSourceSpec.kt
@@ -44,6 +44,7 @@ class SecretBatchValueSourceSpec : FunSpec() {
 
             every { client.batchGetSecretValuePaginator(capture(requestSlot)) } returns paginator
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretBatchValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretIds.set(setOf("secret-one", "secret-two"))

--- a/cores/aws-secrets-manager-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSourceSpec.kt
+++ b/cores/aws-secrets-manager-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretFromCacheValueSourceSpec.kt
@@ -20,6 +20,7 @@ class SecretFromCacheValueSourceSpec : FunSpec() {
             )
             every { cache.getSecretString("my-secret") } returns "cached-value"
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretFromCacheValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("my-secret")

--- a/cores/aws-secrets-manager-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSourceSpec.kt
+++ b/cores/aws-secrets-manager-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/secretsmanager/SecretsManagerValueSourceSpec.kt
@@ -28,6 +28,7 @@ class SecretsManagerValueSourceSpec : FunSpec() {
             every { response.secretString() } returns "super-secret"
             every { client.getSecretValue(capture(slot)) } returns response
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretsManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("my-secret")
@@ -50,6 +51,7 @@ class SecretsManagerValueSourceSpec : FunSpec() {
                 client.getSecretValue(any<GetSecretValueRequest>())
             } throws SecretsManagerException.builder().message("not found").build()
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretsManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("missing-secret")

--- a/cores/aws-secrets-manager-kotlin-base/README.md
+++ b/cores/aws-secrets-manager-kotlin-base/README.md
@@ -21,7 +21,7 @@ dependencies {
 val sm = gradle.sharedServices.registerIfAbsent("sm", SecretsManagerClientBuildService::class) {
     parameters {
         region.set("us-east-1")
-        from(providers.credentials(AwsCredentials::class.java, "sm"))
+        defaultCredentials()
     }
 }
 ```
@@ -33,7 +33,9 @@ set of credential configuration functions.
 
 ## Value Sources
 
-### `SecretsManagerValueSource`
+**Note on configuration cache safety:** Gradle serializes the result of every `ValueSource.obtain()` call to the configuration cache in plaintext. Any credential or secret value returned by a `ValueSource` will be stored in `.gradle/configuration-cache/` and is readable by any process with access to the build directory. The `ValueSource` implementations in this component that retrieve credentials or secrets are deprecated for this reason. Retrieve sensitive values inside a `WorkAction` at task execution time instead — the value is resolved after the cache has been read and is never written to it.
+
+### **Deprecated.** `SecretsManagerValueSource`
 
 Retrieves a single string secret from Secrets Manager:
 
@@ -48,7 +50,7 @@ val secret: Provider<String> = providers.of(SecretsManagerValueSource::class) {
 
 Only string secrets are supported. The `secretString` field of the response is returned directly.
 
-### `SecretBatchValueSource`
+### **Deprecated.** `SecretBatchValueSource`
 
 Retrieves multiple secrets using the paginated batch API, returning a `Map<String, String>` keyed by secret name:
 

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSource.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSource.kt
@@ -22,6 +22,15 @@ import org.gradle.api.tasks.Internal
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secrets to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation that retrieves a set of secrets, by their IDs, from Secrets Manager.
  *
  * Only string secrets are supported.

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSource.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSource.kt
@@ -15,10 +15,24 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. Secret values returned
+ * here will be stored in `.gradle/configuration-cache/` and are readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation that retrieves a set of secrets, by their IDs, from Secrets Manager.
  *
  * Only string secrets are supported.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; secret values " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class SecretBatchValueSource : ValueSource<Map<String, String>, SecretBatchValueSource.Parameters> {
     /**
      * Parameters for [SecretBatchValueSource].

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSource.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSource.kt
@@ -10,10 +10,24 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. A secret value returned
+ * here will be stored in `.gradle/configuration-cache/` and is readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation backed by retrieving a secret from Secrets Manager.
  *
  * Only string secrets are supported.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; the secret value " +
+        "returned by obtain() is stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class SecretsManagerValueSource : ValueSource<String, SecretsManagerValueSource.Parameters> {
     /**
      * Parameters for [SecretsManagerValueSource].

--- a/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSource.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSource.kt
@@ -17,6 +17,15 @@ import org.gradle.api.tasks.Internal
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secret to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation backed by retrieving a secret from Secrets Manager.
  *
  * Only string secrets are supported.

--- a/cores/aws-secrets-manager-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSourceSpec.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretBatchValueSourceSpec.kt
@@ -37,6 +37,7 @@ class SecretBatchValueSourceSpec : FunSpec() {
                 }
             )
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretBatchValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretIds.set(setOf("secret-one", "secret-two"))

--- a/cores/aws-secrets-manager-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSourceSpec.kt
+++ b/cores/aws-secrets-manager-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/secretsmanager/SecretsManagerValueSourceSpec.kt
@@ -26,6 +26,7 @@ class SecretsManagerValueSourceSpec : FunSpec() {
                 secretString = "super-secret"
             }
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretsManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("my-secret")
@@ -46,6 +47,7 @@ class SecretsManagerValueSourceSpec : FunSpec() {
                 client.getSecretValue(any<GetSecretValueRequest>())
             } throws SecretsManagerException("not found")
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretsManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("missing-secret")

--- a/cores/aws-ses-java-base/README.md
+++ b/cores/aws-ses-java-base/README.md
@@ -22,8 +22,10 @@ Register a build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val ses = gradle.sharedServices.registerIfAbsent("ses", SesClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-sns-java-base/README.md
+++ b/cores/aws-sns-java-base/README.md
@@ -23,13 +23,17 @@ registering under different names. Same applies to the async service.
 
 ```kotlin
 val sns = gradle.sharedServices.registerIfAbsent("sns", SnsClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 
 val snsAsync = gradle.sharedServices.registerIfAbsent("sns-async", SnsAsyncClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-sns-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/sns/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-sns-java-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/java/sns/BuildServiceConfigurationCacheSpec.kt
@@ -11,7 +11,7 @@ import java.io.File
  * Probe #1: configuration-cache round-trip of `SnsClientBuildService.Params` (a.k.a. `AwsBuildServiceParams`).
  *
  * Each test pins down the **observed** behavior of the parameter shape — `regionId: Property<String>`,
- * `credentialSource: Property<AwsCredentialSource>`, `accessKeyId/secretAccessKey/sessionToken: Property<String>`,
+ * `credentialSource: Property<AwsCredentialSource>`, `accessKeyIdRef/secretAccessKeyRef/sessionTokenRef: Property<CredentialReference>`,
  * `credentialsProfile: Property<String>`. A failing test means either Gradle's config-cache serializer or the
  * AWS Java extensions have regressed; investigate before "fixing" the test.
  *
@@ -48,8 +48,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "static-credentials",
             parametersBlock = """
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
+                accessKeyIdRef.set(CredentialReference.Literal("ak"))
+                secretAccessKeyRef.set(CredentialReference.Literal("sk"))
             """.trimIndent()
         )
     }
@@ -59,9 +59,9 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "session-credentials",
             parametersBlock = """
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
-                sessionToken.set("tok")
+                accessKeyIdRef.set(CredentialReference.Literal("ak"))
+                secretAccessKeyRef.set(CredentialReference.Literal("sk"))
+                sessionTokenRef.set(CredentialReference.Literal("tok"))
             """.trimIndent()
         )
     }
@@ -89,8 +89,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 regionId.set("us-east-1")
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
+                accessKeyIdRef.set(CredentialReference.Literal("ak"))
+                secretAccessKeyRef.set(CredentialReference.Literal("sk"))
             """.trimIndent()
         )
     }
@@ -121,6 +121,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
         ${IntegrationTestSupport.buildscriptBlock()}
 
         import com.kelvsyc.gradle.aws.java.AwsCredentialSource
+        import com.kelvsyc.gradle.clients.CredentialReference
         import com.kelvsyc.gradle.aws.java.sns.SnsClientBuildService
         import com.kelvsyc.gradle.aws.java.sns.fixtures.SnsBuildServiceProbeTask
 

--- a/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/aws-sns-kotlin-base/src/integrationTest/kotlin/com/kelvsyc/gradle/aws/kotlin/sns/BuildServiceConfigurationCacheSpec.kt
@@ -12,7 +12,8 @@ import java.io.File
  * from `aws-kotlin-extensions`).
  *
  * Each test pins down the **observed** behavior of the parameter shape — `region: Property<String>`,
- * `credentialSource: Property<AwsCredentialSource>`, `accessKeyId/secretAccessKey/sessionToken: Property<String>`,
+ * `credentialSource: Property<AwsCredentialSource>`,
+ * `accessKeyIdRef/secretAccessKeyRef/sessionTokenRef: Property<CredentialReference>`,
  * `credentialsProfile: Property<String>`. A failing test means either Gradle's config-cache serializer or the
  * AWS Kotlin extensions have regressed; investigate before "fixing" the test.
  *
@@ -49,8 +50,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "static-credentials",
             parametersBlock = """
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
+                accessKeyIdRef.set(CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"))
+                secretAccessKeyRef.set(CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"))
             """.trimIndent()
         )
     }
@@ -60,9 +61,9 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "session-credentials",
             parametersBlock = """
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
-                sessionToken.set("tok")
+                accessKeyIdRef.set(CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"))
+                secretAccessKeyRef.set(CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"))
+                sessionTokenRef.set(CredentialReference.EnvironmentVariable("AWS_SESSION_TOKEN"))
             """.trimIndent()
         )
     }
@@ -90,8 +91,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 region.set("us-east-1")
                 credentialSource.set(AwsCredentialSource.STATIC)
-                accessKeyId.set("ak")
-                secretAccessKey.set("sk")
+                accessKeyIdRef.set(CredentialReference.EnvironmentVariable("AWS_ACCESS_KEY_ID"))
+                secretAccessKeyRef.set(CredentialReference.EnvironmentVariable("AWS_SECRET_ACCESS_KEY"))
             """.trimIndent()
         )
     }
@@ -124,6 +125,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
         import com.kelvsyc.gradle.aws.kotlin.AwsCredentialSource
         import com.kelvsyc.gradle.aws.kotlin.sns.SnsClientBuildService
         import com.kelvsyc.gradle.aws.kotlin.sns.fixtures.SnsClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val snsService = gradle.sharedServices.registerIfAbsent(
             "sns",

--- a/cores/aws-sqs-java-base/README.md
+++ b/cores/aws-sqs-java-base/README.md
@@ -22,8 +22,10 @@ Register a build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val sqs = gradle.sharedServices.registerIfAbsent("sqs", SqsClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-ssm-java-base/README.md
+++ b/cores/aws-ssm-java-base/README.md
@@ -19,8 +19,10 @@ dependencies {
 
 ```kotlin
 val ssm = gradle.sharedServices.registerIfAbsent("ssm", SsmClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/aws-sts-java-base/README.md
+++ b/cores/aws-sts-java-base/README.md
@@ -21,8 +21,10 @@ Register the build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val sts = gradle.sharedServices.registerIfAbsent("sts", StsClientBuildService::class) {
-    parameters.region.set(Region.US_EAST_1)
-    parameters.credentials.set(DefaultCredentialsProvider.create())
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
 }
 ```
 

--- a/cores/azure-blob-storage-base/src/integrationTest/kotlin/com/kelvsyc/gradle/azure/storage/blob/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/azure-blob-storage-base/src/integrationTest/kotlin/com/kelvsyc/gradle/azure/storage/blob/BuildServiceConfigurationCacheSpec.kt
@@ -69,7 +69,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
                 credentialSource.set(AzureCredentialSource.CLIENT_SECRET)
                 tenantId.set("00000000-0000-0000-0000-000000000001")
                 clientId.set("00000000-0000-0000-0000-000000000002")
-                clientSecret.set("fake-secret")
+                clientSecretRef.set(CredentialReference.EnvironmentVariable("AZURE_CLIENT_SECRET"))
             """.trimIndent()
         )
     }
@@ -79,7 +79,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "sas-token",
             parametersBlock = """
                 credentialSource.set(AzureCredentialSource.SAS_TOKEN)
-                sasToken.set("sv=2020-10-02&fake")
+                sasTokenRef.set(CredentialReference.EnvironmentVariable("AZURE_STORAGE_SAS_TOKEN"))
             """.trimIndent()
         )
     }
@@ -90,7 +90,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 credentialSource.set(AzureCredentialSource.STORAGE_ACCOUNT_KEY)
                 accountName.set("myaccount")
-                accountKey.set("ZmFrZS1rZXk=")
+                accountKeyRef.set(CredentialReference.EnvironmentVariable("AZURE_STORAGE_ACCOUNT_KEY"))
             """.trimIndent()
         )
     }
@@ -103,7 +103,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
                 credentialSource.set(AzureCredentialSource.CLIENT_SECRET)
                 tenantId.set("00000000-0000-0000-0000-000000000001")
                 clientId.set("00000000-0000-0000-0000-000000000002")
-                clientSecret.set("fake-secret")
+                clientSecretRef.set(CredentialReference.EnvironmentVariable("AZURE_CLIENT_SECRET"))
             """.trimIndent()
         )
     }
@@ -136,6 +136,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
         import com.kelvsyc.gradle.azure.AzureCredentialSource
         import com.kelvsyc.gradle.azure.storage.blob.BlobServiceClientBuildService
         import com.kelvsyc.gradle.azure.storage.blob.fixtures.BlobBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val blobService = gradle.sharedServices.registerIfAbsent(
             "blob",

--- a/cores/azure-extensions/src/main/kotlin/com/kelvsyc/gradle/azure/AbstractAzureClientBuildService.kt
+++ b/cores/azure-extensions/src/main/kotlin/com/kelvsyc/gradle/azure/AbstractAzureClientBuildService.kt
@@ -62,9 +62,9 @@ abstract class AbstractAzureClientBuildService<C : Any, P : AzureBuildServicePar
      * | `NONE` | `null` |
      * | `DEFAULT` | [ResolvedAzureCredential.Token] over `DefaultAzureCredentialBuilder().build()` |
      * | `MANAGED_IDENTITY` | [ResolvedAzureCredential.Token] over `ManagedIdentityCredentialBuilder()` (optionally with `clientId`) |
-     * | `CLIENT_SECRET` | [ResolvedAzureCredential.Token] over `ClientSecretCredentialBuilder()` |
-     * | `SAS_TOKEN` | [ResolvedAzureCredential.Sas] over [AzureSasCredential] |
-     * | `STORAGE_ACCOUNT_KEY` | [ResolvedAzureCredential.NamedKey] over [AzureNamedKeyCredential] |
+     * | `CLIENT_SECRET` | [ResolvedAzureCredential.Token] over `ClientSecretCredentialBuilder()` using [AzureBuildServiceParams.clientSecretRef] |
+     * | `SAS_TOKEN` | [ResolvedAzureCredential.Sas] over [AzureSasCredential] using [AzureBuildServiceParams.sasTokenRef] |
+     * | `STORAGE_ACCOUNT_KEY` | [ResolvedAzureCredential.NamedKey] over [AzureNamedKeyCredential] using [AzureBuildServiceParams.accountKeyRef] |
      * | unset | `null` |
      */
     protected fun resolveCredential(): ResolvedAzureCredential? =
@@ -90,17 +90,17 @@ abstract class AbstractAzureClientBuildService<C : Any, P : AzureBuildServicePar
         val credential: TokenCredential = ClientSecretCredentialBuilder()
             .tenantId(parameters.tenantId.get())
             .clientId(parameters.clientId.get())
-            .clientSecret(parameters.clientSecret.get())
+            .clientSecret(parameters.clientSecretRef.get().resolve())
             .build()
         return ResolvedAzureCredential.Token(credential)
     }
 
     private fun resolveSasToken(): ResolvedAzureCredential.Sas =
-        ResolvedAzureCredential.Sas(AzureSasCredential(parameters.sasToken.get()))
+        ResolvedAzureCredential.Sas(AzureSasCredential(parameters.sasTokenRef.get().resolve()))
 
     private fun resolveStorageAccountKey(): ResolvedAzureCredential.NamedKey =
         ResolvedAzureCredential.NamedKey(
-            AzureNamedKeyCredential(parameters.accountName.get(), parameters.accountKey.get())
+            AzureNamedKeyCredential(parameters.accountName.get(), parameters.accountKeyRef.get().resolve())
         )
 
     /**

--- a/cores/azure-extensions/src/main/kotlin/com/kelvsyc/gradle/azure/AzureBuildServiceParams.kt
+++ b/cores/azure-extensions/src/main/kotlin/com/kelvsyc/gradle/azure/AzureBuildServiceParams.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.azure
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildServiceParameters
 
@@ -10,6 +11,11 @@ import org.gradle.api.services.BuildServiceParameters
  * extension functions on this interface ([noCredentials], [defaultCredential], [managedIdentity],
  * [clientSecret], [sasToken], [sharedKey]) which atomically set [credentialSource] and its
  * supporting fields together.
+ *
+ * Credential fields ([clientSecretRef], [sasTokenRef], [accountKeyRef]) use [CredentialReference]
+ * rather than plain strings to ensure that only lookup metadata — not secret values — is serialized
+ * to the Gradle configuration cache. Non-secret identity fields ([tenantId], [clientId],
+ * [accountName]) remain plain strings.
  *
  * Note that the service-specific endpoint (Storage account URL, Key Vault URL, etc.) is **not**
  * part of this interface — each service builds upon this interface with its own endpoint property
@@ -41,20 +47,22 @@ interface AzureBuildServiceParams : BuildServiceParameters {
     val clientId: Property<String>
 
     /**
-     * Azure AD client secret. Used when [credentialSource] is
+     * Reference to where the Azure AD client secret can be found. Used when [credentialSource] is
      * [AzureCredentialSource.CLIENT_SECRET].
      *
-     * Set via [clientSecret].
+     * Stores a [CredentialReference] pointing to an environment variable or system property whose
+     * value is the client secret. Set via [clientSecret].
      */
-    val clientSecret: Property<String>
+    val clientSecretRef: Property<CredentialReference>
 
     /**
-     * Shared Access Signature token, **without** the leading `?`. Used when [credentialSource] is
-     * [AzureCredentialSource.SAS_TOKEN].
+     * Reference to where the Shared Access Signature token can be found, **without** the leading
+     * `?`. Used when [credentialSource] is [AzureCredentialSource.SAS_TOKEN].
      *
-     * Set via [sasToken].
+     * Stores a [CredentialReference] pointing to an environment variable or system property whose
+     * value is the SAS token. Set via [sasToken].
      */
-    val sasToken: Property<String>
+    val sasTokenRef: Property<CredentialReference>
 
     /**
      * Azure Storage account name. Used when [credentialSource] is
@@ -65,10 +73,11 @@ interface AzureBuildServiceParams : BuildServiceParameters {
     val accountName: Property<String>
 
     /**
-     * Azure Storage account key. Used when [credentialSource] is
-     * [AzureCredentialSource.STORAGE_ACCOUNT_KEY].
+     * Reference to where the Azure Storage account key can be found. Used when [credentialSource]
+     * is [AzureCredentialSource.STORAGE_ACCOUNT_KEY].
      *
-     * Set via [sharedKey].
+     * Stores a [CredentialReference] pointing to an environment variable or system property whose
+     * value is the account key. Set via [sharedKey].
      */
-    val accountKey: Property<String>
+    val accountKeyRef: Property<CredentialReference>
 }

--- a/cores/azure-extensions/src/main/kotlin/com/kelvsyc/gradle/azure/AzureBuildServiceParamsExtensions.kt
+++ b/cores/azure-extensions/src/main/kotlin/com/kelvsyc/gradle/azure/AzureBuildServiceParamsExtensions.kt
@@ -1,6 +1,6 @@
 package com.kelvsyc.gradle.azure
 
-import org.gradle.api.provider.Provider
+import com.kelvsyc.gradle.clients.CredentialReference
 
 /**
  * Configures these parameters to skip credential construction entirely. Suitable for tests, local
@@ -31,64 +31,53 @@ fun AzureBuildServiceParams.managedIdentity(clientId: String? = null) {
 
 /**
  * Configures these parameters to use a `ClientSecretCredential` for an Azure AD service principal.
+ *
+ * [tenantId] and [clientId] are non-sensitive identifiers and are stored as plain strings.
+ * [clientSecret] is a [CredentialReference] pointing to an environment variable or system property
+ * whose value is the client secret — by default `AZURE_CLIENT_SECRET`. The secret value is
+ * resolved at build execution time and never enters the Gradle configuration cache.
  */
 fun AzureBuildServiceParams.clientSecret(
-    tenantId: Provider<String>,
-    clientId: Provider<String>,
-    clientSecret: Provider<String>,
+    tenantId: String,
+    clientId: String,
+    clientSecret: CredentialReference = CredentialReference.EnvironmentVariable("AZURE_CLIENT_SECRET"),
 ) {
     credentialSource.set(AzureCredentialSource.CLIENT_SECRET)
     this.tenantId.set(tenantId)
     this.clientId.set(clientId)
-    this.clientSecret.set(clientSecret)
-}
-
-/**
- * Configures these parameters to use a `ClientSecretCredential` for an Azure AD service principal.
- */
-fun AzureBuildServiceParams.clientSecret(tenantId: String, clientId: String, clientSecret: String) {
-    credentialSource.set(AzureCredentialSource.CLIENT_SECRET)
-    this.tenantId.set(tenantId)
-    this.clientId.set(clientId)
-    this.clientSecret.set(clientSecret)
+    this.clientSecretRef.set(clientSecret)
 }
 
 /**
  * Configures these parameters to use an [com.azure.core.credential.AzureSasCredential]. The token
  * must not include the leading `?`. Supported by Storage services; **not** supported by Key Vault.
+ *
+ * [token] is a [CredentialReference] pointing to an environment variable or system property whose
+ * value is the SAS token — by default `AZURE_STORAGE_SAS_TOKEN`. The token value is resolved at
+ * build execution time and never enters the Gradle configuration cache.
  */
-fun AzureBuildServiceParams.sasToken(token: Provider<String>) {
+fun AzureBuildServiceParams.sasToken(
+    token: CredentialReference = CredentialReference.EnvironmentVariable("AZURE_STORAGE_SAS_TOKEN"),
+) {
     credentialSource.set(AzureCredentialSource.SAS_TOKEN)
-    sasToken.set(token)
-}
-
-/**
- * Configures these parameters to use an [com.azure.core.credential.AzureSasCredential]. The token
- * must not include the leading `?`. Supported by Storage services; **not** supported by Key Vault.
- */
-fun AzureBuildServiceParams.sasToken(token: String) {
-    credentialSource.set(AzureCredentialSource.SAS_TOKEN)
-    sasToken.set(token)
+    sasTokenRef.set(token)
 }
 
 /**
  * Configures these parameters to use an [com.azure.core.credential.AzureNamedKeyCredential] sourced
  * from an Azure Storage account name and access key. Supported by Storage services; **not**
  * supported by Key Vault.
+ *
+ * [accountName] is a non-sensitive identifier stored as a plain string. [accountKey] is a
+ * [CredentialReference] pointing to an environment variable or system property whose value is the
+ * account key — by default `AZURE_STORAGE_ACCOUNT_KEY`. The key value is resolved at build
+ * execution time and never enters the Gradle configuration cache.
  */
-fun AzureBuildServiceParams.sharedKey(accountName: Provider<String>, accountKey: Provider<String>) {
+fun AzureBuildServiceParams.sharedKey(
+    accountName: String,
+    accountKey: CredentialReference = CredentialReference.EnvironmentVariable("AZURE_STORAGE_ACCOUNT_KEY"),
+) {
     credentialSource.set(AzureCredentialSource.STORAGE_ACCOUNT_KEY)
     this.accountName.set(accountName)
-    this.accountKey.set(accountKey)
-}
-
-/**
- * Configures these parameters to use an [com.azure.core.credential.AzureNamedKeyCredential] sourced
- * from an Azure Storage account name and access key. Supported by Storage services; **not**
- * supported by Key Vault.
- */
-fun AzureBuildServiceParams.sharedKey(accountName: String, accountKey: String) {
-    credentialSource.set(AzureCredentialSource.STORAGE_ACCOUNT_KEY)
-    this.accountName.set(accountName)
-    this.accountKey.set(accountKey)
+    this.accountKeyRef.set(accountKey)
 }

--- a/cores/azure-key-vault-base/README.md
+++ b/cores/azure-key-vault-base/README.md
@@ -42,9 +42,9 @@ client construction time.
 | `vaultUrl` | `Property<String>` | Vault URL, e.g. `https://{vaultName}.vault.azure.net` |
 | `credentialSource` | `Property<AzureCredentialSource>` | Which credential to construct. Set via the extension functions. Leave unset to skip credential configuration. |
 
-## Value Source: `KeyVaultSecretValueSource`
+## Value Source: **Deprecated.** `KeyVaultSecretValueSource`
 
-Retrieves a secret from Azure Key Vault as a string.
+**Note on configuration cache safety:** Gradle serializes the result of every `ValueSource.obtain()` call to the configuration cache in plaintext. Any credential or secret value returned by a `ValueSource` will be stored in `.gradle/configuration-cache/` and is readable by any process with access to the build directory. The `ValueSource` implementations in this component that retrieve credentials or secrets are deprecated for this reason. Retrieve sensitive values inside a `WorkAction` at task execution time instead — the value is resolved after the cache has been read and is never written to it.
 
 ```kotlin
 val secret: Provider<String> = providers.of(KeyVaultSecretValueSource::class) {

--- a/cores/azure-key-vault-base/src/main/kotlin/com/kelvsyc/gradle/azure/keyvault/KeyVaultSecretValueSource.kt
+++ b/cores/azure-key-vault-base/src/main/kotlin/com/kelvsyc/gradle/azure/keyvault/KeyVaultSecretValueSource.kt
@@ -15,6 +15,15 @@ import org.gradle.api.tasks.Internal
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secret to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation backed by retrieving a secret from Azure Key Vault.
  *
  * The secret value is returned as a string.

--- a/cores/azure-key-vault-base/src/main/kotlin/com/kelvsyc/gradle/azure/keyvault/KeyVaultSecretValueSource.kt
+++ b/cores/azure-key-vault-base/src/main/kotlin/com/kelvsyc/gradle/azure/keyvault/KeyVaultSecretValueSource.kt
@@ -8,10 +8,24 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. A secret value returned
+ * here will be stored in `.gradle/configuration-cache/` and is readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation backed by retrieving a secret from Azure Key Vault.
  *
  * The secret value is returned as a string.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; the secret value " +
+        "returned by obtain() is stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class KeyVaultSecretValueSource : ValueSource<String, KeyVaultSecretValueSource.Parameters> {
     interface Parameters : ValueSourceParameters {
         /** The build service managing the Key Vault secret client. */

--- a/cores/azure-key-vault-base/src/test/kotlin/com/kelvsyc/gradle/azure/keyvault/KeyVaultSecretValueSourceSpec.kt
+++ b/cores/azure-key-vault-base/src/test/kotlin/com/kelvsyc/gradle/azure/keyvault/KeyVaultSecretValueSourceSpec.kt
@@ -25,6 +25,7 @@ class KeyVaultSecretValueSourceSpec : FunSpec() {
             every { secret.value } returns "super-secret"
             every { client.getSecret(capture(nameSlot)) } returns secret
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(KeyVaultSecretValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("my-secret")
@@ -46,6 +47,7 @@ class KeyVaultSecretValueSourceSpec : FunSpec() {
             every { secret.value } returns "versioned-secret"
             every { client.getSecret(capture(nameSlot), capture(versionSlot)) } returns secret
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(KeyVaultSecretValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("my-secret")
@@ -65,6 +67,7 @@ class KeyVaultSecretValueSourceSpec : FunSpec() {
             val service = project.gradle.sharedServices.registerIfAbsent("kv", MockSecretClientBuildService::class)
             every { client.getSecret(any<String>()) } throws HttpResponseException("not found", mockk<HttpResponse>(relaxed = true))
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(KeyVaultSecretValueSource::class) {
                 parameters.service.set(service)
                 parameters.secretName.set("missing-secret")

--- a/cores/azure-managed-identity-base/README.md
+++ b/cores/azure-managed-identity-base/README.md
@@ -43,9 +43,11 @@ val imds = gradle.sharedServices.registerIfAbsent("imds", AzureImdsClientBuildSe
 
 ## Value Sources
 
-### `AccessTokenValueSource`
+### **Deprecated.** `AccessTokenValueSource`
 
 Retrieves a raw OAuth2 bearer token for the specified Azure scopes.
+
+> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
 
 ```kotlin
 val token: Provider<String> = providers.of(AccessTokenValueSource::class) {

--- a/cores/azure-managed-identity-base/src/main/kotlin/com/kelvsyc/gradle/azure/identity/AccessTokenValueSource.kt
+++ b/cores/azure-managed-identity-base/src/main/kotlin/com/kelvsyc/gradle/azure/identity/AccessTokenValueSource.kt
@@ -14,6 +14,14 @@ import org.gradle.api.tasks.Internal
  * retrieve the token inside a [org.gradle.workers.WorkAction] instead.
  * If the token is genuinely needed at configuration time, be aware of the cache-storage implication.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * token to be stored on disk. For task-execution use cases, use this `ValueSource` only entirely
+ * within a `WorkAction.execute()` body; calling the build service client directly there is
+ * simpler and avoids the `ValueSource` abstraction overhead.
+ *
  * [ValueSource] that obtains an OAuth2 access token for the specified scopes using a
  * [ManagedIdentityCredentialBuildService].
  *

--- a/cores/azure-managed-identity-base/src/main/kotlin/com/kelvsyc/gradle/azure/identity/AccessTokenValueSource.kt
+++ b/cores/azure-managed-identity-base/src/main/kotlin/com/kelvsyc/gradle/azure/identity/AccessTokenValueSource.kt
@@ -8,12 +8,25 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. An OAuth2 token
+ * returned here will be stored in `.gradle/configuration-cache/`. For task-execution use cases,
+ * retrieve the token inside a [org.gradle.workers.WorkAction] instead.
+ * If the token is genuinely needed at configuration time, be aware of the cache-storage implication.
+ *
  * [ValueSource] that obtains an OAuth2 access token for the specified scopes using a
  * [ManagedIdentityCredentialBuildService].
  *
  * The returned string is the raw bearer token value. Obtain a scoped token for Azure Resource
  * Manager via scope `https://management.azure.com/.default`.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; OAuth2 tokens " +
+        "returned by obtain() are stored in plaintext in .gradle/configuration-cache/. " +
+        "For task-execution use cases, retrieve the token inside a WorkAction instead. " +
+        "If the token is required at configuration time, be aware that the value will be cached.",
+    level = DeprecationLevel.WARNING
+)
 abstract class AccessTokenValueSource : ValueSource<String, AccessTokenValueSource.Parameters> {
 
     /**

--- a/cores/azure-managed-identity-base/src/test/kotlin/com/kelvsyc/gradle/azure/identity/AccessTokenValueSourceSpec.kt
+++ b/cores/azure-managed-identity-base/src/test/kotlin/com/kelvsyc/gradle/azure/identity/AccessTokenValueSourceSpec.kt
@@ -26,6 +26,7 @@ class AccessTokenValueSourceSpec : FunSpec() {
             val accessToken = AccessToken("my-token-value", OffsetDateTime.now().plusHours(1))
             every { credential.getToken(capture(contextSlot)) } returns Mono.just(accessToken)
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(AccessTokenValueSource::class) {
                 parameters.service.set(service)
                 parameters.scopes.add("https://management.azure.com/.default")

--- a/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/bitbucket-cloud-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BuildServiceConfigurationCacheSpec.kt
@@ -10,8 +10,8 @@ import java.io.File
 /**
  * Probe: configuration-cache round-trip of `BitbucketCloudClientBuildService.Params`.
  *
- * All parameters are `Property<String>` (`baseUrl`, `username`, `password`) so the CC codec trivially
- * handles them. Each test verifies that a first invocation stores the configuration cache entry and a second
+ * `baseUrl` and `username` are `Property<String>`; `passwordRef` is `Property<CredentialReference>` which stores
+ * only the lookup key. All three types are Gradle config-cache serializable. Each test verifies that a first invocation stores the configuration cache entry and a second
  * invocation reuses it without re-executing task configuration.
  */
 class BuildServiceConfigurationCacheSpec : FunSpec({
@@ -31,7 +31,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "credentials",
             parametersBlock = """
                 username.set("user")
-                password.set("apppassword")
+                passwordRef.set(CredentialReference.EnvironmentVariable("BITBUCKET_APP_PASSWORD"))
             """.trimIndent()
         )
     }
@@ -42,7 +42,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 baseUrl.set("https://api.bitbucket.org/2.0/")
                 username.set("user")
-                password.set("apppassword")
+                passwordRef.set(CredentialReference.EnvironmentVariable("BITBUCKET_APP_PASSWORD"))
             """.trimIndent()
         )
     }
@@ -74,6 +74,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
 
         import com.kelvsyc.gradle.bitbucket.cloud.BitbucketCloudClientBuildService
         import com.kelvsyc.gradle.bitbucket.cloud.fixtures.BitbucketCloudClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val bbService = gradle.sharedServices.registerIfAbsent(
             "bitbucketCloud",

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BitbucketCloudClientBuildService.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BitbucketCloudClientBuildService.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.bitbucket.cloud
 
 import com.kelvsyc.gradle.clients.AbstractClientBuildService
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.Credentials
@@ -36,9 +37,12 @@ abstract class BitbucketCloudClientBuildService :
         val username: Property<String>
 
         /**
-         * Bitbucket Cloud app password for authenticating with the API.
+         * Reference to where the Bitbucket Cloud app password can be found.
+         *
+         * Stores a [CredentialReference] pointing to an environment variable or system property
+         * whose value is the app password. Set via the [basicAuth] extension function.
          */
-        val password: Property<String>
+        val passwordRef: Property<CredentialReference>
     }
 
     override fun createClient(): BitbucketCloudService {
@@ -46,7 +50,7 @@ abstract class BitbucketCloudClientBuildService :
             val request = chain.request().newBuilder()
                 .header("Authorization", Credentials.basic(
                     parameters.username.getOrElse(""),
-                    parameters.password.getOrElse(""),
+                    parameters.passwordRef.orNull?.resolve() ?: "",
                 ))
                 .build()
             chain.proceed(request)

--- a/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BitbucketCloudClientBuildServiceParamsExtensions.kt
+++ b/cores/bitbucket-cloud-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/cloud/BitbucketCloudClientBuildServiceParamsExtensions.kt
@@ -1,0 +1,20 @@
+package com.kelvsyc.gradle.bitbucket.cloud
+
+import com.kelvsyc.gradle.clients.CredentialReference
+
+/**
+ * Configures basic-auth access with a fixed [username] and a [CredentialReference] for the app
+ * password.
+ *
+ * [username] is a non-sensitive identifier stored as a plain string. [password] is a
+ * [CredentialReference] pointing to an environment variable or system property whose value is the
+ * Bitbucket Cloud app password — by default `BITBUCKET_APP_PASSWORD`. The credential value is
+ * resolved at build execution time and never enters the Gradle configuration cache.
+ */
+fun BitbucketCloudClientBuildService.Params.basicAuth(
+    username: String,
+    password: CredentialReference = CredentialReference.EnvironmentVariable("BITBUCKET_APP_PASSWORD"),
+) {
+    this.username.set(username)
+    this.passwordRef.set(password)
+}

--- a/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/bitbucket-data-center-base/src/integrationTest/kotlin/com/kelvsyc/gradle/bitbucket/server/BuildServiceConfigurationCacheSpec.kt
@@ -10,7 +10,8 @@ import java.io.File
 /**
  * Probe: configuration-cache round-trip of `BitbucketServerClientBuildService.Params`.
  *
- * All parameters are `Property<String>` (`baseUrl`, `token`), so the CC codec trivially handles them.
+ * `baseUrl` is `Property<String>`; `tokenRef` is `Property<CredentialReference>` which stores only the lookup
+ * key. Both types are Gradle config-cache serializable.
  * This spec serves as a baseline regression sentinel: if any future change to the params shape introduces
  * a non-serializable type, at least one test here will go red.
  */
@@ -22,7 +23,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
     test("BitbucketServerClientBuildService with token-only survives config-cache round-trip") {
         assertParamsRoundTripCleanly(
             name = "token-only",
-            parametersBlock = """token.set("mytoken")"""
+            parametersBlock = """tokenRef.set(CredentialReference.EnvironmentVariable("BITBUCKET_TOKEN"))"""
         )
     }
 
@@ -31,7 +32,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "base-url-and-token",
             parametersBlock = """
                 baseUrl.set("https://bitbucket.example.com/")
-                token.set("mytoken")
+                tokenRef.set(CredentialReference.EnvironmentVariable("BITBUCKET_TOKEN"))
             """.trimIndent()
         )
     }
@@ -63,6 +64,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
 
         import com.kelvsyc.gradle.bitbucket.server.BitbucketServerClientBuildService
         import com.kelvsyc.gradle.bitbucket.server.fixtures.BitbucketServerClientBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val bbService = gradle.sharedServices.registerIfAbsent(
             "bitbucketServer",

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/BitbucketServerClientBuildService.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/BitbucketServerClientBuildService.kt
@@ -1,6 +1,7 @@
 package com.kelvsyc.gradle.bitbucket.server
 
 import com.kelvsyc.gradle.clients.AbstractClientBuildService
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import okhttp3.Interceptor
@@ -29,15 +30,18 @@ abstract class BitbucketServerClientBuildService :
         val baseUrl: Property<String>
 
         /**
-         * A personal access token (or HTTP access token) for authenticating with the Bitbucket Data Center API.
+         * Reference to where the personal access token (or HTTP access token) can be found.
+         *
+         * Stores a [CredentialReference] pointing to an environment variable or system property
+         * whose value is the token. Set via the [bearerToken] extension function.
          */
-        val token: Property<String>
+        val tokenRef: Property<CredentialReference>
     }
 
     override fun createClient(): BitbucketServerService {
         val authInterceptor = Interceptor { chain ->
             val request = chain.request().newBuilder()
-                .header("Authorization", "Bearer ${parameters.token.get()}")
+                .header("Authorization", "Bearer ${parameters.tokenRef.get().resolve()}")
                 .build()
             chain.proceed(request)
         }

--- a/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/BitbucketServerClientBuildServiceParamsExtensions.kt
+++ b/cores/bitbucket-data-center-base/src/main/kotlin/com/kelvsyc/gradle/bitbucket/server/BitbucketServerClientBuildServiceParamsExtensions.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.bitbucket.server
+
+import com.kelvsyc.gradle.clients.CredentialReference
+
+/**
+ * Configures Bearer-token authentication with a [CredentialReference] for the token.
+ *
+ * [token] is a [CredentialReference] pointing to an environment variable or system property whose
+ * value is the Bitbucket Data Center personal access token (or HTTP access token) — by default
+ * `BITBUCKET_TOKEN`. The credential value is resolved at build execution time and never enters the
+ * Gradle configuration cache.
+ */
+fun BitbucketServerClientBuildService.Params.bearerToken(
+    token: CredentialReference = CredentialReference.EnvironmentVariable("BITBUCKET_TOKEN"),
+) {
+    this.tokenRef.set(token)
+}

--- a/cores/clients-base/src/main/kotlin/com/kelvsyc/gradle/clients/CredentialReference.kt
+++ b/cores/clients-base/src/main/kotlin/com/kelvsyc/gradle/clients/CredentialReference.kt
@@ -1,0 +1,112 @@
+package com.kelvsyc.gradle.clients
+
+/**
+ * A reference to where a build service credential can be found at execution time.
+ *
+ * ## Why this type exists
+ *
+ * Gradle's configuration cache serializes the resolved value of every [org.gradle.api.provider.Property] on
+ * [org.gradle.api.services.BuildServiceParameters] to `.gradle/configuration-cache/` as plaintext when the cache
+ * is first written. This happens regardless of whether the caller used
+ * [org.gradle.api.provider.ProviderFactory.environmentVariable] or a literal string — the provider chain is
+ * fully resolved at cache-write time, and the concrete string is stored on disk. Any user or process with read
+ * access to the build directory can extract those values.
+ *
+ * To keep secrets out of the cache, [BuildServiceParameters][org.gradle.api.services.BuildServiceParameters]
+ * properties that hold credentials use `Property<CredentialReference>` instead of `Property<String>`. A
+ * [CredentialReference] stores only the *name* of an environment variable or JVM system property — never the
+ * secret value itself. Only non-sensitive metadata (a string name) is serialized to the cache.
+ *
+ * ## Where resolution happens
+ *
+ * Subclasses of [com.kelvsyc.gradle.clients.AbstractClientBuildService] resolve credentials inside
+ * `createClient()`, which is called lazily on first access during task execution — after the configuration
+ * cache has already been read and deserialized. The actual secret value is obtained at that point via
+ * [System.getenv] or [System.getProperty] and held only in memory for the lifetime of the build service.
+ *
+ * ## Implementing [Serializable]
+ *
+ * This sealed class implements [java.io.Serializable] so that Gradle's configuration cache can serialize
+ * instances of it (Gradle falls back to Java serialization for custom types held in
+ * [BuildServiceParameters][org.gradle.api.services.BuildServiceParameters] properties).
+ *
+ * @see EnvironmentVariable
+ * @see SystemProperty
+ */
+sealed class CredentialReference : java.io.Serializable {
+    /**
+     * Resolves the credential from an environment variable at build execution time.
+     *
+     * Only the variable [name] is serialized to the configuration cache — the value is looked up via
+     * [System.getenv] when the build service initializes its client, keeping the secret out of the cache.
+     *
+     * @param name The name of the environment variable (e.g. `"AWS_SECRET_ACCESS_KEY"`).
+     */
+    data class EnvironmentVariable(val name: String) : CredentialReference()
+
+    /**
+     * Resolves the credential from a JVM system property at build execution time.
+     *
+     * Only the property [name] is serialized to the configuration cache — the value is looked up via
+     * [System.getProperty] when the build service initializes its client, keeping the secret out of the cache.
+     *
+     * @param name The name of the JVM system property (e.g. `"aws.secretAccessKey"`).
+     *
+     * ## Using `gradle.properties` as a source
+     *
+     * Gradle project properties (set in `gradle.properties` or via `-P`) are not accessible from a
+     * [build service][org.gradle.api.services.BuildService] at execution time. However, any entry in
+     * `gradle.properties` prefixed with `systemProp.` is forwarded by Gradle into the JVM system
+     * properties, making it resolvable via [System.getProperty]:
+     *
+     * ```properties
+     * # ~/.gradle/gradle.properties
+     * systemProp.bitbucket.token=mytoken123
+     * ```
+     *
+     * ```kotlin
+     * parameters.tokenRef.set(CredentialReference.SystemProperty("bitbucket.token"))
+     * ```
+     *
+     * This gives callers a `gradle.properties`-backed credential source that stays completely out of
+     * the configuration cache. Contrast with `from(Provider<PasswordCredentials>)` (where available),
+     * which resolves credentials during configuration and stores the resolved values in the cache —
+     * appropriate for local development on a single machine, but not for shared CI/CD environments.
+     */
+    data class SystemProperty(val name: String) : CredentialReference()
+
+    /**
+     * Stores a credential value directly as a plain string.
+     *
+     * **WARNING — configuration cache unsafe**: This value is serialized to the Gradle configuration
+     * cache in plaintext. Any process with read access to `.gradle/configuration-cache/` can extract it.
+     * Prefer [EnvironmentVariable] or [SystemProperty] for all production and CI/CD use.
+     *
+     * This variant exists to support the `from(Provider<PasswordCredentials>)` family of extension
+     * functions, which must resolve Gradle credential objects during the configuration phase because
+     * [org.gradle.api.credentials.PasswordCredentials] is a configuration-time construct designed for
+     * repository authentication — not for supplying credentials to services that run at task execution
+     * time. Those `from()` functions are deprecated for exactly this reason; prefer
+     * [EnvironmentVariable] or [SystemProperty] directly. For `gradle.properties`-backed credentials,
+     * see [SystemProperty] and the `systemProp.` convention documented there.
+     */
+    data class Literal(val value: String) : CredentialReference()
+
+    /**
+     * Resolves this reference to the actual credential value.
+     *
+     * @throws IllegalStateException if the referenced environment variable or system property is not set.
+     */
+    fun resolve(): String = resolveOrNull()
+        ?: error("Credential not set: $this")
+
+    /**
+     * Resolves this reference to the actual credential value, or `null` if the referenced environment
+     * variable or system property is not set.
+     */
+    fun resolveOrNull(): String? = when (this) {
+        is EnvironmentVariable -> System.getenv(name)
+        is SystemProperty -> System.getProperty(name)
+        is Literal -> value
+    }
+}

--- a/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/AbstractGcpClientBuildService.kt
+++ b/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/AbstractGcpClientBuildService.kt
@@ -57,8 +57,8 @@ abstract class AbstractGcpClientBuildService<C : Any, P : GcpBuildServiceParams>
      * | `NONE` | [NoCredentials.getInstance] |
      * | `APPLICATION_DEFAULT` | [GoogleCredentials.getApplicationDefault] |
      * | `SERVICE_ACCOUNT_JSON_FILE` | [ServiceAccountCredentials.fromStream] over the credentials file |
-     * | `SERVICE_ACCOUNT_JSON_INLINE` | [ServiceAccountCredentials.fromStream] over the credentials JSON |
-     * | `ACCESS_TOKEN` | [GoogleCredentials.create] over an [AccessToken] |
+     * | `SERVICE_ACCOUNT_JSON_ENV` | [ServiceAccountCredentials.fromStream] over JSON resolved from [GcpBuildServiceParams.credentialsJsonRef] |
+     * | `ACCESS_TOKEN` | [GoogleCredentials.create] over an [AccessToken] resolved from [GcpBuildServiceParams.accessTokenRef] |
      * | unset | `null` |
      */
     protected fun resolveCredentials(): Credentials? = when (parameters.credentialSource.orNull) {
@@ -66,10 +66,10 @@ abstract class AbstractGcpClientBuildService<C : Any, P : GcpBuildServiceParams>
         GcpCredentialSource.APPLICATION_DEFAULT -> GoogleCredentials.getApplicationDefault()
         GcpCredentialSource.SERVICE_ACCOUNT_JSON_FILE ->
             parameters.credentialsFile.get().asFile.inputStream().use(ServiceAccountCredentials::fromStream)
-        GcpCredentialSource.SERVICE_ACCOUNT_JSON_INLINE ->
-            parameters.credentialsJson.get().byteInputStream().use(ServiceAccountCredentials::fromStream)
+        GcpCredentialSource.SERVICE_ACCOUNT_JSON_ENV ->
+            parameters.credentialsJsonRef.get().resolve().byteInputStream().use(ServiceAccountCredentials::fromStream)
         GcpCredentialSource.ACCESS_TOKEN ->
-            GoogleCredentials.create(AccessToken(parameters.accessToken.get(), null))
+            GoogleCredentials.create(AccessToken(parameters.accessTokenRef.get().resolve(), null))
         null -> null
     }
 

--- a/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/GcpBuildServiceParams.kt
+++ b/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/GcpBuildServiceParams.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.google.cloud
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.services.BuildServiceParameters
@@ -11,6 +12,10 @@ import org.gradle.api.services.BuildServiceParameters
  * use the extension functions on this interface ([noCredentials], [applicationDefault],
  * [serviceAccount], [accessToken]) which atomically set [credentialSource] and its supporting
  * fields together.
+ *
+ * Credential fields ([credentialsJsonRef], [accessTokenRef]) use [CredentialReference] rather than
+ * plain strings to ensure that only lookup metadata — not secret values — is serialized to the
+ * Gradle configuration cache.
  */
 interface GcpBuildServiceParams : BuildServiceParameters {
     /**
@@ -38,18 +43,20 @@ interface GcpBuildServiceParams : BuildServiceParameters {
     val credentialsFile: RegularFileProperty
 
     /**
-     * Inline Google service account JSON key payload. Used when [credentialSource] is
-     * [GcpCredentialSource.SERVICE_ACCOUNT_JSON_INLINE].
+     * Reference to where the Google service account JSON key payload can be found. Used when
+     * [credentialSource] is [GcpCredentialSource.SERVICE_ACCOUNT_JSON_ENV].
      *
-     * Set via [serviceAccount].
+     * Stores a [CredentialReference] pointing to an environment variable or system property whose
+     * value is the full service account JSON string. Set via [serviceAccount].
      */
-    val credentialsJson: Property<String>
+    val credentialsJsonRef: Property<CredentialReference>
 
     /**
-     * Static OAuth2 access token string. Used when [credentialSource] is
-     * [GcpCredentialSource.ACCESS_TOKEN].
+     * Reference to where the static OAuth2 access token can be found. Used when [credentialSource]
+     * is [GcpCredentialSource.ACCESS_TOKEN].
      *
-     * Set via [accessToken].
+     * Stores a [CredentialReference] pointing to an environment variable or system property whose
+     * value is the token string. Set via [accessToken].
      */
-    val accessToken: Property<String>
+    val accessTokenRef: Property<CredentialReference>
 }

--- a/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/GcpBuildServiceParamsExtensions.kt
+++ b/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/GcpBuildServiceParamsExtensions.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.google.cloud
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
 
@@ -33,29 +34,31 @@ fun GcpBuildServiceParams.serviceAccount(file: Provider<RegularFile>) {
 
 /**
  * Configures these parameters to load
- * [ServiceAccountCredentials][com.google.auth.oauth2.ServiceAccountCredentials] from the supplied
- * inline JSON key payload.
+ * [ServiceAccountCredentials][com.google.auth.oauth2.ServiceAccountCredentials] from a service
+ * account JSON key payload referenced by [json].
+ *
+ * The [json] reference points to an environment variable or system property whose value is the full
+ * service account JSON string. By default, the `GOOGLE_APPLICATION_CREDENTIALS_JSON` environment
+ * variable is used — a common convention in CI/CD systems where the key is stored as a secret.
  */
 @JvmName("serviceAccountFromJson")
-fun GcpBuildServiceParams.serviceAccount(json: Provider<String>) {
-    credentialSource.set(GcpCredentialSource.SERVICE_ACCOUNT_JSON_INLINE)
-    credentialsJson.set(json)
+fun GcpBuildServiceParams.serviceAccount(
+    json: CredentialReference = CredentialReference.EnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS_JSON"),
+) {
+    credentialSource.set(GcpCredentialSource.SERVICE_ACCOUNT_JSON_ENV)
+    credentialsJsonRef.set(json)
 }
 
 /**
- * Configures these parameters to use a static OAuth2 access token, wrapped in
- * [GoogleCredentials.create][com.google.auth.oauth2.GoogleCredentials.create].
+ * Configures these parameters to use a static OAuth2 access token referenced by [token], wrapped
+ * in [GoogleCredentials.create][com.google.auth.oauth2.GoogleCredentials.create].
+ *
+ * The [token] reference points to an environment variable or system property whose value is the
+ * token string. By default, the `GOOGLE_OAUTH2_TOKEN` environment variable is used.
  */
-fun GcpBuildServiceParams.accessToken(token: Provider<String>) {
+fun GcpBuildServiceParams.accessToken(
+    token: CredentialReference = CredentialReference.EnvironmentVariable("GOOGLE_OAUTH2_TOKEN"),
+) {
     credentialSource.set(GcpCredentialSource.ACCESS_TOKEN)
-    accessToken.set(token)
-}
-
-/**
- * Configures these parameters to use a static OAuth2 access token, wrapped in
- * [GoogleCredentials.create][com.google.auth.oauth2.GoogleCredentials.create].
- */
-fun GcpBuildServiceParams.accessToken(token: String) {
-    credentialSource.set(GcpCredentialSource.ACCESS_TOKEN)
-    accessToken.set(token)
+    accessTokenRef.set(token)
 }

--- a/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/GcpCredentialSource.kt
+++ b/cores/google-cloud-extensions/src/main/kotlin/com/kelvsyc/gradle/google/cloud/GcpCredentialSource.kt
@@ -28,14 +28,16 @@ enum class GcpCredentialSource {
     SERVICE_ACCOUNT_JSON_FILE,
 
     /**
-     * Load a [com.google.auth.oauth2.ServiceAccountCredentials] from the JSON key payload in
-     * [GcpBuildServiceParams.credentialsJson].
+     * Load a [com.google.auth.oauth2.ServiceAccountCredentials] from the JSON key payload referenced by
+     * [GcpBuildServiceParams.credentialsJsonRef]. The reference points to an environment variable or system
+     * property whose value is the full service account JSON string.
      */
-    SERVICE_ACCOUNT_JSON_INLINE,
+    SERVICE_ACCOUNT_JSON_ENV,
 
     /**
-     * Build a [com.google.auth.oauth2.GoogleCredentials] from a static OAuth2 access token at
-     * [GcpBuildServiceParams.accessToken].
+     * Build a [com.google.auth.oauth2.GoogleCredentials] from a static OAuth2 access token referenced by
+     * [GcpBuildServiceParams.accessTokenRef]. The reference points to an environment variable or system
+     * property whose value is the token string.
      */
     ACCESS_TOKEN,
 }

--- a/cores/google-cloud-secret-manager-base/README.md
+++ b/cores/google-cloud-secret-manager-base/README.md
@@ -36,7 +36,9 @@ back to the SDK's default application-default-credential resolution.
 The GCP project ID is not part of the build service — each value source and action takes its own `projectId`
 parameter, so a single client can serve calls against multiple projects.
 
-## Value Source: `SecretManagerValueSource`
+## Value Source: **Deprecated.** `SecretManagerValueSource`
+
+**Note on configuration cache safety:** Gradle serializes the result of every `ValueSource.obtain()` call to the configuration cache in plaintext. Any credential or secret value returned by a `ValueSource` will be stored in `.gradle/configuration-cache/` and is readable by any process with access to the build directory. The `ValueSource` implementations in this component that retrieve credentials or secrets are deprecated for this reason. Retrieve sensitive values inside a `WorkAction` at task execution time instead — the value is resolved after the cache has been read and is never written to it.
 
 Retrieves a secret version payload as a UTF-8 string.
 

--- a/cores/google-cloud-secret-manager-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/secretmanager/SecretManagerValueSource.kt
+++ b/cores/google-cloud-secret-manager-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/secretmanager/SecretManagerValueSource.kt
@@ -11,10 +11,24 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
+ * **Deprecated — configuration cache unsafe.** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext. A secret value returned
+ * here will be stored in `.gradle/configuration-cache/` and is readable by any process with
+ * access to the build directory. Retrieve secrets inside a
+ * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
+ * written to the cache.
+ *
  * [ValueSource] implementation backed by retrieving a secret version from Google Cloud Secret Manager.
  *
  * The secret payload is returned as a UTF-8 string.
  */
+@Deprecated(
+    message = "ValueSource results are serialized to the Gradle configuration cache; the secret value " +
+        "returned by obtain() is stored in plaintext in .gradle/configuration-cache/. " +
+        "Retrieve secrets inside a WorkAction at task execution time instead, " +
+        "where the value is never written to the cache.",
+    level = DeprecationLevel.WARNING
+)
 abstract class SecretManagerValueSource : ValueSource<String, SecretManagerValueSource.Parameters> {
     companion object {
         val logger by GradleLoggerDelegate

--- a/cores/google-cloud-secret-manager-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/secretmanager/SecretManagerValueSource.kt
+++ b/cores/google-cloud-secret-manager-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/secretmanager/SecretManagerValueSource.kt
@@ -18,6 +18,15 @@ import org.gradle.api.tasks.Internal
  * [org.gradle.workers.WorkAction] at task execution time instead, where the value is never
  * written to the cache.
  *
+ * **Task-field storage is also unsafe.** Gradle's config-cache codec walks the entire task
+ * object graph — including `@get:Internal` properties and private `val` fields — and resolves
+ * all `Provider` values at cache-write time. Wiring a `Provider` backed by this `ValueSource`
+ * into any task field (annotated or not) causes `obtain()` to run at configuration time and the
+ * secret to be stored on disk. The only safe location is entirely within a `@TaskAction` or
+ * `WorkAction.execute()` body. Using this `ValueSource` only inside task execution code is safe
+ * but counterproductive — the abstraction adds no value there; call the build service client
+ * directly instead.
+ *
  * [ValueSource] implementation backed by retrieving a secret version from Google Cloud Secret Manager.
  *
  * The secret payload is returned as a UTF-8 string.

--- a/cores/google-cloud-secret-manager-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/secretmanager/SecretManagerValueSourceSpec.kt
+++ b/cores/google-cloud-secret-manager-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/secretmanager/SecretManagerValueSourceSpec.kt
@@ -31,6 +31,7 @@ class SecretManagerValueSourceSpec : FunSpec() {
             every { payload.data } returns ByteString.copyFromUtf8("super-secret")
             every { client.accessSecretVersion(capture(slot)) } returns response
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.projectId.set("my-project")
@@ -56,6 +57,7 @@ class SecretManagerValueSourceSpec : FunSpec() {
             every { payload.data } returns ByteString.copyFromUtf8("secret-value")
             every { client.accessSecretVersion(capture(slot)) } returns response
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.projectId.set("my-project")
@@ -74,6 +76,7 @@ class SecretManagerValueSourceSpec : FunSpec() {
 
             every { client.accessSecretVersion(any<AccessSecretVersionRequest>()) } throws mockk<ApiException>(relaxed = true)
 
+            @Suppress("DEPRECATION")
             val provider = project.providers.ofKt(SecretManagerValueSource::class) {
                 parameters.service.set(service)
                 parameters.projectId.set("my-project")

--- a/cores/google-cloud-storage-base/src/integrationTest/kotlin/com/kelvsyc/gradle/google/cloud/storage/BuildServiceConfigurationCacheSpec.kt
+++ b/cores/google-cloud-storage-base/src/integrationTest/kotlin/com/kelvsyc/gradle/google/cloud/storage/BuildServiceConfigurationCacheSpec.kt
@@ -13,7 +13,7 @@ import java.io.File
  *
  * Each test pins down the **observed** behavior of the parameter shape — `projectId: Property<String>`,
  * `credentialSource: Property<GcpCredentialSource>`, `credentialsFile: RegularFileProperty`,
- * `credentialsJson: Property<String>`, `accessToken: Property<String>`. A failing test means either
+ * `credentialsJsonRef: Property<CredentialReference>`, `accessTokenRef: Property<CredentialReference>`. A failing test means either
  * Gradle's config-cache serializer or the Google Cloud extensions have regressed; investigate before
  * "fixing" the test.
  *
@@ -24,7 +24,8 @@ import java.io.File
  * and `ServiceAccountCredentials.fromStream(...)` carry non-`Serializable` state. So
  * `GcpBuildServiceParams` exposes only serializable primitives and the SDK credential is reconstructed
  * inside `createClient()` via `resolveCredentials()` / `resolveCredentialsProvider()`. These tests
- * exercise every branch of [com.kelvsyc.gradle.google.cloud.GcpCredentialSource] across the
+ * exercise every branch of [com.kelvsyc.gradle.google.cloud.GcpCredentialSource] (note:
+ * `SERVICE_ACCOUNT_JSON_INLINE` was renamed to `SERVICE_ACCOUNT_JSON_ENV`) across the
  * configuration-cache boundary and a second invocation that should reuse the stored entry.
  */
 class BuildServiceConfigurationCacheSpec : FunSpec({
@@ -58,7 +59,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             name = "access-token",
             parametersBlock = """
                 credentialSource.set(GcpCredentialSource.ACCESS_TOKEN)
-                accessToken.set("fake-token")
+                accessTokenRef.set(CredentialReference.EnvironmentVariable("GOOGLE_OAUTH2_TOKEN"))
             """.trimIndent()
         )
     }
@@ -67,8 +68,8 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
         assertParamsRoundTripCleanly(
             name = "service-account-inline",
             parametersBlock = """
-                credentialSource.set(GcpCredentialSource.SERVICE_ACCOUNT_JSON_INLINE)
-                credentialsJson.set("{}")
+                credentialSource.set(GcpCredentialSource.SERVICE_ACCOUNT_JSON_ENV)
+                credentialsJsonRef.set(CredentialReference.EnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS_JSON"))
             """.trimIndent()
         )
     }
@@ -89,7 +90,7 @@ class BuildServiceConfigurationCacheSpec : FunSpec({
             parametersBlock = """
                 projectId.set("test-project")
                 credentialSource.set(GcpCredentialSource.ACCESS_TOKEN)
-                accessToken.set("fake-token")
+                accessTokenRef.set(CredentialReference.EnvironmentVariable("GOOGLE_OAUTH2_TOKEN"))
             """.trimIndent()
         )
     }
@@ -122,6 +123,7 @@ private fun writeConfigCacheProbeProject(name: String, parametersBlock: String):
         import com.kelvsyc.gradle.google.cloud.GcpCredentialSource
         import com.kelvsyc.gradle.google.cloud.storage.StorageClientBuildService
         import com.kelvsyc.gradle.google.cloud.storage.fixtures.StorageBuildServiceProbeTask
+        import com.kelvsyc.gradle.clients.CredentialReference
 
         val storageService = gradle.sharedServices.registerIfAbsent(
             "storage",

--- a/cores/gradle-extensions/README.md
+++ b/cores/gradle-extensions/README.md
@@ -229,8 +229,12 @@ configuration cache when the cache is written, and reuses that result on subsequ
 
 - **Plaintext storage:** The serialized result is stored in plaintext in `.gradle/configuration-cache/`. If
   `obtain()` returns sensitive values (passwords, tokens, secrets), those values are readable by any process with
-  access to the build directory. Retrieve sensitive values inside a `WorkAction` at task execution time instead —
-  the value is resolved after the cache has been read and is never written to it.
+  access to the build directory. Retrieve sensitive values at task execution time instead — either inside a
+  `@TaskAction` body or inside a `WorkAction.execute()` body — by calling `ProviderFactory` (or our extensions)
+  directly there. Values obtained this way are resolved after the cache has been read and are never written to it.
+  The unsafe pattern is wiring a `Provider` into a task `@Input` property, which forces resolution at cache-write
+  time; calling `providers.of(...)` or `providers.environmentVariable(...)` entirely within task or work action
+  code is safe.
 
 ### `AbstractResourceValueSource`
 

--- a/cores/gradle-extensions/README.md
+++ b/cores/gradle-extensions/README.md
@@ -232,9 +232,12 @@ configuration cache when the cache is written, and reuses that result on subsequ
   access to the build directory. Retrieve sensitive values at task execution time instead — either inside a
   `@TaskAction` body or inside a `WorkAction.execute()` body — by calling `ProviderFactory` (or our extensions)
   directly there. Values obtained this way are resolved after the cache has been read and are never written to it.
-  The unsafe pattern is wiring a `Provider` into a task `@Input` property, which forces resolution at cache-write
-  time; calling `providers.of(...)` or `providers.environmentVariable(...)` entirely within task or work action
-  code is safe.
+  The unsafe pattern is storing a `Provider` backed by a `ValueSource` in any task field — whether `@Input`,
+  `@get:Internal`, or a private `val` — because Gradle's config-cache codec walks the entire task object graph
+  and resolves all `Provider` values at cache-write time regardless of annotation. The only safe location is
+  creating and resolving the `Provider` entirely within a `@TaskAction` or `WorkAction.execute()` body;
+  `providers.of(...)` or `providers.environmentVariable(...)` called there runs after the cache has been read
+  and the value is never serialized.
 
 ### `AbstractResourceValueSource`
 

--- a/cores/gradle-extensions/README.md
+++ b/cores/gradle-extensions/README.md
@@ -189,6 +189,17 @@ system properties (`teamcity.build.id`, `teamcity.buildType.id`, `teamcity.build
 build properties file whose path is given by the `TEAMCITY_BUILD_PROPERTIES_FILE` environment variable, using
 `PropertiesFromFileValueSource`.
 
+**Configuration cache and sensitive parameters:** TeamCity writes "Password" type build parameters to the system
+properties file and the configuration parameters file in plaintext — the masking in the TeamCity UI and build logs
+is display-only. Any `system.*` parameter of "Password" type will appear in the build properties file read by this
+class, and the configuration parameters file (path exposed via `configurationPropertiesFilePath`) may also contain
+password-type parameters.
+
+The properties exposed by `TeamCityProviders` are limited to well-known, non-sensitive system properties. However,
+if you access additional properties from the same files — for example to read a custom `system.myPassword` parameter
+— those values will be serialized to the Gradle configuration cache in plaintext. Read sensitive TeamCity
+parameters inside a `WorkAction` at task execution time instead.
+
 ## Logging Extensions (`GradleLoggerExtensions`)
 
 Lambda-form logging methods that avoid string construction when the log level is disabled:
@@ -204,6 +215,22 @@ All methods accept either `message: () -> String` or `(Throwable, () -> String)`
 `quiet`, `warn`, `error`.
 
 ## Value Sources
+
+**Configuration cache behaviour:** Gradle serializes the result of every `ValueSource.obtain()` call to the
+configuration cache when the cache is written, and reuses that result on subsequent builds without re-running
+`obtain()`. Two implications follow:
+
+- **Staleness:** The cached result reflects the state at the time the cache was written. External state — file
+  contents, API responses, environment variables — is not re-read on cache hits. For file-backed sources, Gradle
+  uses the input file as a cache key and invalidates the cache when the file changes. For sources that call
+  external services or read values that change independently of the inputs declared in `Parameters`, the cached
+  result may be stale until the cache is explicitly invalidated (e.g. `--rerun-tasks` or deleting
+  `.gradle/configuration-cache/`).
+
+- **Plaintext storage:** The serialized result is stored in plaintext in `.gradle/configuration-cache/`. If
+  `obtain()` returns sensitive values (passwords, tokens, secrets), those values are readable by any process with
+  access to the build directory. Retrieve sensitive values inside a `WorkAction` at task execution time instead —
+  the value is resolved after the cache has been read and is never written to it.
 
 ### `AbstractResourceValueSource`
 
@@ -249,6 +276,12 @@ val defaults: Provider<Properties> = providers.of(PropertiesResourceValueSource:
 
 Reads a `.properties` file into a `Provider<Properties>`. Returns absent (rather than throwing) on missing or
 malformed files. Use via `ProviderFactory.propertiesFile()`.
+
+**Configuration cache:** The entire `Properties` result is serialized to the Gradle configuration cache in
+plaintext when the cache is written. If the file contains sensitive values (passwords, tokens, API keys), those
+values will be stored in `.gradle/configuration-cache/`. Only use this source with files whose complete contents
+can be safely cached. When sensitive values are required at task execution time, read the file inside a
+`WorkAction` instead.
 
 ### `ChecksumValueSource`
 

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/PropertiesFromFileValueSource.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/PropertiesFromFileValueSource.kt
@@ -9,6 +9,13 @@ import java.util.*
 /**
  * Gradle [ValueSource] that provides a [Properties] object from reading a properties file.
  *
+ * **Configuration cache:** The entire [Properties] result returned by [obtain] is serialized to the Gradle
+ * configuration cache in plaintext when the cache is written. If the file contains sensitive values — passwords,
+ * tokens, API keys — those values will be stored in `.gradle/configuration-cache/` and are readable by any
+ * process with access to the build directory. Only use this source with files whose complete contents can be
+ * safely cached. When sensitive values must be available at task execution time, read the file inside a
+ * [org.gradle.workers.WorkAction] instead.
+ *
  * If the input file is not found, or there is an error reading the properties file, no value will be provided.
  */
 abstract class PropertiesFromFileValueSource : ValueSource<Properties, PropertiesFromFileValueSource.Parameters> {

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/TeamCityProviders.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/TeamCityProviders.kt
@@ -13,6 +13,15 @@ import javax.inject.Inject
  * - **System properties** written to a properties file whose path is given by the `TEAMCITY_BUILD_PROPERTIES_FILE`
  *   environment variable. These are read via [PropertiesFromFileValueSource].
  *
+ * **Configuration cache and sensitive parameters:** TeamCity writes "Password" type build parameters to the
+ * system properties file in plaintext — the masking applied in the TeamCity UI and build logs is display-only and
+ * does not prevent the value from appearing in the file. Any `system.*` parameter defined as "Password" type in the
+ * build configuration will therefore be present in the file read by this class. The properties exposed here are
+ * limited to well-known, non-sensitive system properties (build IDs, paths, branch names). However, callers who
+ * access additional properties from the same file — or who use [configurationPropertiesFilePath] to read the
+ * configuration parameters file — risk caching password-type parameter values in the Gradle configuration cache
+ * in plaintext. Read sensitive properties inside a [org.gradle.workers.WorkAction] at task execution time instead.
+ *
  * See [TeamCity Build Script Interaction](https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html).
  */
 abstract class TeamCityProviders @Inject constructor(layout: ProjectLayout, providers: ProviderFactory) {
@@ -171,6 +180,11 @@ abstract class TeamCityProviders @Inject constructor(layout: ProjectLayout, prov
      * Provides the path to the configuration parameters file. This file contains TeamCity configuration parameters
      * (those without a `system.` or `env.` prefix). Sourced from the `teamcity.configuration.properties.file`
      * system property.
+     *
+     * **Warning:** TeamCity configuration parameters of "Password" type are written to this file in plaintext.
+     * Reading this file via [PropertiesFromFileValueSource] or [ProviderFactory.propertiesFile][org.gradle.api.provider.ProviderFactory]
+     * will serialize those values to the Gradle configuration cache. Use this path only to read non-sensitive
+     * configuration parameters, or read the file inside a [org.gradle.workers.WorkAction] at task execution time.
      */
     val configurationPropertiesFilePath = buildProperties.getting("teamcity.configuration.properties.file")
 


### PR DESCRIPTION
## Summary

- Introduces `CredentialReference`, a sealed class in `clients-base` that stores only the *lookup key* (env var name or system property name) for a credential — never the value. Only non-sensitive metadata is serialized when the Gradle configuration cache is written; `resolve()` is called inside `createClient()` at task execution time.
- Renames credential-value `Property<String>` fields to `Property<CredentialReference>` (suffix `Ref`) across all build service params: AWS Java/Kotlin extensions, GCP extensions, Azure extensions, Artifactory, Bitbucket Cloud, Bitbucket Data Center. Adds companion extension files providing `basicAuth()`, `bearerToken()`, `clientSecret()`, `sasToken()`, `sharedKey()` sugar.
- **SEC-001**: Deprecates all `ValueSource` implementations that retrieve credentials or secret values. `obtain()` results are serialized to `.gradle/configuration-cache/` in plaintext; callers should use `WorkAction`s at task execution time instead. READMEs updated with security guidance and corrected build service registration examples.

## Deprecations (non-breaking — `@Deprecated(level = WARNING)`)

| Class | Reason |
|---|---|
| `from(Provider<PasswordCredentials>)` extensions | `PasswordCredentials` is a configuration-phase construct; resolving it writes live credentials to the config cache |
| `GradleCredentialsProviders` | Wrong abstraction: designed for repository auth, not SDK clients |
| `GradleSessionCredentialsProvider` | Same |
| `SecretsManagerValueSource` (Java + Kotlin) | `obtain()` result stored in config cache in plaintext |
| `SecretFromCacheValueSource` | Same |
| `SecretBatchValueSource` (Java + Kotlin) | Same |
| `KeyVaultSecretValueSource` | Same |
| `SecretManagerValueSource` | Same |
| `GetAuthorizationTokenValueSource` (CodeArtifact, ECR Java, ECR Kotlin) | Token stored in config cache; still needed for some repository auth use cases |
| `AccessTokenValueSource` | OAuth2 token stored in config cache |

## Test plan

- [x] `./gradlew :test` — BUILD SUCCESSFUL (341 tasks)
- [x] `./gradlew :clients-base:detekt :aws-java-extensions:detekt :aws-kotlin-extensions:detekt :artifactory-base:detekt :bitbucket-cloud-base:detekt :bitbucket-data-center-base:detekt :google-cloud-extensions:detekt :azure-extensions:detekt` — BUILD SUCCESSFUL
- [x] `./gradlew :aws-secrets-manager-java-base:detekt :aws-secrets-manager-kotlin-base:detekt :azure-key-vault-base:detekt :google-cloud-secret-manager-base:detekt :aws-codeartifact-java-base:detekt :aws-ecr-java-base:detekt :aws-ecr-kotlin-base:detekt :azure-managed-identity-base:detekt` — BUILD SUCCESSFUL
- [ ] Integration tests require live AWS/Azure/GCP credentials — not run locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)