### PR TITLE
docs: config-cache security warnings for ValueSources and Category B READMEs

### DIFF
--- a/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/AbstractArtifactValueSource.kt
+++ b/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/AbstractArtifactValueSource.kt
@@ -12,6 +12,18 @@ import java.io.InputStream
  *
  * Subclasses should implement the [doObtain] function, transforming an [InputStream] object to an object of the
  * desired type.
+ *
+ * **Configuration cache and sensitive artifacts:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the artifact may contain (credentials, private keys, tokens) — will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched artifact may contain sensitive data, call the [ArtifactoryClientBuildService] client directly
+ * inside a [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
+ * Non-sensitive artifacts (version manifests, metadata, changelogs) are safe to use at configuration time.
  */
 abstract class AbstractArtifactValueSource<T : Any, P : AbstractArtifactValueSource.Parameters> : ValueSource<T, P> {
     /**

--- a/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/AbstractStreamingRequestValueSource.kt
+++ b/cores/artifactory-base/src/main/kotlin/com/kelvsyc/gradle/artifactory/AbstractStreamingRequestValueSource.kt
@@ -13,6 +13,16 @@ import org.jfrog.artifactory.client.ArtifactoryStreamingResponse
  *
  * Subclasses should implement the [doObtain] function, transforming an [ArtifactoryStreamingResponse] object to an
  * object of the desired type.
+ *
+ * **Configuration cache and sensitive responses:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the API response may contain — will be stored in `.gradle/configuration-cache/` and is
+ * readable by any process with access to the build directory. This applies regardless of how the resulting
+ * [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input` property, a `@get:Internal`
+ * property, or a private `val` all cause `obtain()` to run at configuration time and the result to be cached.
+ *
+ * If the API response may contain sensitive data, call the [ArtifactoryClientBuildService] client directly inside
+ * a [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
  */
 abstract class AbstractStreamingRequestValueSource<T : Any, P : AbstractStreamingRequestValueSource.Parameters>
     : ValueSource<T, P> {

--- a/cores/aws-codeartifact-java-base/README.md
+++ b/cores/aws-codeartifact-java-base/README.md
@@ -118,6 +118,8 @@ abstract class MyAssetValueSource :
 
 Parameters: `service`, `domain`, `domainOwner`, `repository`, `namespace`, `packageValue`, `packageVersion`, `asset`.
 
+> **Security note:** Whatever `doObtain()` returns is serialized to `.gradle/configuration-cache/` in plaintext at cache-write time — this applies whether the resulting `Provider` is stored in a task `@Input`, a `@get:Internal` property, or a private `val`. If the asset contains sensitive data (private keys, credentials, tokens), use `GetGenericPackageVersionAssetAction` to download it to a file at task execution time, or call the `CodeArtifactClientBuildService` client directly inside a `WorkAction.execute()` body. Non-sensitive assets (version manifests, metadata) are safe to use at configuration time.
+
 ## WorkActions
 
 ### `GetGenericPackageVersionAssetAction`

--- a/cores/aws-codeartifact-java-base/README.md
+++ b/cores/aws-codeartifact-java-base/README.md
@@ -36,22 +36,36 @@ and leave `credentials` unset to fall back to anonymous credentials.
 
 ### **Deprecated.** `GetAuthorizationTokenValueSource`
 
-Retrieves a temporary authorization token for a CodeArtifact domain:
+Retrieves a temporary authorization token for a CodeArtifact domain.
 
-> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
+> **Deprecated — configuration cache unsafe.** Gradle serializes `ValueSource.obtain()` results to `.gradle/configuration-cache/` in plaintext at cache-write time. The token value is written to disk. See the class KDoc for full safety constraints, including the `@get:Internal` and private `val` caveats.
 
-```kotlin
-val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {
-    parameters {
-        service.set(codeartifact)
-        domain.set("my-domain")
-        domainOwner.set("123456789012")
-        duration.set(900L)
-    }
-}
-```
+**Repository authentication** is the common use case, but Gradle resolves `maven { credentials { } }` blocks at configuration time — any token obtained here will be stored in the cache regardless of how it was fetched. There is no deferred-credential mechanism. The pre-generation pattern avoids this ValueSource entirely:
 
-Returns `null` if the call throws `CodeartifactException`.
+1. Obtain the token before Gradle runs, in a CI startup step or pipeline script:
+   ```bash
+   export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token \
+     --domain my-domain \
+     --domain-owner 123456789012 \
+     --duration-seconds 3600 \
+     --query authorizationToken \
+     --output text)
+   ```
+
+2. Reference it via `providers.environmentVariable()` in the credentials block. Gradle stores the env var _name_ in the config cache and re-reads the value on every build — the token itself is never cached:
+   ```kotlin
+   maven {
+       url = uri("https://my-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/")
+       credentials {
+           username = "aws"
+           password = providers.environmentVariable("CODEARTIFACT_TOKEN").get()
+       }
+   }
+   ```
+
+CodeArtifact tokens are valid for up to 12 hours (configurable via `--duration-seconds`). The threat model of the pre-generation pattern is equivalent to the CI environment variable attack surface — no new exposure.
+
+**Task-execution use cases**: use the `CodeArtifactClientBuildService` client directly inside a `WorkAction.execute()` body instead. The `ValueSource` abstraction adds no value there. Returns `null` if the call throws `CodeartifactException`.
 
 ### `GetRepositoryEndpointValueSource`
 

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractGetGenericAssetValueSource.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractGetGenericAssetValueSource.kt
@@ -15,6 +15,23 @@ import software.amazon.awssdk.services.codeartifact.model.PackageFormat
  *
  * Subclasses should implement the [doObtain] function, transforming the supplied parameters to an object of the
  * desired type.
+ *
+ * **Configuration cache and sensitive assets:** Gradle serializes the result of every [ValueSource.obtain] call to
+ * the configuration cache in plaintext when the cache is written. If the asset retrieved by a subclass contains
+ * sensitive data — private keys, API tokens, credentials, or any secret material — that data will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the [org.gradle.api.provider.Provider] is stored: wiring the result into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched asset may contain sensitive data, either:
+ * - Use [GetGenericPackageVersionAssetAction] to download the asset to a file at task execution time, then read
+ *   the file within the task action; or
+ * - Call the [CodeArtifactClientBuildService] client directly inside a [org.gradle.workers.WorkAction.execute]
+ *   body, where the result is never written to the cache.
+ *
+ * If the fetched asset is non-sensitive (version manifests, changelogs, metadata), this `ValueSource` is safe to
+ * use at configuration time.
  */
 abstract class AbstractGetGenericAssetValueSource<T : Any, P : AbstractGetGenericAssetValueSource.Parameters> :
     ValueSource<T, P> {

--- a/cores/aws-codeartifact-kotlin-base/README.md
+++ b/cores/aws-codeartifact-kotlin-base/README.md
@@ -103,6 +103,8 @@ abstract class MyAssetValueSource
 }
 ```
 
+> **Security note:** Whatever `doObtain()` returns is serialized to `.gradle/configuration-cache/` in plaintext at cache-write time — this applies whether the resulting `Provider` is stored in a task `@Input`, a `@get:Internal` property, or a private `val`. If the asset contains sensitive data (private keys, credentials, tokens), use `GetGenericPackageVersionAssetAction` to download it to a file at task execution time, or call the `CodeArtifactClientBuildService` client directly inside a `WorkAction.execute()` body. Non-sensitive assets (version manifests, metadata) are safe to use at configuration time.
+
 ## Value Source: `ListPackageVersionsValueSource`
 
 Lists all version strings for a package in a CodeArtifact repository, paginating automatically:

--- a/cores/aws-codeartifact-kotlin-base/README.md
+++ b/cores/aws-codeartifact-kotlin-base/README.md
@@ -31,20 +31,38 @@ default region provider chain. Omit the credentials call to skip the `credential
 case the SDK applies its own default behavior. See [aws-kotlin-extensions](../aws-kotlin-extensions) for the full
 set of credential configuration functions.
 
-## Value Source: `GetAuthorizationTokenValueSource`
+## **Deprecated.** Value Source: `GetAuthorizationTokenValueSource`
 
-Retrieves an AWS CodeArtifact authorization token:
+Retrieves an AWS CodeArtifact authorization token.
 
-```kotlin
-val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {
-    parameters {
-        service.set(codeArtifact)
-        domain.set("my-domain")
-        domainOwner.set("111122223333")
-        duration.set(3600L)
-    }
-}
-```
+> **Deprecated — configuration cache unsafe.** Gradle serializes `ValueSource.obtain()` results to `.gradle/configuration-cache/` in plaintext at cache-write time. The token value is written to disk. See the class KDoc for full safety constraints, including the `@get:Internal` and private `val` caveats.
+
+**Repository authentication** is the common use case, but Gradle resolves `maven { credentials { } }` blocks at configuration time — any token obtained here will be stored in the cache regardless of how it was fetched. There is no deferred-credential mechanism. The pre-generation pattern avoids this ValueSource entirely:
+
+1. Obtain the token before Gradle runs, in a CI startup step or pipeline script:
+   ```bash
+   export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token \
+     --domain my-domain \
+     --domain-owner 111122223333 \
+     --duration-seconds 3600 \
+     --query authorizationToken \
+     --output text)
+   ```
+
+2. Reference it via `providers.environmentVariable()` in the credentials block. Gradle stores the env var _name_ in the config cache and re-reads the value on every build — the token itself is never cached:
+   ```kotlin
+   maven {
+       url = uri("https://my-domain-111122223333.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/")
+       credentials {
+           username = "aws"
+           password = providers.environmentVariable("CODEARTIFACT_TOKEN").get()
+       }
+   }
+   ```
+
+CodeArtifact tokens are valid for up to 12 hours (configurable via `--duration-seconds`). The threat model of the pre-generation pattern is equivalent to the CI environment variable attack surface — no new exposure.
+
+**Task-execution use cases**: use the `CodeArtifactClientBuildService` client directly inside a `WorkAction.execute()` body instead. The `ValueSource` abstraction adds no value there.
 
 Parameters:
 

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetGenericAssetValueSource.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetGenericAssetValueSource.kt
@@ -15,6 +15,23 @@ import org.gradle.api.tasks.Internal
  *
  * Subclasses should implement the [doObtain] function, transforming the supplied parameters to an object of the
  * desired type.
+ *
+ * **Configuration cache and sensitive assets:** Gradle serializes the result of every [ValueSource.obtain] call to
+ * the configuration cache in plaintext when the cache is written. If the asset retrieved by a subclass contains
+ * sensitive data — private keys, API tokens, credentials, or any secret material — that data will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the [org.gradle.api.provider.Provider] is stored: wiring the result into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched asset may contain sensitive data, either:
+ * - Use [GetGenericPackageVersionAssetAction] to download the asset to a file at task execution time, then read
+ *   the file within the task action; or
+ * - Call the [CodeArtifactClientBuildService] client directly inside a [org.gradle.workers.WorkAction.execute]
+ *   body, where the result is never written to the cache.
+ *
+ * If the fetched asset is non-sensitive (version manifests, changelogs, metadata), this `ValueSource` is safe to
+ * use at configuration time.
  */
 abstract class AbstractGetGenericAssetValueSource<T : Any, P : AbstractGetGenericAssetValueSource.Parameters> :
     ValueSource<T, P> {

--- a/cores/aws-ecr-java-base/README.md
+++ b/cores/aws-ecr-java-base/README.md
@@ -35,17 +35,33 @@ and leave `credentials` unset to fall back to anonymous credentials.
 
 ### **Deprecated.** `GetAuthorizationTokenValueSource`
 
-Returns the base64-encoded `user:password` ECR authorization token for the caller's default registry:
+Returns the base64-encoded `user:password` ECR authorization token for the caller's default registry.
 
-> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
+> **Deprecated — configuration cache unsafe.** Gradle serializes `ValueSource.obtain()` results to `.gradle/configuration-cache/` in plaintext at cache-write time. The token value is written to disk. See the class KDoc for full safety constraints, including the `@get:Internal` and private `val` caveats.
 
-```kotlin
-val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {
-    parameters {
-        service.set(ecr)
-    }
-}
-```
+**Repository authentication** is the common use case, but Gradle resolves `maven { credentials { } }` blocks at configuration time — any token obtained here will be stored in the cache regardless of how it was fetched. There is no deferred-credential mechanism. The pre-generation pattern avoids this ValueSource entirely:
+
+1. Obtain the token before Gradle runs, in a CI startup step or pipeline script:
+   ```bash
+   export ECR_TOKEN=$(aws ecr get-authorization-token \
+     --output text \
+     --query 'authorizationData[0].authorizationToken')
+   ```
+
+2. Reference it via `providers.environmentVariable()` in the credentials block. Gradle stores the env var _name_ in the config cache and re-reads the value on every build — the token itself is never cached:
+   ```kotlin
+   maven {
+       url = uri("https://<account>.dkr.ecr.<region>.amazonaws.com")
+       credentials {
+           username = "AWS"
+           password = providers.environmentVariable("ECR_TOKEN").get()
+       }
+   }
+   ```
+
+ECR tokens are valid for up to 12 hours. The threat model of the pre-generation pattern is equivalent to the CI environment variable attack surface — no new exposure.
+
+**Task-execution use cases** (e.g. running `docker login` as a build step): use the `EcrClientBuildService` client directly inside a `WorkAction.execute()` body instead. The `ValueSource` abstraction adds no value there.
 
 ### `DescribeRepositoriesValueSource`
 

--- a/cores/aws-ecr-kotlin-base/README.md
+++ b/cores/aws-ecr-kotlin-base/README.md
@@ -35,21 +35,34 @@ set of credential configuration functions.
 
 ### **Deprecated.** `GetAuthorizationTokenValueSource`
 
-Retrieves the base64-encoded `user:password` authorization token for the caller's default ECR registry, suitable
-for `docker login`:
+Returns the base64-encoded `user:password` authorization token for the caller's default ECR registry, suitable
+for `docker login`. The first entry of the response's `authorizationData` list is returned.
 
-> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
+> **Deprecated — configuration cache unsafe.** Gradle serializes `ValueSource.obtain()` results to `.gradle/configuration-cache/` in plaintext at cache-write time. The token value is written to disk. See the class KDoc for full safety constraints, including the `@get:Internal` and private `val` caveats.
 
-```kotlin
-val token: Provider<String> = providers.of(GetAuthorizationTokenValueSource::class) {
-    parameters {
-        service.set(ecr)
-    }
-}
-```
+**Repository authentication** is the common use case, but Gradle resolves `maven { credentials { } }` blocks at configuration time — any token obtained here will be stored in the cache regardless of how it was fetched. There is no deferred-credential mechanism. The pre-generation pattern avoids this ValueSource entirely:
 
-The first entry of the response's `authorizationData` list is returned. To target a non-default registry, use
-the SDK directly.
+1. Obtain the token before Gradle runs, in a CI startup step or pipeline script:
+   ```bash
+   export ECR_TOKEN=$(aws ecr get-authorization-token \
+     --output text \
+     --query 'authorizationData[0].authorizationToken')
+   ```
+
+2. Reference it via `providers.environmentVariable()` in the credentials block. Gradle stores the env var _name_ in the config cache and re-reads the value on every build — the token itself is never cached:
+   ```kotlin
+   maven {
+       url = uri("https://<account>.dkr.ecr.<region>.amazonaws.com")
+       credentials {
+           username = "AWS"
+           password = providers.environmentVariable("ECR_TOKEN").get()
+       }
+   }
+   ```
+
+ECR tokens are valid for up to 12 hours. The threat model of the pre-generation pattern is equivalent to the CI environment variable attack surface — no new exposure.
+
+**Task-execution use cases** (e.g. running `docker login` as a build step): use the `EcrClientBuildService` client directly inside a `WorkAction.execute()` body instead. To target a non-default registry, use the SDK directly.
 
 ### `DescribeRepositoriesValueSource`
 

--- a/cores/aws-imds-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/imds/AbstractImdsValueSource.kt
+++ b/cores/aws-imds-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/imds/AbstractImdsValueSource.kt
@@ -12,6 +12,17 @@ import software.amazon.awssdk.imds.Ec2MetadataResponse
  *
  * Subclasses should implement the [doObtain] function, transforming the [Ec2MetadataResponse] to an object of the
  * desired type.
+ *
+ * **Configuration cache and sensitive IMDS paths:** Gradle serializes the result of every [ValueSource.obtain]
+ * call to the configuration cache in plaintext when the cache is written. Most IMDS paths return non-sensitive
+ * instance metadata (AMI ID, instance type, availability zone). However, some paths return sensitive data — for
+ * example, `/latest/meta-data/iam/security-credentials/` returns temporary IAM credentials. Whatever [doObtain]
+ * returns will be stored in `.gradle/configuration-cache/` and is readable by any process with access to the
+ * build directory, regardless of whether the result is stored in a task `@Input`, `@get:Internal`, or private
+ * `val` — all cause `obtain()` to run at configuration time and the result to be cached.
+ *
+ * If the queried IMDS path may return sensitive data, call the [ImdsClientBuildService] client directly inside a
+ * [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
  */
 abstract class AbstractImdsValueSource<T : Any, P : AbstractImdsValueSource.Parameters> : ValueSource<T, P> {
     /**

--- a/cores/aws-imds-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/imds/AbstractInstanceIdentityValueSource.kt
+++ b/cores/aws-imds-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/imds/AbstractInstanceIdentityValueSource.kt
@@ -12,6 +12,14 @@ import software.amazon.awssdk.core.document.Document
  *
  * Subclasses should implement the [doObtain] function, transforming a [Document] object to an object of the desired
  * type.
+ *
+ * **Configuration cache:** Gradle serializes the result of every [ValueSource.obtain] call to the configuration
+ * cache in plaintext when the cache is written. The instance identity document contains non-sensitive instance
+ * metadata (account ID, region, instance ID, image ID) — this is typically safe to cache. However, whatever
+ * [doObtain] returns is what gets serialized, and a subclass could derive values that the caller considers
+ * sensitive. Storing the resulting [org.gradle.api.provider.Provider] in any task field — `@Input`,
+ * `@get:Internal`, or a private `val` — causes `obtain()` to run at configuration time and the return value to
+ * be serialized.
  */
 abstract class AbstractInstanceIdentityValueSource<T : Any, P : AbstractInstanceIdentityValueSource.Parameters> :
     ValueSource<T, P> {

--- a/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractImdsValueSource.kt
+++ b/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractImdsValueSource.kt
@@ -13,6 +13,17 @@ import org.gradle.api.tasks.Internal
  *
  * Subclasses should implement the [doObtain] function, transforming the raw IMDS response string to an object of the
  * desired type.
+ *
+ * **Configuration cache and sensitive IMDS paths:** Gradle serializes the result of every [ValueSource.obtain]
+ * call to the configuration cache in plaintext when the cache is written. Most IMDS paths return non-sensitive
+ * instance metadata (AMI ID, instance type, availability zone). However, some paths return sensitive data — for
+ * example, `/latest/meta-data/iam/security-credentials/` returns temporary IAM credentials. Whatever [doObtain]
+ * returns will be stored in `.gradle/configuration-cache/` and is readable by any process with access to the
+ * build directory, regardless of whether the result is stored in a task `@Input`, `@get:Internal`, or private
+ * `val` — all cause `obtain()` to run at configuration time and the result to be cached.
+ *
+ * If the queried IMDS path may return sensitive data, call the [ImdsClientBuildService] client directly inside a
+ * [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
  */
 abstract class AbstractImdsValueSource<T : Any, P : AbstractImdsValueSource.Parameters> : ValueSource<T, P> {
     /**

--- a/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractInstanceIdentityValueSource.kt
+++ b/cores/aws-imds-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/imds/AbstractInstanceIdentityValueSource.kt
@@ -12,6 +12,14 @@ import org.gradle.api.tasks.Internal
  * [IMDS Instance Identity Document](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html).
  *
  * Subclasses should implement the [doObtain] function, transforming a string to an object of the desired type.
+ *
+ * **Configuration cache:** Gradle serializes the result of every [ValueSource.obtain] call to the configuration
+ * cache in plaintext when the cache is written. The instance identity document contains non-sensitive instance
+ * metadata (account ID, region, instance ID, image ID) — this is typically safe to cache. However, whatever
+ * [doObtain] returns is what gets serialized, and a subclass could derive values that the caller considers
+ * sensitive. Storing the resulting [org.gradle.api.provider.Provider] in any task field — `@Input`,
+ * `@get:Internal`, or a private `val` — causes `obtain()` to run at configuration time and the return value to
+ * be serialized.
  */
 abstract class AbstractInstanceIdentityValueSource<T : Any, P : AbstractInstanceIdentityValueSource.Parameters> :
     ValueSource<T, P> {

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractListObjectsValueSource.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractListObjectsValueSource.kt
@@ -12,6 +12,13 @@ import software.amazon.awssdk.services.s3.model.S3Object
  *
  * Pagination is handled internally; subclasses receive the full list of [S3Object] summaries across all pages
  * via [doObtain] and transform it to the desired type.
+ *
+ * **Configuration cache:** Gradle serializes the result of every [ValueSource.obtain] call to the configuration
+ * cache in plaintext when the cache is written. The [S3Object] summaries passed to [doObtain] contain only object
+ * metadata (key, size, ETag, last-modified), not object content — this is typically non-sensitive. However,
+ * whatever [doObtain] returns is what gets cached, and a subclass could derive sensitive values from the listing.
+ * Storing the resulting [org.gradle.api.provider.Provider] in any task field — `@Input`, `@get:Internal`, or a
+ * private `val` — causes `obtain()` to run at configuration time and the return value to be serialized.
  */
 abstract class AbstractListObjectsValueSource<T : Any, P : AbstractListObjectsValueSource.Parameters>
     : ValueSource<T, P> {

--- a/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractS3ValueSource.kt
+++ b/cores/aws-s3-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/s3/AbstractS3ValueSource.kt
@@ -13,6 +13,18 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse
  *
  * Subclasses should implement the [doObtain] function, transforming a [ResponseBytes] object to an object of the
  * desired type. This class should only be used on S3 objects for which the entire object can be kept in memory.
+ *
+ * **Configuration cache and sensitive objects:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the S3 object may contain (credentials, private keys, tokens) — will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched object may contain sensitive data, call the [S3ClientBuildService] client directly inside a
+ * [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
+ * Non-sensitive objects (version manifests, metadata, changelogs) are safe to use at configuration time.
  */
 abstract class AbstractS3ValueSource<T : Any, P : AbstractS3ValueSource.Parameters> : ValueSource<T, P> {
     /**

--- a/cores/aws-s3-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/s3/AbstractListObjectsValueSource.kt
+++ b/cores/aws-s3-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/s3/AbstractListObjectsValueSource.kt
@@ -15,6 +15,13 @@ import org.gradle.api.tasks.Internal
  *
  * Pagination is handled internally via the SDK Kotlin paginated flow; subclasses receive the full list of
  * [S3Object] summaries across all pages via [doObtain] and transform it to the desired type.
+ *
+ * **Configuration cache:** Gradle serializes the result of every [ValueSource.obtain] call to the configuration
+ * cache in plaintext when the cache is written. The [S3Object] summaries passed to [doObtain] contain only object
+ * metadata (key, size, ETag, last-modified), not object content — this is typically non-sensitive. However,
+ * whatever [doObtain] returns is what gets cached, and a subclass could derive sensitive values from the listing.
+ * Storing the resulting [org.gradle.api.provider.Provider] in any task field — `@Input`, `@get:Internal`, or a
+ * private `val` — causes `obtain()` to run at configuration time and the return value to be serialized.
  */
 abstract class AbstractListObjectsValueSource<T : Any, P : AbstractListObjectsValueSource.Parameters>
     : ValueSource<T, P> {

--- a/cores/aws-s3-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/s3/AbstractS3ValueSource.kt
+++ b/cores/aws-s3-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/s3/AbstractS3ValueSource.kt
@@ -8,6 +8,24 @@ import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
+/**
+ * Base class for [ValueSource] implementations that provide a value by reading an S3 object.
+ *
+ * Subclasses should implement the [doObtain] function, transforming a [GetObjectResponse] to an object of the
+ * desired type. This class should only be used on S3 objects for which the entire object can be kept in memory.
+ *
+ * **Configuration cache and sensitive objects:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the S3 object may contain (credentials, private keys, tokens) — will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched object may contain sensitive data, call the [S3ClientBuildService] client directly inside a
+ * [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
+ * Non-sensitive objects (version manifests, metadata, changelogs) are safe to use at configuration time.
+ */
 abstract class AbstractS3ValueSource<T : Any, P : AbstractS3ValueSource.Parameters> : ValueSource<T, P> {
     interface Parameters : ValueSourceParameters {
         @get:Internal

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractBlobStorageValueSource.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractBlobStorageValueSource.kt
@@ -11,6 +11,18 @@ import org.gradle.api.tasks.Internal
  *
  * Subclasses should implement the [doObtain] function, transforming a [BinaryData] object to an object of the
  * desired type. This class should only be used on blobs for which the entire blob can be kept in memory.
+ *
+ * **Configuration cache and sensitive blobs:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the blob may contain (credentials, private keys, tokens) — will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched blob may contain sensitive data, call the [BlobServiceClientBuildService] client directly inside
+ * a [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
+ * Non-sensitive blobs (version manifests, metadata, changelogs) are safe to use at configuration time.
  */
 abstract class AbstractBlobStorageValueSource<T : Any, P : AbstractBlobStorageValueSource.Parameters> :
     ValueSource<T, P> {

--- a/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractListBlobsValueSource.kt
+++ b/cores/azure-blob-storage-base/src/main/kotlin/com/kelvsyc/gradle/azure/storage/blob/AbstractListBlobsValueSource.kt
@@ -13,6 +13,13 @@ import org.gradle.api.tasks.Internal
  *
  * Pagination is handled internally; subclasses receive the full list of [BlobItem] entries across all pages
  * via [doObtain] and transform it to the desired type.
+ *
+ * **Configuration cache:** Gradle serializes the result of every [ValueSource.obtain] call to the configuration
+ * cache in plaintext when the cache is written. The [BlobItem] entries passed to [doObtain] contain only blob
+ * metadata (name, size, content type, last-modified), not blob content — this is typically non-sensitive.
+ * However, whatever [doObtain] returns is what gets cached, and a subclass could derive sensitive values from the
+ * listing. Storing the resulting [org.gradle.api.provider.Provider] in any task field — `@Input`, `@get:Internal`,
+ * or a private `val` — causes `obtain()` to run at configuration time and the return value to be serialized.
  */
 abstract class AbstractListBlobsValueSource<T : Any, P : AbstractListBlobsValueSource.Parameters> :
     ValueSource<T, P> {

--- a/cores/azure-managed-identity-base/README.md
+++ b/cores/azure-managed-identity-base/README.md
@@ -47,16 +47,32 @@ val imds = gradle.sharedServices.registerIfAbsent("imds", AzureImdsClientBuildSe
 
 Retrieves a raw OAuth2 bearer token for the specified Azure scopes.
 
-> **Security note:** This Value Source is deprecated because its result (an authorization token) is cached by Gradle's configuration cache. See the class KDoc for details.
+> **Deprecated — configuration cache unsafe.** Gradle serializes `ValueSource.obtain()` results to `.gradle/configuration-cache/` in plaintext at cache-write time. The token value is written to disk. See the class KDoc for full safety constraints, including the `@get:Internal` and private `val` caveats.
 
-```kotlin
-val token: Provider<String> = providers.of(AccessTokenValueSource::class) {
-    parameters {
-        service.set(mi)
-        scopes.add("https://management.azure.com/.default")
-    }
-}
-```
+**Repository authentication** (e.g. Azure Artifacts / Azure DevOps package feeds) is the common configuration-time use case, but Gradle resolves `maven { credentials { } }` blocks at configuration time — any token obtained here will be stored in the cache regardless of how it was fetched. There is no deferred-credential mechanism. The pre-generation pattern avoids this ValueSource entirely:
+
+1. Obtain the token before Gradle runs, in a CI startup step or pipeline script. On an Azure VM or container with managed identity:
+   ```bash
+   export AZURE_TOKEN=$(az account get-access-token \
+     --resource https://pkgs.dev.azure.com \
+     --query accessToken \
+     --output tsv)
+   ```
+
+2. Reference it via `providers.environmentVariable()` in the credentials block. Gradle stores the env var _name_ in the config cache and re-reads the value on every build — the token itself is never cached:
+   ```kotlin
+   maven {
+       url = uri("https://pkgs.dev.azure.com/<org>/<project>/_packaging/<feed>/maven/v1")
+       credentials {
+           username = "AzureDevOps"
+           password = providers.environmentVariable("AZURE_TOKEN").get()
+       }
+   }
+   ```
+
+Azure AD tokens are typically valid for 1 hour. The threat model of the pre-generation pattern is equivalent to the CI environment variable attack surface — no new exposure.
+
+**Task-execution use cases**: use the `ManagedIdentityCredentialBuildService` client directly inside a `WorkAction.execute()` body instead. The `ValueSource` abstraction adds no value there.
 
 ### `AzureComputeMetadataValueSource`
 

--- a/cores/google-cloud-artifact-registry-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/artifact/AbstractArtifactValueSource.kt
+++ b/cores/google-cloud-artifact-registry-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/artifact/AbstractArtifactValueSource.kt
@@ -16,6 +16,18 @@ import java.io.PipedOutputStream
  * Base class for [ValueSource] implementations that provide a value by reading a file from Google Artifact Registry.
  *
  * Subclasses should implement the [doObtain] function, transforming an [InputStream] to an object of the desired type.
+ *
+ * **Configuration cache and sensitive files:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the file may contain (credentials, private keys, tokens) — will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched file may contain sensitive data, call the [ArtifactRegistryClientBuildService] client directly
+ * inside a [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
+ * Non-sensitive files (version manifests, metadata, changelogs) are safe to use at configuration time.
  */
 abstract class AbstractArtifactValueSource<T : Any, P : AbstractArtifactValueSource.Parameters> : ValueSource<T, P> {
     interface Parameters : ValueSourceParameters {

--- a/cores/google-cloud-storage-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/storage/AbstractGCSValueSource.kt
+++ b/cores/google-cloud-storage-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/storage/AbstractGCSValueSource.kt
@@ -10,6 +10,18 @@ import org.gradle.api.tasks.Internal
  *
  * Subclasses should implement the [doObtain] function, transforming a [ByteArray] to an object of the desired type.
  * This class should only be used on blobs for which the entire blob can be kept in memory.
+ *
+ * **Configuration cache and sensitive blobs:** Gradle serializes the result of every [ValueSource.obtain] call
+ * to the configuration cache in plaintext when the cache is written. Whatever [doObtain] returns — including any
+ * sensitive content the GCS blob may contain (credentials, private keys, tokens) — will be stored in
+ * `.gradle/configuration-cache/` and is readable by any process with access to the build directory. This applies
+ * regardless of how the resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input`
+ * property, a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time and
+ * the result to be cached.
+ *
+ * If the fetched blob may contain sensitive data, call the [StorageClientBuildService] client directly inside a
+ * [org.gradle.workers.WorkAction.execute] body instead, where the result is never written to the cache.
+ * Non-sensitive blobs (version manifests, metadata, changelogs) are safe to use at configuration time.
  */
 abstract class AbstractGCSValueSource<T : Any, P : AbstractGCSValueSource.Parameters> : ValueSource<T, P> {
     /**

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/AbstractResourceValueSource.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/AbstractResourceValueSource.kt
@@ -10,6 +10,12 @@ import java.io.InputStream
  *
  * Subclasses should implement the [doObtain] function, transforming an [InputStream] object to an object of the
  * desired type.
+ *
+ * **Configuration cache:** Gradle serializes the result of every [ValueSource.obtain] call to the configuration
+ * cache in plaintext when the cache is written. Resources bundled in a plugin JAR are developer-controlled and
+ * typically contain non-sensitive defaults (configuration schemas, version strings, embedded templates). However,
+ * whatever [doObtain] returns is what gets serialized, so ensure the resource does not contain sensitive data
+ * before using this as a configuration-time value source.
  */
 abstract class AbstractResourceValueSource<T : Any, P : AbstractResourceValueSource.Parameters> : ValueSource<T, P> {
     /**

--- a/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/AbstractArtifactorySearchValueSource.kt
+++ b/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/AbstractArtifactorySearchValueSource.kt
@@ -16,6 +16,17 @@ import javax.inject.Inject
  * Subclasses must implement [buildSearchArgs] to supply the search-specific CLI arguments (pattern, file spec path,
  * or AQL flags), and [doObtain] to transform the raw JSON string into the desired type.
  *
+ * **Configuration cache — access token:** If [Parameters.accessToken] is set, the token value is a
+ * `Property<String>` on `ValueSourceParameters` and will be serialized to `.gradle/configuration-cache/` in
+ * plaintext when the cache is written. Prefer leaving [Parameters.accessToken] unset and configuring credentials
+ * in the JFrog CLI itself (via `jf config add`), so that no token ever enters the configuration cache.
+ *
+ * **Configuration cache — search results:** Gradle serializes the result of every [ValueSource.obtain] call to
+ * the configuration cache in plaintext. Whatever [doObtain] returns will be stored in
+ * `.gradle/configuration-cache/`. Search results are typically artifact metadata (names, checksums, paths) and
+ * are not sensitive. However, storing the resulting [org.gradle.api.provider.Provider] in any task field —
+ * `@Input`, `@get:Internal`, or a private `val` — causes `obtain()` to run at configuration time.
+ *
  * @param T The type of value produced by this source.
  * @param P The parameters type, which must extend [Parameters].
  */

--- a/cores/moshi-extensions/src/main/kotlin/com/kelvsyc/gradle/moshi/JsonValueSource.kt
+++ b/cores/moshi-extensions/src/main/kotlin/com/kelvsyc/gradle/moshi/JsonValueSource.kt
@@ -11,6 +11,14 @@ import java.io.IOException
  * Gradle [ValueSource] that provides a [JsonValue] tree parsed from a JSON file.
  *
  * If the input file is not found or cannot be parsed, no value will be provided.
+ *
+ * **Configuration cache and sensitive files:** Gradle serializes the entire [JsonValue] result to the configuration
+ * cache in plaintext when the cache is written. If the JSON file contains sensitive values — API keys, tokens,
+ * passwords — those values will be stored in `.gradle/configuration-cache/`. This applies regardless of how the
+ * resulting [org.gradle.api.provider.Provider] is stored: a task `@Input`, `@get:Internal`, or private `val` all
+ * cause `obtain()` to run at configuration time and the parsed tree to be cached. For files containing sensitive
+ * data, read and use the file entirely within a `@TaskAction` or [org.gradle.workers.WorkAction.execute] body
+ * instead.
  */
 abstract class JsonValueSource : ValueSource<JsonValue, JsonValueSource.Parameters> {
     /**

--- a/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/YamlValueSource.kt
+++ b/cores/snakeyaml-extensions/src/main/kotlin/com/kelvsyc/gradle/snakeyaml/YamlValueSource.kt
@@ -12,6 +12,14 @@ import java.io.IOException
  * Gradle [ValueSource] that provides a [YamlValue] tree parsed from a YAML file.
  *
  * If the input file is not found, cannot be read, or cannot be parsed, no value will be provided.
+ *
+ * **Configuration cache and sensitive files:** Gradle serializes the entire [YamlValue] tree to the configuration
+ * cache in plaintext when the cache is written. If the YAML file contains sensitive values — passwords, tokens, API
+ * keys — those values will be stored in `.gradle/configuration-cache/`. This applies regardless of how the
+ * resulting [org.gradle.api.provider.Provider] is stored: a task `@Input`, `@get:Internal`, or private `val` all
+ * cause `obtain()` to run at configuration time and the parsed tree to be cached. For files containing sensitive
+ * data, read and use the file entirely within a `@TaskAction` or [org.gradle.workers.WorkAction.execute] body
+ * instead.
  */
 abstract class YamlValueSource : ValueSource<YamlValue, YamlValueSource.Parameters> {
     /**

--- a/cores/xml-extensions/src/main/kotlin/com/kelvsyc/gradle/xml/XmlValueSource.kt
+++ b/cores/xml-extensions/src/main/kotlin/com/kelvsyc/gradle/xml/XmlValueSource.kt
@@ -14,6 +14,14 @@ import javax.xml.stream.XMLStreamException
  * The parser is non-validating, does not process DTDs, and disables external entity resolution.
  *
  * If the input file is not found or cannot be parsed, no value will be provided.
+ *
+ * **Configuration cache and sensitive files:** Gradle serializes the entire [XmlElement] tree to the configuration
+ * cache in plaintext when the cache is written. If the XML file contains sensitive values — passwords, tokens, API
+ * keys — those values will be stored in `.gradle/configuration-cache/`. This applies regardless of how the
+ * resulting [org.gradle.api.provider.Provider] is stored: a task `@Input`, `@get:Internal`, or private `val` all
+ * cause `obtain()` to run at configuration time and the parsed tree to be cached. For files containing sensitive
+ * data, read and use the file entirely within a `@TaskAction` or [org.gradle.workers.WorkAction.execute] body
+ * instead.
  */
 abstract class XmlValueSource : ValueSource<XmlElement, XmlValueSource.Parameters> {
     /**


### PR DESCRIPTION
## Summary

- Adds pre-generation guidance to ECR, CodeArtifact (Java + Kotlin), and Azure Managed Identity READMEs: generate tokens before Gradle runs, store in an env var, and reference via `providers.environmentVariable()` so the token itself is never written to the config cache.
- Flags `AbstractGetGenericAssetValueSource` (both SDK variants) with a config-cache warning, since `doObtain()` could return sensitive content depending on the fetched asset.
- Extends the same documentation to all remaining abstract `ValueSource` base classes across S3, GCS, Azure Blob, Artifactory, GCP Artifact Registry, IMDS, and the file-format parsers (JSON, XML, YAML), calibrated by risk tier.
- Calls out `AbstractArtifactorySearchValueSource.Parameters.accessToken: Property<String>` as a credential stored in plaintext in the config cache if set; guidance recommends CLI-configured credentials instead.
- All warnings clarify that `@get:Internal` properties and private `val` fields are equally unsafe as `@Input` — Gradle's config-cache codec walks the full task object graph regardless of annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)