### PR TITLE
security: force msgpack-core to 0.9.12 to address CVE-2026-21452

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,6 +106,7 @@ moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 pkl-core = "org.pkl-lang:pkl-core:0.31.1"
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 mockk = "io.mockk:mockk:1.14.9"
+msgpack-core = "org.msgpack:msgpack-core:0.9.12"
 okhttp = { module = "com.squareup.okhttp3:okhttp" } # version from BOM 'okhttp-bom'
 retrofit = { module = "com.squareup.retrofit2:retrofit" } # version from BOM 'retrofit-bom'
 retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi" } # version from BOM 'retrofit-bom'

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
         api(libs.commons.lang)
         api(libs.moshi)
         api(libs.moshi.kotlin)
+        api(libs.msgpack.core)
         api(libs.pkl.core)
         api(libs.woodstox)
     }


### PR DESCRIPTION
## Summary

- Adds `msgpack-core:0.9.12` to the version catalog and adds it as a BOM constraint in `gradle/platform`
- Forces Gradle to resolve `org.msgpack:msgpack-core` to 0.9.12 everywhere, overriding the vulnerable 0.9.8 pulled in transitively by `pkl-core:0.31.1`
- Addresses CVE-2026-21452 (DoS via gradual memory over-allocation for payloads >64MB, fixed in 0.9.11); no patched pkl-core release exists yet so a direct constraint is the appropriate interim fix

## Test plan

- [ ] Verify `./gradlew :pkl-extensions:dependencies --configuration runtimeClasspath` shows `msgpack-core:0.9.8 -> 0.9.12`
- [ ] `./gradlew :pkl-extensions:test` passes
- [ ] `./gradlew :pkl-extensions:detekt` passes
- [ ] Dependabot alert closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)