### PR TITLE
security: migrate jfrog-cli-core access tokens to CredentialReference

### DIFF
--- a/cores/jfrog-cli-core/README.md
+++ b/cores/jfrog-cli-core/README.md
@@ -77,7 +77,7 @@ Requires a server connection.
 ```kotlin
 tasks.register<PublishBuildInfo>("publishBuildInfo") {
     serverUrl.set("https://artifactory.example.com")
-    accessToken.set(providers.environmentVariable("JFROG_ACCESS_TOKEN"))
+    accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
     buildName.set("my-app")
     buildNumber.set(providers.environmentVariable("BUILD_NUMBER"))
     envExcludePatterns.add("*PASSWORD*")   // optional: strip sensitive vars before publishing
@@ -88,7 +88,7 @@ tasks.register<PublishBuildInfo>("publishBuildInfo") {
 |---|---|---|
 | `jfCommand` | `Property<String>` | Path to the `jf` binary. Set via convention when plugin is applied. |
 | `serverUrl` | `Property<String>` | Artifactory server URL |
-| `accessToken` | `Property<String>` | JFrog access token for authentication |
+| `accessTokenRef` | `Property<CredentialReference>` | Reference to the JFrog access token — only the lookup name is cached, not the token value |
 | `buildName` | `Property<String>` | Build name |
 | `buildNumber` | `Property<String>` | Build number |
 | `envExcludePatterns` | `ListProperty<String>` | Glob patterns for env var names to strip before publishing. |
@@ -119,7 +119,7 @@ with Xray enabled. The build must already be published before scanning — use `
 ```kotlin
 tasks.register<ScanBuild>("scanBuild") {
     serverUrl.set("https://artifactory.example.com")
-    accessToken.set(providers.environmentVariable("JFROG_ACCESS_TOKEN"))
+    accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
     buildName.set("my-app")
     buildNumber.set(providers.environmentVariable("BUILD_NUMBER"))
     failBuild.set(true)    // optional: fail the build on policy violations
@@ -130,7 +130,7 @@ tasks.register<ScanBuild>("scanBuild") {
 |---|---|---|
 | `jfCommand` | `Property<String>` | Path to the `jf` binary. Set via convention when plugin is applied. |
 | `serverUrl` | `Property<String>` | Artifactory server URL |
-| `accessToken` | `Property<String>` | JFrog access token for authentication |
+| `accessTokenRef` | `Property<CredentialReference>` | Reference to the JFrog access token — only the lookup name is cached, not the token value |
 | `buildName` | `Property<String>` | Build name |
 | `buildNumber` | `Property<String>` | Build number |
 | `failBuild` | `Property<Boolean>` | Fail the build if Xray policy violations are found. Defaults to `false`. |
@@ -145,7 +145,7 @@ abstract class MyTask @Inject constructor(private val workers: WorkerExecutor) :
     fun run() {
         workers.noIsolation().submit(PublishBuildInfoAction::class) {
             serverUrl.set("https://artifactory.example.com")
-            accessToken.set("...")
+            accessToken.set(System.getenv("JFROG_ACCESS_TOKEN"))
             buildName.set("my-app")
             buildNumber.set("42")
         }
@@ -200,7 +200,7 @@ val latestVersion: Provider<String> = providers.of(LatestVersionValueSource::cla
     parameters {
         jfCommand.set(providers.which("jf"))
         serverUrl.set("https://artifactory.example.com")
-        accessToken.set(providers.environmentVariable("JFROG_ACCESS_TOKEN"))
+        accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
         repoKey.set("libs-release-local")
         artifactName.set("my-app")
     }
@@ -213,7 +213,7 @@ Base parameters declared in `AbstractArtifactorySearchValueSource.Parameters`:
 |---|---|---|
 | `jfCommand` | `Property<String>` | Path to the `jf` binary |
 | `serverUrl` | `Property<String>` | Artifactory server URL. Leave unset to use the CLI's configured default. |
-| `accessToken` | `Property<String>` | JFrog access token. Leave unset to use the CLI's configured credentials. |
+| `accessTokenRef` | `Property<CredentialReference>` | Reference to the JFrog access token. Leave unset to use the CLI's configured credentials. |
 
 ## See Also
 

--- a/cores/jfrog-cli-core/build.gradle.kts
+++ b/cores/jfrog-cli-core/build.gradle.kts
@@ -19,5 +19,7 @@ gradlePlugin {
 }
 
 dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+
     testImplementation(libs.mockk)
 }

--- a/cores/jfrog-cli-core/settings.gradle.kts
+++ b/cores/jfrog-cli-core/settings.gradle.kts
@@ -5,3 +5,5 @@ pluginManagement {
 plugins {
     id("com.kelvsyc.internal")
 }
+
+includeBuild("../clients-base")

--- a/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/AbstractArtifactorySearchValueSource.kt
+++ b/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/AbstractArtifactorySearchValueSource.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.jfrog
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -16,10 +17,12 @@ import javax.inject.Inject
  * Subclasses must implement [buildSearchArgs] to supply the search-specific CLI arguments (pattern, file spec path,
  * or AQL flags), and [doObtain] to transform the raw JSON string into the desired type.
  *
- * **Configuration cache — access token:** If [Parameters.accessToken] is set, the token value is a
- * `Property<String>` on `ValueSourceParameters` and will be serialized to `.gradle/configuration-cache/` in
- * plaintext when the cache is written. Prefer leaving [Parameters.accessToken] unset and configuring credentials
- * in the JFrog CLI itself (via `jf config add`), so that no token ever enters the configuration cache.
+ * **Configuration cache — access token:** If [Parameters.accessTokenRef] is set, only the lookup reference
+ * (environment variable name or system property key) is serialized to `.gradle/configuration-cache/` — never
+ * the token value itself. The token is resolved via [CredentialReference.resolve] inside [obtain], which runs
+ * at configuration time but leaves no trace of the raw value in the cache. Prefer leaving
+ * [Parameters.accessTokenRef] unset and configuring credentials in the JFrog CLI itself (via `jf config add`)
+ * to avoid token resolution at configuration time entirely.
  *
  * **Configuration cache — search results:** Gradle serializes the result of every [ValueSource.obtain] call to
  * the configuration cache in plaintext. Whatever [doObtain] returns will be stored in
@@ -50,10 +53,12 @@ abstract class AbstractArtifactorySearchValueSource<T : Any, P : AbstractArtifac
         val serverUrl: Property<String>
 
         /**
-         * The JFrog access token for authentication. Leave unset to use the CLI's configured credentials.
+         * A reference to the JFrog access token for authentication. Leave unset to use the CLI's configured
+         * credentials. Set to a [CredentialReference.EnvironmentVariable] or [CredentialReference.SystemProperty]
+         * pointing to the token — the lookup name, not the token value, is what is stored in the configuration cache.
          */
         @get:Internal
-        val accessToken: Property<String>
+        val accessTokenRef: Property<CredentialReference>
     }
 
     /**
@@ -83,9 +88,9 @@ abstract class AbstractArtifactorySearchValueSource<T : Any, P : AbstractArtifac
                     add("--url")
                     add(parameters.serverUrl.get())
                 }
-                if (parameters.accessToken.isPresent) {
+                if (parameters.accessTokenRef.isPresent) {
                     add("--access-token")
-                    add(parameters.accessToken.get())
+                    add(parameters.accessTokenRef.get().resolve())
                 }
                 addAll(buildSearchArgs())
             }

--- a/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/PublishBuildInfo.kt
+++ b/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/PublishBuildInfo.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.jfrog
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.jfrog.actions.PublishBuildInfoAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.ListProperty
@@ -40,12 +41,14 @@ abstract class PublishBuildInfo @Inject constructor(private val workers: WorkerE
     abstract val serverUrl: Property<String>
 
     /**
-     * The JFrog access token for authentication.
+     * A reference to the JFrog access token for authentication. Set to a [CredentialReference.EnvironmentVariable]
+     * or [CredentialReference.SystemProperty] pointing to the token — only the lookup name is serialized to the
+     * configuration cache, never the token value itself.
      *
      * @see [PublishBuildInfoAction.Parameters.accessToken]
      */
     @get:Internal
-    abstract val accessToken: Property<String>
+    abstract val accessTokenRef: Property<CredentialReference>
 
     /**
      * The build name.
@@ -77,7 +80,7 @@ abstract class PublishBuildInfo @Inject constructor(private val workers: WorkerE
         workers.noIsolation().submit(PublishBuildInfoAction::class) {
             jfCommand.set(this@PublishBuildInfo.jfCommand)
             serverUrl.set(this@PublishBuildInfo.serverUrl)
-            accessToken.set(this@PublishBuildInfo.accessToken)
+            accessToken.set(this@PublishBuildInfo.accessTokenRef.get().resolve())
             buildName.set(this@PublishBuildInfo.buildName)
             buildNumber.set(this@PublishBuildInfo.buildNumber)
             envExcludePatterns.set(this@PublishBuildInfo.envExcludePatterns)

--- a/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/ScanBuild.kt
+++ b/cores/jfrog-cli-core/src/main/kotlin/com/kelvsyc/gradle/jfrog/ScanBuild.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.jfrog
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.jfrog.actions.ScanBuildAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
@@ -39,12 +40,14 @@ abstract class ScanBuild @Inject constructor(private val workers: WorkerExecutor
     abstract val serverUrl: Property<String>
 
     /**
-     * The JFrog access token for authentication.
+     * A reference to the JFrog access token for authentication. Set to a [CredentialReference.EnvironmentVariable]
+     * or [CredentialReference.SystemProperty] pointing to the token — only the lookup name is serialized to the
+     * configuration cache, never the token value itself.
      *
      * @see [ScanBuildAction.Parameters.accessToken]
      */
     @get:Internal
-    abstract val accessToken: Property<String>
+    abstract val accessTokenRef: Property<CredentialReference>
 
     /**
      * The build name.
@@ -76,7 +79,7 @@ abstract class ScanBuild @Inject constructor(private val workers: WorkerExecutor
         workers.noIsolation().submit(ScanBuildAction::class) {
             jfCommand.set(this@ScanBuild.jfCommand)
             serverUrl.set(this@ScanBuild.serverUrl)
-            accessToken.set(this@ScanBuild.accessToken)
+            accessToken.set(this@ScanBuild.accessTokenRef.get().resolve())
             buildName.set(this@ScanBuild.buildName)
             buildNumber.set(this@ScanBuild.buildNumber)
             failBuild.set(this@ScanBuild.failBuild)

--- a/cores/jfrog-cli-core/src/test/kotlin/com/kelvsyc/gradle/jfrog/PublishBuildInfoSpec.kt
+++ b/cores/jfrog-cli-core/src/test/kotlin/com/kelvsyc/gradle/jfrog/PublishBuildInfoSpec.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.jfrog
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.plugins.JFrogCliPlugin
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -37,13 +38,13 @@ class PublishBuildInfoSpec : FunSpec() {
                 task.serverUrl.get() shouldBe "https://artifactory.example.com"
             }
 
-            test("accessToken can be set and retrieved") {
+            test("accessTokenRef can be set and retrieved") {
                 val project = ProjectBuilder.builder().build()
                 val task = project.tasks.register<PublishBuildInfo>("myTask").get()
 
-                task.accessToken.set("mytoken")
+                task.accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
 
-                task.accessToken.get() shouldBe "mytoken"
+                task.accessTokenRef.get() shouldBe CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN")
             }
 
             test("envExcludePatterns can be set and retrieved") {

--- a/cores/jfrog-cli-core/src/test/kotlin/com/kelvsyc/gradle/jfrog/ScanBuildSpec.kt
+++ b/cores/jfrog-cli-core/src/test/kotlin/com/kelvsyc/gradle/jfrog/ScanBuildSpec.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.jfrog
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.plugins.JFrogCliPlugin
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -37,13 +38,13 @@ class ScanBuildSpec : FunSpec() {
                 task.serverUrl.get() shouldBe "https://artifactory.example.com"
             }
 
-            test("accessToken can be set and retrieved") {
+            test("accessTokenRef can be set and retrieved") {
                 val project = ProjectBuilder.builder().build()
                 val task = project.tasks.register<ScanBuild>("myTask").get()
 
-                task.accessToken.set("mytoken")
+                task.accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
 
-                task.accessToken.get() shouldBe "mytoken"
+                task.accessTokenRef.get() shouldBe CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN")
             }
 
             test("failBuild can be set to true") {

--- a/cores/jfrog-cli-core/src/test/kotlin/com/kelvsyc/gradle/plugins/JFrogCliPluginSpec.kt
+++ b/cores/jfrog-cli-core/src/test/kotlin/com/kelvsyc/gradle/plugins/JFrogCliPluginSpec.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.plugins
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.jfrog.AddGitInfoToBuild
 import com.kelvsyc.gradle.jfrog.CleanBuildInfo
 import com.kelvsyc.gradle.jfrog.CollectBuildEnvironment
@@ -38,7 +39,7 @@ class JFrogCliPluginSpec : FunSpec() {
 
             project.tasks.register<PublishBuildInfo>("myTask") {
                 serverUrl.set("https://artifactory.example.com")
-                accessToken.set("mytoken")
+                accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
                 buildName.set("my-build")
                 buildNumber.set("1")
             }.get()
@@ -60,7 +61,7 @@ class JFrogCliPluginSpec : FunSpec() {
 
             project.tasks.register<ScanBuild>("myTask") {
                 serverUrl.set("https://artifactory.example.com")
-                accessToken.set("mytoken")
+                accessTokenRef.set(CredentialReference.EnvironmentVariable("JFROG_ACCESS_TOKEN"))
                 buildName.set("my-build")
                 buildNumber.set("1")
             }.get()


### PR DESCRIPTION
## Summary

- Adds `clients-base` as an `api` dependency of `jfrog-cli-core` so `CredentialReference` is available on the classpath.
- Renames `accessToken: Property<String>` → `accessTokenRef: Property<CredentialReference>` on `AbstractArtifactorySearchValueSource.Parameters`, `PublishBuildInfo`, and `ScanBuild` — aligning with the convention established in #560.
- `WorkAction.Parameters` fields (`PublishBuildInfoAction`, `ScanBuildAction`) remain `Property<String>` as they are resolved at execution time and are never serialized to the configuration cache.
- Updates tests and README to reflect the new API.

## Test plan

- [x] `./gradlew :jfrog-cli-core:test` — all tests pass
- [x] `./gradlew :jfrog-cli-core:detekt` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)