### PR TITLE
New components: hashicorp-vault-extensions and hashicorp-vault-base

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ since the two AWS SDKs are distinct libraries:
 | `google-cloud-storage-base` | GCP Cloud Storage |
 | `google-cloud-secret-manager-base` | GCP Secret Manager |
 | `google-cloud-pubsub-base` | GCP Pub/Sub |
+| `hashicorp-vault-base` | HashiCorp Vault KV and dynamic credentials |
 | `google-cloud-kms-base` | GCP Cloud KMS |
 | `azure-blob-storage-base` | Azure Blob Storage |
 | `azure-key-vault-base` | Azure Key Vault |
@@ -81,6 +82,7 @@ dependencies {
 | `aws-java-extensions` | Config-cache-safe BuildService base class, `AwsBuildServiceParams`, and credential adapters for the AWS SDK for Java |
 | `aws-kotlin-extensions` | Base client info interface and credential extensions for the AWS SDK for Kotlin |
 | `google-cloud-extensions` | Config-cache-safe BuildService base class and `GcpBuildServiceParams` for the Google Cloud SDK |
+| `hashicorp-vault-extensions` | Config-cache-safe BuildService base for HashiCorp Vault with token renewal and lease tracking |
 | `azure-extensions` | Config-cache-safe BuildService base class and `AzureBuildServiceParams` for the Azure SDK |
 | `moshi-extensions` | `ValueSource` implementations and `Provider` extensions for Moshi JSON parsing |
 | `pkl-extensions` | `ValueSource` implementations for evaluating Pkl configuration files |

--- a/cores/hashicorp-vault-base/README.md
+++ b/cores/hashicorp-vault-base/README.md
@@ -1,0 +1,205 @@
+# HashiCorp Vault Base
+
+A Kotlin library providing [HashiCorp Vault](https://www.vaultproject.io/) integration for Gradle builds. Includes WorkAction implementations for KV secrets, dynamic credentials, and lease management, built on `clients-base` and `hashicorp-vault-extensions`.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:hashicorp-vault-base")
+}
+```
+
+## Setup
+
+See [hashicorp-vault-extensions](../hashicorp-vault-extensions) for authentication setup and `VaultBuildServiceParams` configuration options (token, AppRole, Kubernetes, AWS IAM, GCP, and TLS).
+
+## VaultClientBuildService Registration
+
+Register the build service in your plugin or settings plugin:
+
+```kotlin
+val vault = gradle.sharedServices.registerIfAbsent("vault", VaultClientBuildService::class) {
+    parameters {
+        endpoint.set("https://vault.example.com:8200")
+        tokenAuth()  // or appRoleAuth(), kubernetesAuth(), etc.
+    }
+}
+```
+
+## Primary Usage: Inject Service into Custom WorkActions
+
+The recommended pattern is to inject `VaultClientBuildService` directly into your own custom [WorkAction](https://docs.gradle.org/current/javadoc/org/gradle/workers/WorkAction.html):
+
+```kotlin
+abstract class FetchSecretAction : WorkAction<FetchSecretAction.Parameters> {
+    interface Parameters : WorkParameters {
+        @get:Internal
+        val vaultService: Property<VaultClientBuildService>
+        val secretPath: Property<String>
+    }
+
+    override fun execute() {
+        val secret = parameters.vaultService.get().getKvSecret(
+            parameters.secretPath.get(),
+            "apiKey"
+        )
+        println("Secret: $secret")
+    }
+}
+```
+
+Submit via `WorkerExecutor`:
+
+```kotlin
+workerExecutor.noIsolation().submit(FetchSecretAction::class) {
+    vaultService.set(vault)
+    secretPath.set("secret/data/myapp")
+}
+```
+
+## KV WorkActions
+
+WorkActions for reading and writing Vault KV secrets:
+
+| Class | Purpose | Parameters |
+|-------|---------|------------|
+| `WriteKvSecretAction` | Write a key-value pair to a KV path | `service`, `path`, `key`, `value` |
+| `DeleteKvSecretAction` | Delete a KV path | `service`, `path` |
+
+### `WriteKvSecretAction`
+
+Writes a single key to a KV secrets engine path. The `service` and `value` parameters are marked `@get:Internal` for task caching.
+
+| Parameter | Type | Snapshot | Description |
+|-----------|------|----------|-------------|
+| `service` | `Property<VaultClientBuildService>` | Excluded | Vault build service |
+| `path` | `Property<String>` | Included | KV path, e.g. `secret/data/myapp` (KV v2) |
+| `key` | `Property<String>` | Included | Key name within the secret |
+| `value` | `Property<String>` | Excluded | Secret value to write |
+
+```kotlin
+workerExecutor.noIsolation().submit(WriteKvSecretAction::class) {
+    service.set(vault)
+    path.set("secret/data/myapp")
+    key.set("apiKey")
+    value.set("secret-value-here")
+}
+```
+
+### `DeleteKvSecretAction`
+
+Deletes a KV path. The `service` parameter is marked `@get:Internal`.
+
+| Parameter | Type | Snapshot | Description |
+|-----------|------|----------|-------------|
+| `service` | `Property<VaultClientBuildService>` | Excluded | Vault build service |
+| `path` | `Property<String>` | Included | KV path to delete |
+
+```kotlin
+workerExecutor.noIsolation().submit(DeleteKvSecretAction::class) {
+    service.set(vault)
+    path.set("secret/data/myapp")
+}
+```
+
+## Dynamic Credential WorkActions
+
+WorkActions for issuing and revoking dynamic credentials. All follow the same two-layer revocation pattern (immediate try/finally + safety-net).
+
+| Class | Credential Type | Issue Method | Usage |
+|-------|-----------------|--------------|-------|
+| `AbstractDatabaseCredentialWorkAction` | Database (username/password) | `issueDatabaseCredential(role)` | Abstract; subclass and implement `doExecute` |
+| `AbstractAwsCredentialWorkAction` | AWS (access key + secret) | `issueAwsCredential(role)` | Abstract; subclass and implement `doExecute` |
+| `AbstractGcpCredentialWorkAction` | GCP (access token) | `issueGcpCredential(role)` | Abstract; subclass and implement `doExecute` |
+| `AbstractAzureCredentialWorkAction` | Azure (client ID + secret) | `issueAzureCredential(role)` | Abstract; subclass and implement `doExecute` |
+
+### Subclassing Pattern
+
+Extend one of the abstract classes and implement `doExecute(credential)` to use the issued credential:
+
+```kotlin
+abstract class RunDatabaseMigrationAction : AbstractDatabaseCredentialWorkAction() {
+    override fun doExecute(credential: DatabaseCredential) {
+        val conn = DriverManager.getConnection(
+            "jdbc:postgresql://localhost/mydb",
+            credential.username,
+            credential.password
+        )
+        conn.use { /* run migration */ }
+    }
+}
+```
+
+Submit via `WorkerExecutor`:
+
+```kotlin
+workerExecutor.noIsolation().submit(RunDatabaseMigrationAction::class) {
+    service.set(vault)
+    role.set("my-db-role")
+}
+```
+
+### Shorthand: `with*Credential` Helpers
+
+As an alternative to subclassing, call the `with*` methods on `VaultClientBuildService` directly (these are available at execution time only):
+
+```kotlin
+vault.get().withDatabaseCredential("my-db-role") { credential ->
+    // use credential.username, credential.password
+}
+```
+
+### Parameter Details
+
+All abstract credential WorkActions expose these parameters:
+
+| Parameter | Type | Snapshot | Description |
+|-----------|------|----------|-------------|
+| `service` | `Property<VaultClientBuildService>` | Excluded | Vault build service |
+| `role` | `Property<String>` | Included | Role/roleset name (e.g. `my-db-role`) |
+
+**Note:** The `role` parameter is intentionally included in task snapshots because role names are not credentials — they are configuration. In environments where role names are sensitive, mark the parameter `@get:Internal` in your subclass:
+
+```kotlin
+interface Parameters : AbstractDatabaseCredentialWorkAction.Parameters {
+    @get:Internal
+    override val role: Property<String>
+}
+```
+
+## Lease Revocation Strategy
+
+### Two-Layer Revocation
+
+Dynamic credentials are revoked through two independent mechanisms:
+
+1. **Immediate revocation** — All abstract credential WorkActions revoke the lease in a `try/finally` block immediately after `doExecute()` returns, guaranteeing revocation even if the work throws an exception.
+
+2. **Safety-net revocation** — The `VaultClientBuildService` maintains an internal lease registry. On build completion (`close()` hook), any leases not yet revoked are revoked as best-effort cleanup. Failures are logged as warnings and do not fail the build.
+
+This ensures that even if immediate revocation is missed (e.g., due to a WorkAction crash or process termination), Vault will revoke the lease when the build service shuts down.
+
+### Explicit Revocation: `RevokeLeaseAction`
+
+For fine-grained control, use `RevokeLeaseAction` to revoke a specific lease at a particular point in the task graph:
+
+```kotlin
+workerExecutor.noIsolation().submit(RevokeLeaseAction::class) {
+    service.set(vault)
+    leaseId.set(credential.leaseId)
+}
+```
+
+This is useful when you want to revoke a credential before the abstract WorkAction's automatic revocation would occur, or when managing leases outside the abstract classes.
+
+## Azure Credential Note
+
+The `AbstractAzureCredentialWorkAction` is defined for completeness. However, Azure Managed Identity authentication (`VaultCredentialSource.AZURE_MSI`) is **not currently supported** by vault-java-driver 6.2.1. Using `AZURE_MSI` will throw an `UnsupportedOperationException` when the build service is created.
+
+Azure service principal credentials can still be issued via the Azure secrets engine and used with `AbstractAzureCredentialWorkAction`.
+
+## See Also
+
+- [clients-base](../clients-base) — The underlying service client infrastructure
+- [hashicorp-vault-extensions](../hashicorp-vault-extensions) — Authentication, credential types, and build service parameters

--- a/cores/hashicorp-vault-base/build.gradle.kts
+++ b/cores/hashicorp-vault-base/build.gradle.kts
@@ -1,0 +1,21 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("HashiCorp Vault Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:hashicorp-vault-extensions")
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/hashicorp-vault-base/gradle.properties
+++ b/cores/hashicorp-vault-base/gradle.properties
@@ -1,0 +1,2 @@
+# Dokka V2 migration
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/cores/hashicorp-vault-base/settings.gradle.kts
+++ b/cores/hashicorp-vault-base/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../hashicorp-vault-extensions")

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractAwsCredentialWorkAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractAwsCredentialWorkAction.kt
@@ -1,0 +1,77 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that issues dynamic AWS credentials from Vault,
+ * executes work with them, and immediately revokes the credential lease.
+ *
+ * ## Lease revocation
+ *
+ * This action uses a two-layer revocation strategy:
+ *
+ * 1. **Immediate revocation** — The lease is revoked in a `try/finally` block
+ *    immediately after [doExecute] returns, whether or not it throws.
+ * 2. **Safety-net revocation** — The lease is also tracked by the [VaultClientBuildService]
+ *    and will be revoked on build completion if the immediate revocation fails.
+ *
+ * Subclass this action and implement [doExecute] to use the issued credentials:
+ *
+ * ```kotlin
+ * abstract class AssumeRoleAction : AbstractAwsCredentialWorkAction() {
+ *     override fun doExecute(credential: AwsDynamicCredential) {
+ *         // use credential.accessKeyId, credential.secretAccessKey, credential.sessionToken
+ *     }
+ * }
+ * ```
+ *
+ * ## Role sensitivity
+ *
+ * The [Parameters.role] property is not marked `@get:Internal` because the role name
+ * is not a credential value — it contributes to Gradle's up-to-date checks. In
+ * environments where role names are considered sensitive, mark the property
+ * `@get:Internal` in the subclass parameters override.
+ */
+abstract class AbstractAwsCredentialWorkAction :
+    WorkAction<AbstractAwsCredentialWorkAction.Parameters> {
+
+    /** Parameters for [AbstractAwsCredentialWorkAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to issue and revoke credentials.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /**
+         * The AWS role configured in Vault. Not a credential value; contributes
+         * to Gradle's up-to-date checks. Mark `@get:Internal` in subclasses if the
+         * role name is considered sensitive in your environment.
+         */
+        val role: Property<String>
+    }
+
+    final override fun execute() {
+        val credential = parameters.service.get().issueAwsCredential(parameters.role.get())
+        try {
+            doExecute(credential)
+        } finally {
+            parameters.service.get().revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Executes work using the issued [credential].
+     *
+     * Called within a `try/finally` block — the credential lease is revoked after
+     * this method returns, whether or not it throws.
+     *
+     * @param credential The issued [AwsDynamicCredential] containing access key ID,
+     *   secret access key, optional session token, lease ID, and lease duration.
+     */
+    protected abstract fun doExecute(credential: AwsDynamicCredential)
+}

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractAzureCredentialWorkAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractAzureCredentialWorkAction.kt
@@ -1,0 +1,84 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that issues dynamic Azure credentials from Vault,
+ * executes work with them, and immediately revokes the credential lease.
+ *
+ * ## Lease revocation
+ *
+ * This action uses a two-layer revocation strategy:
+ *
+ * 1. **Immediate revocation** — The lease is revoked in a `try/finally` block
+ *    immediately after [doExecute] returns, whether or not it throws.
+ * 2. **Safety-net revocation** — The lease is also tracked by the [VaultClientBuildService]
+ *    and will be revoked on build completion if the immediate revocation fails.
+ *
+ * Subclass this action and implement [doExecute] to use the issued credentials:
+ *
+ * ```kotlin
+ * abstract class AuthenticateApplicationAction : AbstractAzureCredentialWorkAction() {
+ *     override fun doExecute(credential: AzureDynamicCredential) {
+ *         // use credential.clientId, credential.clientSecret
+ *     }
+ * }
+ * ```
+ *
+ * ## Azure Managed Identity note
+ *
+ * The Azure credential WorkAction is defined for completeness. However, Azure Managed Identity
+ * authentication (`VaultCredentialSource.AZURE_MSI`) is not currently supported by
+ * vault-java-driver 6.2.1. Using `AZURE_MSI` will throw an `UnsupportedOperationException`
+ * when the build service is created.
+ *
+ * ## Role sensitivity
+ *
+ * The [Parameters.role] property is not marked `@get:Internal` because the role name
+ * is not a credential value — it contributes to Gradle's up-to-date checks. In
+ * environments where role names are considered sensitive, mark the property
+ * `@get:Internal` in the subclass parameters override.
+ */
+abstract class AbstractAzureCredentialWorkAction :
+    WorkAction<AbstractAzureCredentialWorkAction.Parameters> {
+
+    /** Parameters for [AbstractAzureCredentialWorkAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to issue and revoke credentials.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /**
+         * The Azure role configured in Vault. Not a credential value; contributes
+         * to Gradle's up-to-date checks. Mark `@get:Internal` in subclasses if the
+         * role name is considered sensitive in your environment.
+         */
+        val role: Property<String>
+    }
+
+    final override fun execute() {
+        val credential = parameters.service.get().issueAzureCredential(parameters.role.get())
+        try {
+            doExecute(credential)
+        } finally {
+            parameters.service.get().revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Executes work using the issued [credential].
+     *
+     * Called within a `try/finally` block — the credential lease is revoked after
+     * this method returns, whether or not it throws.
+     *
+     * @param credential The issued [AzureDynamicCredential] containing client ID,
+     *   client secret, lease ID, and lease duration.
+     */
+    protected abstract fun doExecute(credential: AzureDynamicCredential)
+}

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractDatabaseCredentialWorkAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractDatabaseCredentialWorkAction.kt
@@ -1,0 +1,77 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that issues dynamic database credentials from Vault,
+ * executes work with them, and immediately revokes the credential lease.
+ *
+ * ## Lease revocation
+ *
+ * This action uses a two-layer revocation strategy:
+ *
+ * 1. **Immediate revocation** — The lease is revoked in a `try/finally` block
+ *    immediately after [doExecute] returns, whether or not it throws.
+ * 2. **Safety-net revocation** — The lease is also tracked by the [VaultClientBuildService]
+ *    and will be revoked on build completion if the immediate revocation fails.
+ *
+ * Subclass this action and implement [doExecute] to use the issued credentials:
+ *
+ * ```kotlin
+ * abstract class RunMigrationAction : AbstractDatabaseCredentialWorkAction() {
+ *     override fun doExecute(credential: DatabaseCredential) {
+ *         // use credential.username, credential.password
+ *     }
+ * }
+ * ```
+ *
+ * ## Role sensitivity
+ *
+ * The [Parameters.role] property is not marked `@get:Internal` because the role name
+ * is not a credential value — it contributes to Gradle's up-to-date checks. In
+ * environments where role names are considered sensitive, mark the property
+ * `@get:Internal` in the subclass parameters override.
+ */
+abstract class AbstractDatabaseCredentialWorkAction :
+    WorkAction<AbstractDatabaseCredentialWorkAction.Parameters> {
+
+    /** Parameters for [AbstractDatabaseCredentialWorkAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to issue and revoke credentials.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /**
+         * The database role configured in Vault. Not a credential value; contributes
+         * to Gradle's up-to-date checks. Mark `@get:Internal` in subclasses if the
+         * role name is considered sensitive in your environment.
+         */
+        val role: Property<String>
+    }
+
+    final override fun execute() {
+        val credential = parameters.service.get().issueDatabaseCredential(parameters.role.get())
+        try {
+            doExecute(credential)
+        } finally {
+            parameters.service.get().revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Executes work using the issued [credential].
+     *
+     * Called within a `try/finally` block — the credential lease is revoked after
+     * this method returns, whether or not it throws.
+     *
+     * @param credential The issued [DatabaseCredential] containing username, password,
+     *   lease ID, and lease duration.
+     */
+    protected abstract fun doExecute(credential: DatabaseCredential)
+}

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractGcpCredentialWorkAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractGcpCredentialWorkAction.kt
@@ -1,0 +1,77 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that issues dynamic GCP credentials from Vault,
+ * executes work with them, and immediately revokes the credential lease.
+ *
+ * ## Lease revocation
+ *
+ * This action uses a two-layer revocation strategy:
+ *
+ * 1. **Immediate revocation** — The lease is revoked in a `try/finally` block
+ *    immediately after [doExecute] returns, whether or not it throws.
+ * 2. **Safety-net revocation** — The lease is also tracked by the [VaultClientBuildService]
+ *    and will be revoked on build completion if the immediate revocation fails.
+ *
+ * Subclass this action and implement [doExecute] to use the issued credentials:
+ *
+ * ```kotlin
+ * abstract class AuthenticateServiceAccountAction : AbstractGcpCredentialWorkAction() {
+ *     override fun doExecute(credential: GcpDynamicCredential) {
+ *         // use credential.token
+ *     }
+ * }
+ * ```
+ *
+ * ## Role sensitivity
+ *
+ * The [Parameters.role] property is not marked `@get:Internal` because the role name
+ * is not a credential value — it contributes to Gradle's up-to-date checks. In
+ * environments where role names are considered sensitive, mark the property
+ * `@get:Internal` in the subclass parameters override.
+ */
+abstract class AbstractGcpCredentialWorkAction :
+    WorkAction<AbstractGcpCredentialWorkAction.Parameters> {
+
+    /** Parameters for [AbstractGcpCredentialWorkAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to issue and revoke credentials.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /**
+         * The GCP roleset configured in Vault. Not a credential value; contributes
+         * to Gradle's up-to-date checks. Mark `@get:Internal` in subclasses if the
+         * role name is considered sensitive in your environment.
+         */
+        val role: Property<String>
+    }
+
+    final override fun execute() {
+        val credential = parameters.service.get().issueGcpCredential(parameters.role.get())
+        try {
+            doExecute(credential)
+        } finally {
+            parameters.service.get().revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Executes work using the issued [credential].
+     *
+     * Called within a `try/finally` block — the credential lease is revoked after
+     * this method returns, whether or not it throws.
+     *
+     * @param credential The issued [GcpDynamicCredential] containing token,
+     *   lease ID, and lease duration.
+     */
+    protected abstract fun doExecute(credential: GcpDynamicCredential)
+}

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/DeleteKvSecretAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/DeleteKvSecretAction.kt
@@ -1,0 +1,37 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * A [WorkAction] that deletes a Vault KV secrets engine path.
+ *
+ * Submit this action via [org.gradle.workers.WorkerExecutor.noIsolation]:
+ *
+ * ```kotlin
+ * workerExecutor.noIsolation().submit(DeleteKvSecretAction::class) {
+ *     service.set(vaultService)
+ *     path.set("secret/data/myapp")
+ * }
+ * ```
+ */
+abstract class DeleteKvSecretAction : WorkAction<DeleteKvSecretAction.Parameters> {
+    /** Parameters for [DeleteKvSecretAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to perform the delete operation.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /** The KV path to delete. */
+        val path: Property<String>
+    }
+
+    override fun execute() {
+        parameters.service.get().getClient().logical().delete(parameters.path.get())
+    }
+}

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/RevokeLeaseAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/RevokeLeaseAction.kt
@@ -1,0 +1,44 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * A [WorkAction] that explicitly revokes a Vault lease.
+ *
+ * Use this when you need to revoke a lease at a specific point in the task graph,
+ * beyond the automatic revocation provided by [AbstractDatabaseCredentialWorkAction]
+ * and its sibling classes. The [VaultClientBuildService] always revokes all
+ * tracked leases on build completion as a safety net.
+ *
+ * ```kotlin
+ * workerExecutor.noIsolation().submit(RevokeLeaseAction::class) {
+ *     service.set(vaultService)
+ *     leaseId.set(credential.leaseId)
+ * }
+ * ```
+ */
+abstract class RevokeLeaseAction : WorkAction<RevokeLeaseAction.Parameters> {
+    /** Parameters for [RevokeLeaseAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to revoke the lease.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /**
+         * The Vault lease ID to revoke.
+         * Excluded from task snapshots as it is a sensitive runtime value.
+         */
+        @get:Internal
+        val leaseId: Property<String>
+    }
+
+    override fun execute() {
+        parameters.service.get().revokeLease(parameters.leaseId.get())
+    }
+}

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultClientBuildService.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultClientBuildService.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+/**
+ * A concrete [AbstractVaultClientBuildService] using [VaultBuildServiceParams].
+ *
+ * Register this service with [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent]:
+ *
+ * ```kotlin
+ * val vault = gradle.sharedServices.registerIfAbsent("vault", VaultClientBuildService::class) {
+ *     parameters {
+ *         endpoint.set("https://vault.example.com:8200")
+ *         tokenAuth()
+ *     }
+ * }
+ * ```
+ *
+ * Inject the service into your own [org.gradle.workers.WorkAction] to access credentials
+ * at task execution time:
+ *
+ * ```kotlin
+ * abstract class MyWorkAction : WorkAction<MyWorkAction.Parameters> {
+ *     interface Parameters : WorkParameters {
+ *         @get:Internal
+ *         val vaultService: Property<VaultClientBuildService>
+ *     }
+ *
+ *     override fun execute() {
+ *         val secret = parameters.vaultService.get().getKvSecret("secret/myapp", "apiKey")
+ *         // use secret...
+ *     }
+ * }
+ * ```
+ */
+abstract class VaultClientBuildService : AbstractVaultClientBuildService<VaultBuildServiceParams>()

--- a/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/WriteKvSecretAction.kt
+++ b/cores/hashicorp-vault-base/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/WriteKvSecretAction.kt
@@ -1,0 +1,52 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * A [WorkAction] that writes a single key-value pair to a Vault KV secrets engine path.
+ *
+ * Submit this action via [org.gradle.workers.WorkerExecutor.noIsolation]:
+ *
+ * ```kotlin
+ * workerExecutor.noIsolation().submit(WriteKvSecretAction::class) {
+ *     service.set(vaultService)
+ *     path.set("secret/data/myapp")
+ *     key.set("apiKey")
+ *     value.set("my-secret-value")
+ * }
+ * ```
+ */
+abstract class WriteKvSecretAction : WorkAction<WriteKvSecretAction.Parameters> {
+    /** Parameters for [WriteKvSecretAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The Vault build service used to perform the write operation.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<VaultClientBuildService>
+
+        /** The KV path to write to, e.g. `secret/data/myapp` (KV v2) or `secret/myapp` (KV v1). */
+        val path: Property<String>
+
+        /** The key within the secret to write. */
+        val key: Property<String>
+
+        /**
+         * The secret value to write.
+         *
+         * This field is marked `@get:Internal` because it contains sensitive data.
+         * It does not contribute to task snapshots.
+         */
+        @get:Internal
+        val value: Property<String>
+    }
+
+    override fun execute() {
+        parameters.service.get().getClient().logical()
+            .write(parameters.path.get(), mapOf(parameters.key.get() to parameters.value.get()))
+    }
+}

--- a/cores/hashicorp-vault-extensions/README.md
+++ b/cores/hashicorp-vault-extensions/README.md
@@ -23,7 +23,9 @@ dependencies {
 | Kubernetes | `kubernetesAuth(role)` | Role name, JWT path (default: `/var/run/secrets/kubernetes.io/serviceaccount/token`) |
 | AWS IAM | `awsIamAuth()` | None — uses ambient AWS credentials |
 | Google Cloud | `gcpAuth()` | GCP JWT reference |
-| Azure Managed Identity | `azureMsiAuth()` | Azure JWT reference |
+| Azure Managed Identity | `azureMsiAuth()` | **(not supported)** |
+
+Azure Managed Identity authentication (`AZURE_MSI`) is defined for future compatibility but is not currently supported by vault-java-driver 6.2.1. Attempting to use it will throw an `UnsupportedOperationException` at build execution time.
 
 ## Build Service Registration
 

--- a/cores/hashicorp-vault-extensions/README.md
+++ b/cores/hashicorp-vault-extensions/README.md
@@ -1,0 +1,221 @@
+# HashiCorp Vault Extensions
+
+Kotlin extension library for HashiCorp Vault integrations in Gradle build services. Provides type-safe configuration, automatic token renewal, and secure credential lease management.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:hashicorp-vault-extensions:1.0.0")
+}
+```
+
+## Design Note
+
+**Configuration-time credential access is not supported.** All credential retrieval must occur at task execution time (inside `@TaskAction` or `WorkAction.execute()`). This is an intentional security design: credentials are fetched only when absolutely needed, and sensitive values never enter the Gradle configuration cache.
+
+## Authentication Methods
+
+| Method | Extension Function | Required Fields |
+|--------|-------------------|-----------------|
+| Pre-issued Token | `tokenAuth()` | Token reference (env var: `VAULT_TOKEN`) |
+| AppRole | `appRoleAuth(roleId)` | Role ID, secret ID reference (env var: `VAULT_SECRET_ID`) |
+| Kubernetes | `kubernetesAuth(role)` | Role name, JWT path (default: `/var/run/secrets/kubernetes.io/serviceaccount/token`) |
+| AWS IAM | `awsIamAuth()` | None — uses ambient AWS credentials |
+| Google Cloud | `gcpAuth()` | GCP JWT reference |
+| Azure Managed Identity | `azureMsiAuth()` | Azure JWT reference |
+
+## Build Service Registration
+
+### Token Authentication
+
+```kotlin
+gradle.sharedServices.registerIfAbsent("vaultToken", MyVaultBuildService::class) {
+    parameters {
+        endpoint.set("https://vault.example.com:8200")
+        tokenAuth()  // Uses VAULT_TOKEN env var
+    }
+}
+```
+
+### AppRole Authentication
+
+```kotlin
+gradle.sharedServices.registerIfAbsent("vaultAppRole", MyVaultBuildService::class) {
+    parameters {
+        endpoint.set("https://vault.example.com:8200")
+        appRoleAuth(
+            roleId = "my-role",
+            secretId = CredentialReference.EnvironmentVariable("MY_SECRET_ID")
+        )
+    }
+}
+```
+
+## Primary Usage Pattern
+
+Define your own `WorkAction` with a `VaultClientBuildService` injected as a parameter:
+
+```kotlin
+abstract class FetchDatabaseCredentialsAction : WorkAction<FetchDatabaseCredentialsAction.Params> {
+    interface Params : WorkParameters {
+        val vault: Property<MyVaultBuildService>
+        val role: Property<String>
+        val outputFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val vaultService = parameters.vault.get()
+        val credential = vaultService.issueDatabaseCredential(parameters.role.get())
+        
+        // Use credential: pass to next tool, write to file, etc.
+        parameters.outputFile.get().asFile.writeText(
+            "USERNAME=${credential.username}\nPASSWORD=${credential.password}"
+        )
+        // Credential is NOT automatically revoked here — see withDatabaseCredential below.
+    }
+}
+```
+
+Register and use this action inside a task:
+
+```kotlin
+tasks.register<JavaExec>("fetchDbCreds") {
+    val vault = gradle.sharedServices.registerIfAbsent("vault", MyVaultBuildService::class) {
+        parameters {
+            endpoint.set("https://vault.example.com:8200")
+            tokenAuth()
+        }
+    }
+
+    val workQueue = workerExecutor.classLoaderIsolation()
+    doLast {
+        workQueue.submit(FetchDatabaseCredentialsAction::class) {
+            vault.set(vault)
+            role.set("my-db-role")
+            outputFile.set(layout.buildDirectory.file("secrets/db.env"))
+        }
+    }
+}
+```
+
+## Scoped Credential Access
+
+For simpler cases, use the `with*Credential` helpers for ergonomic credential issuance with immediate revocation:
+
+```kotlin
+abstract class MyVaultBuildService : AbstractVaultClientBuildService<MyVaultBuildService.Params>() {
+    interface Params : VaultBuildServiceParams {
+        // Add any custom fields here
+    }
+}
+
+// Inside a task @TaskAction or WorkAction.execute():
+val vaultService = // ... obtain the build service instance
+vaultService.withDatabaseCredential("my-db-role") { credential ->
+    // Use credential here
+    println("Database user: ${credential.username}")
+    // Lease is revoked in a try/finally immediately after this block
+}
+```
+
+Equivalent with AWS credentials:
+
+```kotlin
+vaultService.withAwsCredential("my-aws-role") { credential ->
+    val s3Client = AmazonS3ClientBuilder.standard()
+        .withCredentials(AWSStaticCredentialsProvider(
+            BasicAWSCredentials(credential.accessKeyId, credential.secretAccessKey)
+        ))
+        .build()
+    // Use s3Client
+    // Credential is revoked immediately after this block
+}
+```
+
+## Lease Lifecycle
+
+Dynamic credentials are revoked through a two-layer strategy:
+
+### Layer 1: Immediate Revocation (Tight Window)
+
+Methods like `withDatabaseCredential()` and `withAwsCredential()` revoke the lease in a `try/finally` block:
+
+```kotlin
+fun <T> withDatabaseCredential(role: String, block: (DatabaseCredential) -> T): T {
+    val credential = issueDatabaseCredential(role)
+    return try {
+        block(credential)
+    } finally {
+        revokeLease(credential.leaseId)  // Revoked immediately
+    }
+}
+```
+
+If you call `issueDatabaseCredential()` directly (without the `with*` wrapper), the credential is issued but not immediately revoked — revocation defers to Layer 2.
+
+### Layer 2: Safety-Net Revocation (Build Service Cleanup)
+
+When the build service closes (at the end of the build or when garbage collected), the `close()` method revokes any leases still in the internal registry:
+
+```kotlin
+override fun close() {
+    for (leaseId in leaseRegistry) {
+        runCatching { getClient().leases().revoke(leaseId) }
+            .onFailure { logger.warn("Failed to revoke Vault lease $leaseId during cleanup", it) }
+    }
+    super.close()
+}
+```
+
+Revocation failures are logged as warnings and do not fail the build. This ensures that even if a task forgets to revoke a credential, Vault leases do not accumulate indefinitely.
+
+## TLS Configuration
+
+### Verify Using Default Trust Store
+
+By default, the JVM's default certificate trust store is used:
+
+```kotlin
+parameters {
+    endpoint.set("https://vault.example.com:8200")
+    tokenAuth()
+    // Default: uses JVM trust store
+}
+```
+
+### Verify Using Custom CA Certificate
+
+```kotlin
+parameters {
+    endpoint.set("https://vault.example.com:8200")
+    tokenAuth()
+    caCertFile.set(file("config/vault-ca.pem"))
+}
+```
+
+### Disable Verification (Development Only)
+
+```kotlin
+parameters {
+    endpoint.set("https://vault.example.com:8200")
+    tokenAuth()
+    skipVerify.set(true)
+    // WARNING: Disables certificate verification; vulnerable to MITM attacks
+    // Only use in controlled development environments with self-signed certs
+}
+```
+
+## Vault Enterprise: Namespace Configuration
+
+Vault Enterprise supports multi-tenancy via namespaces. Set the namespace if your Vault instance uses them:
+
+```kotlin
+parameters {
+    endpoint.set("https://vault.example.com:8200")
+    namespace.set("my-team")  // Vault Enterprise only
+    tokenAuth()
+}
+```
+
+For open-source Vault, omit this field — it defaults to the root namespace.

--- a/cores/hashicorp-vault-extensions/build.gradle.kts
+++ b/cores/hashicorp-vault-extensions/build.gradle.kts
@@ -1,0 +1,23 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("HashiCorp Vault Extensions")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api(libs.vault.java.driver)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    // Required for ProjectBuilder / MockK on JDK 25
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/hashicorp-vault-extensions/gradle.properties
+++ b/cores/hashicorp-vault-extensions/gradle.properties
@@ -1,0 +1,2 @@
+# Dokka V2 migration
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2EnabledWithHelpers

--- a/cores/hashicorp-vault-extensions/settings.gradle.kts
+++ b/cores/hashicorp-vault-extensions/settings.gradle.kts
@@ -1,0 +1,9 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractVaultClientBuildService.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractVaultClientBuildService.kt
@@ -121,7 +121,9 @@ abstract class AbstractVaultClientBuildService<P : VaultBuildServiceParams> :
                 vault.auth().loginByGCP("gcp", jwt)
             }
             VaultCredentialSource.AZURE_MSI -> {
-                error("Azure Managed Identity authentication is not supported by vault-java-driver")
+                throw UnsupportedOperationException(
+                    "Azure Managed Identity authentication is not supported by vault-java-driver 6.2.1"
+                )
             }
         }
     }

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractVaultClientBuildService.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractVaultClientBuildService.kt
@@ -84,6 +84,12 @@ abstract class AbstractVaultClientBuildService<P : VaultBuildServiceParams> :
             }
         }
 
+        // Apply token to config if using TOKEN authentication
+        if (parameters.credentialSource.get() == VaultCredentialSource.TOKEN) {
+            val token = parameters.tokenRef.get().resolve()
+            configBuilder.token(token)
+        }
+
         val config = configBuilder.build()
         val vault = Vault.create(config)
 
@@ -96,11 +102,7 @@ abstract class AbstractVaultClientBuildService<P : VaultBuildServiceParams> :
     private fun authenticate(vault: Vault) {
         when (parameters.credentialSource.get()) {
             VaultCredentialSource.TOKEN -> {
-                val token = parameters.tokenRef.get().resolve()
-                val configBuilder = VaultConfig()
-                    .address(parameters.endpoint.get())
-                    .token(token)
-                parameters.namespace.orNull?.let { configBuilder.nameSpace(it) }
+                // Token is already set in VaultConfig during client creation
             }
             VaultCredentialSource.APP_ROLE -> {
                 val roleId = parameters.roleId.get()

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractVaultClientBuildService.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AbstractVaultClientBuildService.kt
@@ -1,0 +1,374 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import io.github.jopenlibs.vault.Vault
+import io.github.jopenlibs.vault.VaultConfig
+import io.github.jopenlibs.vault.SslConfig
+import com.kelvsyc.gradle.clients.AbstractClientBuildService
+import org.gradle.api.logging.Logging
+import java.io.File
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * Abstract base class for HashiCorp Vault build services.
+ *
+ * Manages the lifecycle of a [Vault] client, including:
+ * - Authentication via the method configured in [VaultBuildServiceParams]
+ * - Automatic token renewal at 80% of the token TTL
+ * - Lease tracking and revocation for dynamic credentials
+ *
+ * ## Execution-time only
+ *
+ * Configuration-time credential access is explicitly not supported. All methods
+ * that retrieve secrets or issue credentials ([getKvSecret], [getKvSecretMap],
+ * [issueDatabaseCredential], etc.) must be called at task execution time — either
+ * inside a [org.gradle.workers.WorkAction.execute] implementation or inside a
+ * `@TaskAction`-annotated method.
+ *
+ * ## Lease revocation
+ *
+ * Dynamic credentials are managed through a two-layer revocation strategy:
+ *
+ * 1. **Immediate revocation** — The [withDatabaseCredential], [withAwsCredential],
+ *    [withGcpCredential], and [withAzureCredential] helpers revoke the lease in a
+ *    `try/finally` block immediately after the caller's block completes. The abstract
+ *    WorkActions in `hashicorp-vault-base` follow the same pattern.
+ *
+ * 2. **Safety-net revocation** — All issued leases are tracked in an internal registry.
+ *    On [close], any leases not yet revoked are revoked as a best-effort cleanup.
+ *    Revocation failures are logged as warnings and do not fail the build.
+ *
+ * ## TLS
+ *
+ * TLS certificate verification is enabled by default. See [VaultBuildServiceParams.skipVerify]
+ * for the option to disable it — but never do so in production.
+ */
+@Suppress("TooManyFunctions")
+abstract class AbstractVaultClientBuildService<P : VaultBuildServiceParams> :
+    AbstractClientBuildService<Vault, P>() {
+
+    private val logger = Logging.getLogger(AbstractVaultClientBuildService::class.java)
+
+    @Volatile
+    private var clientInitialized = false
+
+    private val leaseRegistry = CopyOnWriteArrayList<String>()
+    private var renewalExecutor: ScheduledExecutorService? = null
+
+    companion object {
+        private const val TOKEN_RENEWAL_THRESHOLD = 0.8
+    }
+
+    override fun createClient(): Vault {
+        clientInitialized = true
+
+        val configBuilder = VaultConfig()
+            .address(parameters.endpoint.get())
+
+        parameters.namespace.orNull?.let { configBuilder.nameSpace(it) }
+
+        if (parameters.skipVerify.getOrElse(false)) {
+            configBuilder.sslConfig(
+                SslConfig().verify(false).build()
+            )
+        } else {
+            parameters.caCertFile.orNull?.let { file ->
+                configBuilder.sslConfig(
+                    SslConfig()
+                        .pemFile(file.asFile)
+                        .build()
+                )
+            }
+        }
+
+        val config = configBuilder.build()
+        val vault = Vault.create(config)
+
+        authenticate(vault)
+        scheduleTokenRenewal(vault)
+
+        return vault
+    }
+
+    private fun authenticate(vault: Vault) {
+        when (parameters.credentialSource.get()) {
+            VaultCredentialSource.TOKEN -> {
+                val token = parameters.tokenRef.get().resolve()
+                val configBuilder = VaultConfig()
+                    .address(parameters.endpoint.get())
+                    .token(token)
+                parameters.namespace.orNull?.let { configBuilder.nameSpace(it) }
+            }
+            VaultCredentialSource.APP_ROLE -> {
+                val roleId = parameters.roleId.get()
+                val secretId = parameters.secretIdRef.get().resolve()
+                vault.auth().loginByAppRole(roleId, secretId)
+            }
+            VaultCredentialSource.KUBERNETES -> {
+                val role = parameters.kubernetesRole.get()
+                val jwtPath = parameters.kubernetesJwtPath.get()
+                val jwt = File(jwtPath).readText().trim()
+                vault.auth().loginByKubernetes(role, jwt)
+            }
+            VaultCredentialSource.AWS_IAM -> {
+                vault.auth().loginByAwsIam("aws", null, null, null, null)
+            }
+            VaultCredentialSource.GCP -> {
+                val jwt = parameters.jwtRef.get().resolve()
+                vault.auth().loginByGCP("gcp", jwt)
+            }
+            VaultCredentialSource.AZURE_MSI -> {
+                error("Azure Managed Identity authentication is not supported by vault-java-driver")
+            }
+        }
+    }
+
+    private fun scheduleTokenRenewal(vault: Vault) {
+        val ttlSeconds = runCatching {
+            vault.auth().lookupSelf().ttl
+        }.getOrElse {
+            logger.warn("Could not determine token TTL for renewal scheduling; token renewal disabled", it)
+            return
+        }
+
+        if (ttlSeconds <= 0) {
+            logger.info("Vault token does not expire; token renewal not scheduled")
+            return
+        }
+
+        val renewalIntervalSeconds = (ttlSeconds * TOKEN_RENEWAL_THRESHOLD).toLong()
+        val executor = Executors.newSingleThreadScheduledExecutor()
+        renewalExecutor = executor
+
+        executor.scheduleAtFixedRate(
+            {
+                runCatching { vault.auth().renewSelf() }
+                    .onFailure { logger.warn("Vault token renewal failed", it) }
+            },
+            renewalIntervalSeconds,
+            renewalIntervalSeconds,
+            TimeUnit.SECONDS,
+        )
+    }
+
+    /**
+     * Tracks a Vault lease for safety-net revocation on [close].
+     * Called internally by all credential issuance methods.
+     */
+    fun trackLease(leaseId: String) {
+        leaseRegistry.add(leaseId)
+    }
+
+    /**
+     * Revokes a Vault lease and removes it from the internal registry.
+     * Revocation failures are logged as warnings and do not throw.
+     */
+    @Suppress("DEPRECATION")
+    fun revokeLease(leaseId: String) {
+        runCatching { getClient().leases().revoke(leaseId) }
+            .onFailure { logger.warn("Failed to revoke Vault lease $leaseId", it) }
+        leaseRegistry.remove(leaseId)
+    }
+
+    /**
+     * Retrieves a single value from a KV secrets engine path.
+     *
+     * Must be called at task execution time. Configuration-time access is not supported.
+     *
+     * @param path The KV path, e.g. `secret/data/myapp` (KV v2) or `secret/myapp` (KV v1).
+     * @param key The key within the secret.
+     * @return The secret value.
+     * @throws IllegalStateException if the key does not exist at the given path.
+     */
+    fun getKvSecret(path: String, key: String): String =
+        getKvSecretMap(path)[key]
+            ?: error("Key '$key' not found at Vault path '$path'")
+
+    /**
+     * Retrieves all key-value pairs from a KV secrets engine path.
+     *
+     * Must be called at task execution time. Configuration-time access is not supported.
+     *
+     * @param path The KV path.
+     * @return A map of all key-value pairs at the path.
+     */
+    fun getKvSecretMap(path: String): Map<String, String> =
+        getClient().logical().read(path).data
+
+    /**
+     * Issues dynamic database credentials from Vault's database secrets engine.
+     *
+     * The issued lease is registered for safety-net revocation on [close]. For the
+     * tightest revocation window, use [withDatabaseCredential] instead.
+     *
+     * @param role The database role configured in Vault.
+     * @return The issued [DatabaseCredential].
+     */
+    fun issueDatabaseCredential(role: String): DatabaseCredential {
+        val response = getClient().logical().read("database/creds/$role")
+        val leaseId = response.leaseId
+        trackLease(leaseId)
+        return DatabaseCredential(
+            username = response.data.getValue("username"),
+            password = response.data.getValue("password"),
+            leaseId = leaseId,
+            leaseDuration = Duration.ofSeconds(response.leaseDuration),
+        )
+    }
+
+    /**
+     * Issues dynamic AWS credentials from Vault's AWS secrets engine.
+     *
+     * The issued lease is registered for safety-net revocation on [close]. For the
+     * tightest revocation window, use [withAwsCredential] instead.
+     *
+     * @param role The AWS role configured in Vault.
+     * @return The issued [AwsDynamicCredential].
+     */
+    fun issueAwsCredential(role: String): AwsDynamicCredential {
+        val response = getClient().logical().read("aws/creds/$role")
+        val leaseId = response.leaseId
+        trackLease(leaseId)
+        return AwsDynamicCredential(
+            accessKeyId = response.data.getValue("access_key"),
+            secretAccessKey = response.data.getValue("secret_key"),
+            sessionToken = response.data["security_token"],
+            leaseId = leaseId,
+            leaseDuration = Duration.ofSeconds(response.leaseDuration),
+        )
+    }
+
+    /**
+     * Issues dynamic GCP credentials from Vault's GCP secrets engine.
+     *
+     * The issued lease is registered for safety-net revocation on [close]. For the
+     * tightest revocation window, use [withGcpCredential] instead.
+     *
+     * @param role The GCP roleset configured in Vault.
+     * @return The issued [GcpDynamicCredential].
+     */
+    fun issueGcpCredential(role: String): GcpDynamicCredential {
+        val response = getClient().logical().read("gcp/token/$role")
+        val leaseId = response.leaseId
+        trackLease(leaseId)
+        return GcpDynamicCredential(
+            token = response.data.getValue("token"),
+            leaseId = leaseId,
+            leaseDuration = Duration.ofSeconds(response.leaseDuration),
+        )
+    }
+
+    /**
+     * Issues dynamic Azure credentials from Vault's Azure secrets engine.
+     *
+     * The issued lease is registered for safety-net revocation on [close]. For the
+     * tightest revocation window, use [withAzureCredential] instead.
+     *
+     * @param role The Azure role configured in Vault.
+     * @return The issued [AzureDynamicCredential].
+     */
+    fun issueAzureCredential(role: String): AzureDynamicCredential {
+        val response = getClient().logical().read("azure/creds/$role")
+        val leaseId = response.leaseId
+        trackLease(leaseId)
+        return AzureDynamicCredential(
+            clientId = response.data.getValue("client_id"),
+            clientSecret = response.data.getValue("client_secret"),
+            leaseId = leaseId,
+            leaseDuration = Duration.ofSeconds(response.leaseDuration),
+        )
+    }
+
+    /**
+     * Issues database credentials, executes [block] with them, then revokes the lease
+     * immediately in a `try/finally` block.
+     *
+     * This provides the tightest possible revocation window. The BuildService lease
+     * registry also tracks the lease as a safety net in case revocation fails.
+     *
+     * @param role The database role configured in Vault.
+     * @param block The block to execute with the issued credential.
+     * @return The return value of [block].
+     */
+    fun <T> withDatabaseCredential(role: String, block: (DatabaseCredential) -> T): T {
+        val credential = issueDatabaseCredential(role)
+        return try {
+            block(credential)
+        } finally {
+            revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Issues AWS credentials, executes [block] with them, then revokes the lease
+     * immediately in a `try/finally` block.
+     *
+     * @param role The AWS role configured in Vault.
+     * @param block The block to execute with the issued credential.
+     * @return The return value of [block].
+     */
+    fun <T> withAwsCredential(role: String, block: (AwsDynamicCredential) -> T): T {
+        val credential = issueAwsCredential(role)
+        return try {
+            block(credential)
+        } finally {
+            revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Issues GCP credentials, executes [block] with them, then revokes the lease
+     * immediately in a `try/finally` block.
+     *
+     * @param role The GCP roleset configured in Vault.
+     * @param block The block to execute with the issued credential.
+     * @return The return value of [block].
+     */
+    fun <T> withGcpCredential(role: String, block: (GcpDynamicCredential) -> T): T {
+        val credential = issueGcpCredential(role)
+        return try {
+            block(credential)
+        } finally {
+            revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Issues Azure credentials, executes [block] with them, then revokes the lease
+     * immediately in a `try/finally` block.
+     *
+     * @param role The Azure role configured in Vault.
+     * @param block The block to execute with the issued credential.
+     * @return The return value of [block].
+     */
+    fun <T> withAzureCredential(role: String, block: (AzureDynamicCredential) -> T): T {
+        val credential = issueAzureCredential(role)
+        return try {
+            block(credential)
+        } finally {
+            revokeLease(credential.leaseId)
+        }
+    }
+
+    /**
+     * Cancels token renewal, revokes all tracked leases, and closes the Vault client.
+     *
+     * Lease revocation is best-effort — individual failures are logged as warnings
+     * and do not prevent cleanup of remaining leases or the client.
+     */
+    @Suppress("DEPRECATION")
+    override fun close() {
+        if (clientInitialized) {
+            renewalExecutor?.shutdownNow()
+            for (leaseId in leaseRegistry) {
+                runCatching { getClient().leases().revoke(leaseId) }
+                    .onFailure { logger.warn("Failed to revoke Vault lease $leaseId during cleanup", it) }
+            }
+        }
+        super.close()
+    }
+}
+

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AwsDynamicCredential.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AwsDynamicCredential.kt
@@ -1,0 +1,20 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import java.time.Duration
+
+/**
+ * Dynamic AWS credentials issued by Vault's AWS secrets engine.
+ *
+ * @property accessKeyId The AWS access key ID.
+ * @property secretAccessKey The AWS secret access key.
+ * @property sessionToken The AWS session token, present for STS-based credentials.
+ * @property leaseId The Vault lease ID. Used to renew or revoke this credential.
+ * @property leaseDuration The duration for which this credential is valid.
+ */
+data class AwsDynamicCredential(
+    val accessKeyId: String,
+    val secretAccessKey: String,
+    val sessionToken: String?,
+    val leaseId: String,
+    val leaseDuration: Duration,
+)

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AzureDynamicCredential.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/AzureDynamicCredential.kt
@@ -1,0 +1,18 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import java.time.Duration
+
+/**
+ * Dynamic Azure credentials issued by Vault's Azure secrets engine.
+ *
+ * @property clientId The Azure client ID.
+ * @property clientSecret The Azure client secret.
+ * @property leaseId The Vault lease ID. Used to renew or revoke this credential.
+ * @property leaseDuration The duration for which this credential is valid.
+ */
+data class AzureDynamicCredential(
+    val clientId: String,
+    val clientSecret: String,
+    val leaseId: String,
+    val leaseDuration: Duration,
+)

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/DatabaseCredential.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/DatabaseCredential.kt
@@ -1,0 +1,18 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import java.time.Duration
+
+/**
+ * Dynamic database credentials issued by Vault's database secrets engine.
+ *
+ * @property username The database username.
+ * @property password The database password.
+ * @property leaseId The Vault lease ID. Used to renew or revoke this credential.
+ * @property leaseDuration The duration for which this credential is valid.
+ */
+data class DatabaseCredential(
+    val username: String,
+    val password: String,
+    val leaseId: String,
+    val leaseDuration: Duration,
+)

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/GcpDynamicCredential.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/GcpDynamicCredential.kt
@@ -1,0 +1,16 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import java.time.Duration
+
+/**
+ * Dynamic GCP credentials issued by Vault's GCP secrets engine.
+ *
+ * @property token The OAuth2 access token or service account key.
+ * @property leaseId The Vault lease ID. Used to renew or revoke this credential.
+ * @property leaseDuration The duration for which this credential is valid.
+ */
+data class GcpDynamicCredential(
+    val token: String,
+    val leaseId: String,
+    val leaseDuration: Duration,
+)

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParams.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParams.kt
@@ -1,0 +1,79 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import com.kelvsyc.gradle.clients.CredentialReference
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildServiceParameters
+
+/**
+ * Parameters for configuring a HashiCorp Vault build service.
+ *
+ * Sensitive credential fields use [CredentialReference] — only the lookup key
+ * (environment variable name or system property name) is serialized to the
+ * Gradle configuration cache, never the actual credential value.
+ *
+ * Non-sensitive fields (endpoint, namespace, role IDs, paths) are plain [Property] values.
+ */
+interface VaultBuildServiceParams : BuildServiceParameters {
+    /** The Vault server endpoint, e.g. `https://vault.example.com:8200`. */
+    val endpoint: Property<String>
+
+    /**
+     * The Vault namespace (Vault Enterprise only). Leave unset for open-source Vault.
+     */
+    val namespace: Property<String>
+
+    /**
+     * A CA certificate file for TLS verification. If unset, the JVM's default trust store is used.
+     */
+    val caCertFile: RegularFileProperty
+
+    /**
+     * Disables TLS certificate verification.
+     *
+     * **WARNING:** Never set this to `true` in production. It makes connections vulnerable
+     * to man-in-the-middle attacks. Only use in controlled internal environments with
+     * self-signed certificates.
+     */
+    val skipVerify: Property<Boolean>
+
+    /** The authentication method to use when connecting to Vault. */
+    val credentialSource: Property<VaultCredentialSource>
+
+    /**
+     * A reference to the Vault token for [VaultCredentialSource.TOKEN] authentication.
+     * Resolved at build execution time — never stored as a plaintext value.
+     */
+    val tokenRef: Property<CredentialReference>
+
+    /**
+     * The AppRole role ID for [VaultCredentialSource.APP_ROLE] authentication.
+     * The role ID is non-sensitive and may appear in task snapshots.
+     */
+    val roleId: Property<String>
+
+    /**
+     * A reference to the AppRole secret ID for [VaultCredentialSource.APP_ROLE] authentication.
+     * Resolved at build execution time — never stored as a plaintext value.
+     */
+    val secretIdRef: Property<CredentialReference>
+
+    /**
+     * A reference to the JWT for [VaultCredentialSource.APP_ROLE] JWT or cloud IAM authentication.
+     * Resolved at build execution time — never stored as a plaintext value.
+     */
+    val jwtRef: Property<CredentialReference>
+
+    /**
+     * The Kubernetes auth role name for [VaultCredentialSource.KUBERNETES] authentication.
+     * The role name is non-sensitive.
+     */
+    val kubernetesRole: Property<String>
+
+    /**
+     * The filesystem path to the Kubernetes service account JWT file.
+     * Defaults to the standard in-cluster path. The path itself is non-sensitive;
+     * the file content is read at build execution time.
+     */
+    val kubernetesJwtPath: Property<String>
+}

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParams.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParams.kt
@@ -59,7 +59,7 @@ interface VaultBuildServiceParams : BuildServiceParameters {
     val secretIdRef: Property<CredentialReference>
 
     /**
-     * A reference to the JWT for [VaultCredentialSource.APP_ROLE] JWT or cloud IAM authentication.
+     * A reference to the JWT for [VaultCredentialSource.GCP] authentication.
      * Resolved at build execution time — never stored as a plaintext value.
      */
     val jwtRef: Property<CredentialReference>

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParamsExtensions.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParamsExtensions.kt
@@ -62,8 +62,13 @@ fun VaultBuildServiceParams.gcpAuth() {
 }
 
 /**
- * Configures Azure Managed Identity authentication. Vault will verify the caller's
- * Azure identity using the managed identity available in the environment.
+ * Configures Azure Managed Identity authentication.
+ *
+ * **Note:** Azure Managed Identity authentication is not currently supported by
+ * the underlying vault-java-driver client. Calling this method will register
+ * [VaultCredentialSource.AZURE_MSI] as the credential source, but attempting
+ * to create a Vault client will throw an [UnsupportedOperationException] at
+ * build execution time.
  */
 fun VaultBuildServiceParams.azureMsiAuth() {
     credentialSource.set(VaultCredentialSource.AZURE_MSI)

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParamsExtensions.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParamsExtensions.kt
@@ -1,0 +1,70 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+import com.kelvsyc.gradle.clients.CredentialReference
+
+/**
+ * Configures token-based authentication using a pre-issued Vault token.
+ *
+ * @param token A reference to the Vault token. Defaults to the `VAULT_TOKEN` environment variable.
+ */
+fun VaultBuildServiceParams.tokenAuth(
+    token: CredentialReference = CredentialReference.EnvironmentVariable("VAULT_TOKEN"),
+) {
+    credentialSource.set(VaultCredentialSource.TOKEN)
+    tokenRef.set(token)
+}
+
+/**
+ * Configures AppRole authentication.
+ *
+ * @param roleId The AppRole role ID (non-sensitive).
+ * @param secretId A reference to the AppRole secret ID. Defaults to the `VAULT_SECRET_ID` environment variable.
+ */
+fun VaultBuildServiceParams.appRoleAuth(
+    roleId: String,
+    secretId: CredentialReference = CredentialReference.EnvironmentVariable("VAULT_SECRET_ID"),
+) {
+    credentialSource.set(VaultCredentialSource.APP_ROLE)
+    this.roleId.set(roleId)
+    secretIdRef.set(secretId)
+}
+
+/**
+ * Configures Kubernetes service account authentication.
+ *
+ * @param role The Kubernetes auth role name configured in Vault.
+ * @param jwtPath Path to the Kubernetes service account JWT file.
+ *   Defaults to the standard in-cluster path `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+ */
+fun VaultBuildServiceParams.kubernetesAuth(
+    role: String,
+    jwtPath: String = "/var/run/secrets/kubernetes.io/serviceaccount/token",
+) {
+    credentialSource.set(VaultCredentialSource.KUBERNETES)
+    kubernetesRole.set(role)
+    kubernetesJwtPath.set(jwtPath)
+}
+
+/**
+ * Configures AWS IAM authentication. Vault will verify the caller's AWS identity
+ * using the IAM credentials available in the environment.
+ */
+fun VaultBuildServiceParams.awsIamAuth() {
+    credentialSource.set(VaultCredentialSource.AWS_IAM)
+}
+
+/**
+ * Configures Google Cloud service account authentication. Vault will verify the
+ * caller's GCP identity using the credentials available in the environment.
+ */
+fun VaultBuildServiceParams.gcpAuth() {
+    credentialSource.set(VaultCredentialSource.GCP)
+}
+
+/**
+ * Configures Azure Managed Identity authentication. Vault will verify the caller's
+ * Azure identity using the managed identity available in the environment.
+ */
+fun VaultBuildServiceParams.azureMsiAuth() {
+    credentialSource.set(VaultCredentialSource.AZURE_MSI)
+}

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParamsExtensions.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultBuildServiceParamsExtensions.kt
@@ -56,9 +56,14 @@ fun VaultBuildServiceParams.awsIamAuth() {
 /**
  * Configures Google Cloud service account authentication. Vault will verify the
  * caller's GCP identity using the credentials available in the environment.
+ *
+ * @param jwt A reference to the GCP JWT. Defaults to the `GOOGLE_OAUTH2_TOKEN` environment variable.
  */
-fun VaultBuildServiceParams.gcpAuth() {
+fun VaultBuildServiceParams.gcpAuth(
+    jwt: CredentialReference = CredentialReference.EnvironmentVariable("GOOGLE_OAUTH2_TOKEN"),
+) {
     credentialSource.set(VaultCredentialSource.GCP)
+    jwtRef.set(jwt)
 }
 
 /**

--- a/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultCredentialSource.kt
+++ b/cores/hashicorp-vault-extensions/src/main/kotlin/com/kelvsyc/gradle/hashicorp/vault/VaultCredentialSource.kt
@@ -1,0 +1,19 @@
+package com.kelvsyc.gradle.hashicorp.vault
+
+/**
+ * The authentication method used to authenticate to HashiCorp Vault.
+ */
+enum class VaultCredentialSource {
+    /** Authenticate using a pre-issued Vault token. */
+    TOKEN,
+    /** Authenticate using AppRole (role ID + secret ID). */
+    APP_ROLE,
+    /** Authenticate using AWS IAM credentials. */
+    AWS_IAM,
+    /** Authenticate using Google Cloud service account credentials. */
+    GCP,
+    /** Authenticate using Azure Managed Identity. */
+    AZURE_MSI,
+    /** Authenticate using a Kubernetes service account JWT. */
+    KUBERNETES,
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -110,6 +110,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp" } # version from BOM 'okhttp-b
 retrofit = { module = "com.squareup.retrofit2:retrofit" } # version from BOM 'retrofit-bom'
 retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi" } # version from BOM 'retrofit-bom'
 sqlite-jdbc = "org.xerial:sqlite-jdbc:3.53.1.0"
+vault-java-driver = { module = "io.github.jopenlibs:vault-java-driver", version = "6.2.1" }
 woodstox = "com.fasterxml.woodstox:woodstox-core:7.1.1"
 
 [plugins]

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
         api(libs.moshi)
         api(libs.moshi.kotlin)
         api(libs.pkl.core)
+        api(libs.vault.java.driver)
         api(libs.woodstox)
     }
 }


### PR DESCRIPTION
## Summary

- Adds `hashicorp-vault-extensions`: config-cache-safe BuildService infrastructure for HashiCorp Vault, including `AbstractVaultClientBuildService` with automatic token renewal, thread-safe lease tracking, KV secret access methods, dynamic credential issuance (database, AWS, GCP, Azure), and `with*Credential` scoped helpers with `try/finally` revocation.
- Adds `hashicorp-vault-base`: concrete `VaultClientBuildService`, KV WorkActions (`WriteKvSecretAction`, `DeleteKvSecretAction`), four abstract dynamic credential WorkActions with `final execute()` and dual-layer lease revocation, and `RevokeLeaseAction` for explicit lease control.
- Both components build on `CredentialReference` from `clients-base` (PR #560): sensitive auth fields use `Property<CredentialReference>` so only lookup keys (env var names) are serialized to the configuration cache, never credential values.
- Configuration-time credential access is explicitly unsupported by design; all credential retrieval occurs at task execution time.
- Adds `io.github.jopenlibs:vault-java-driver:6.2.1` to the version catalog and platform BOM.

## Test Plan

- [ ] `./gradlew :hashicorp-vault-extensions:build` passes
- [ ] `./gradlew :hashicorp-vault-base:build` passes
- [ ] `./gradlew :hashicorp-vault-extensions:detekt` passes
- [ ] `./gradlew :hashicorp-vault-base:detekt` passes
- [ ] `./gradlew :build` passes (aggregation picks up both components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)