### PR TITLE
security: migrate git-core token fields to CredentialReference

### DIFF
--- a/cores/git-core/README.md
+++ b/cores/git-core/README.md
@@ -125,7 +125,7 @@ tasks.register<GetGitHubRepoArchive>("fetchSource") {
     owner.set("example")
     repo.set("my-repo")
     ref.set("v2.0.0")
-    token.set(providers.environmentVariable("GITHUB_TOKEN"))
+    tokenRef.set(CredentialReference.EnvironmentVariable("GITHUB_TOKEN"))
     outputFile.set(layout.buildDirectory.file("source.tar.gz"))
 }
 ```
@@ -134,7 +134,7 @@ tasks.register<GetGitHubRepoArchive>("fetchSource") {
 |---|---|---|
 | `ghCommand` | `Property<String>` | Path to the `gh` binary. Set via convention when plugin is applied. |
 | `hostname` | `Property<String>` | GitHub Enterprise hostname. Leave unset for GitHub.com. |
-| `token` | `Property<String>` | Personal access token (`GH_TOKEN` or `GH_ENTERPRISE_TOKEN`). |
+| `tokenRef` | `Property<CredentialReference>` | Reference to the personal access token (`GH_TOKEN` or `GH_ENTERPRISE_TOKEN`). Leave unset to use CLI-configured credentials. |
 | `owner` | `Property<String>` | Repository owner |
 | `repo` | `Property<String>` | Repository name |
 | `ref` | `Property<String>` | Commit ref to archive |
@@ -192,7 +192,7 @@ tasks.register<GetGitLabRepoArchive>("fetchSource") {
     owner.set("example-group")
     repo.set("my-project")
     ref.set("v2.0.0")
-    token.set(providers.environmentVariable("GITLAB_TOKEN"))
+    tokenRef.set(CredentialReference.EnvironmentVariable("GITLAB_TOKEN"))
     outputFile.set(layout.buildDirectory.file("source.tar.gz"))
 }
 ```
@@ -201,7 +201,7 @@ tasks.register<GetGitLabRepoArchive>("fetchSource") {
 |---|---|---|
 | `glabCommand` | `Property<String>` | Path to the `glab` binary. Set via convention when plugin is applied. |
 | `hostname` | `Property<String>` | Self-hosted GitLab hostname. Leave unset for GitLab.com. |
-| `token` | `Property<String>` | Personal access token (`GITLAB_TOKEN`). |
+| `tokenRef` | `Property<CredentialReference>` | Reference to the personal access token (`GITLAB_TOKEN`). Leave unset to use CLI-configured credentials. |
 | `owner` | `Property<String>` | Namespace or group owning the repository |
 | `repo` | `Property<String>` | Repository name |
 | `ref` | `Property<String>` | Commit ref to archive |

--- a/cores/git-core/build.gradle.kts
+++ b/cores/git-core/build.gradle.kts
@@ -19,6 +19,7 @@ gradlePlugin {
 }
 
 dependencies {
+    api("com.kelvsyc.gradle:clients-base")
     api(libs.jgit)
 
     testImplementation(libs.mockk)

--- a/cores/git-core/settings.gradle.kts
+++ b/cores/git-core/settings.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     id("com.kelvsyc.internal")
 }
 
+includeBuild("../clients-base")
 includeBuild("../gradle-extensions")

--- a/cores/git-core/src/main/kotlin/com/kelvsyc/gradle/github/GetGitHubRepoArchive.kt
+++ b/cores/git-core/src/main/kotlin/com/kelvsyc/gradle/github/GetGitHubRepoArchive.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.github
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.github.actions.GitHubRepoArchiveAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -39,12 +40,14 @@ abstract class GetGitHubRepoArchive @Inject constructor(private val workers: Wor
     abstract val hostname: Property<String>
 
     /**
-     * The GitHub personal access token.
+     * A reference to the GitHub personal access token. Leave unset to use the CLI's configured credentials.
+     * Set to a [CredentialReference.EnvironmentVariable] or [CredentialReference.SystemProperty] pointing to
+     * the token — only the lookup name is serialized to the configuration cache, never the token value itself.
      *
      * @see [GitHubRepoArchiveAction.Parameters.token]
      */
     @get:Internal
-    abstract val token: Property<String>
+    abstract val tokenRef: Property<CredentialReference>
 
     /**
      * The owner of the repository.
@@ -86,7 +89,7 @@ abstract class GetGitHubRepoArchive @Inject constructor(private val workers: Wor
         queue.submit(GitHubRepoArchiveAction::class) {
             ghCommand.set(this@GetGitHubRepoArchive.ghCommand)
             hostname.set(this@GetGitHubRepoArchive.hostname)
-            token.set(this@GetGitHubRepoArchive.token)
+            this@GetGitHubRepoArchive.tokenRef.orNull?.let { token.set(it.resolve()) }
             owner.set(this@GetGitHubRepoArchive.owner)
             repo.set(this@GetGitHubRepoArchive.repo)
             ref.set(this@GetGitHubRepoArchive.ref)

--- a/cores/git-core/src/main/kotlin/com/kelvsyc/gradle/gitlab/GetGitLabRepoArchive.kt
+++ b/cores/git-core/src/main/kotlin/com/kelvsyc/gradle/gitlab/GetGitLabRepoArchive.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.gitlab
 
+import com.kelvsyc.gradle.clients.CredentialReference
 import com.kelvsyc.gradle.gitlab.actions.GitLabRepoArchiveAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -39,12 +40,14 @@ abstract class GetGitLabRepoArchive @Inject constructor(private val workers: Wor
     abstract val hostname: Property<String>
 
     /**
-     * The GitLab personal access token.
+     * A reference to the GitLab personal access token. Leave unset to use the CLI's configured credentials.
+     * Set to a [CredentialReference.EnvironmentVariable] or [CredentialReference.SystemProperty] pointing to
+     * the token — only the lookup name is serialized to the configuration cache, never the token value itself.
      *
      * @see [GitLabRepoArchiveAction.Parameters.token]
      */
     @get:Internal
-    abstract val token: Property<String>
+    abstract val tokenRef: Property<CredentialReference>
 
     /**
      * The namespace or group owning the repository.
@@ -86,7 +89,7 @@ abstract class GetGitLabRepoArchive @Inject constructor(private val workers: Wor
         queue.submit(GitLabRepoArchiveAction::class) {
             glabCommand.set(this@GetGitLabRepoArchive.glabCommand)
             hostname.set(this@GetGitLabRepoArchive.hostname)
-            token.set(this@GetGitLabRepoArchive.token)
+            this@GetGitLabRepoArchive.tokenRef.orNull?.let { token.set(it.resolve()) }
             owner.set(this@GetGitLabRepoArchive.owner)
             repo.set(this@GetGitLabRepoArchive.repo)
             ref.set(this@GetGitLabRepoArchive.ref)


### PR DESCRIPTION
## Summary

- Adds `clients-base` as an `api` dependency of `git-core`.
- Renames `token: Property<String>` → `tokenRef: Property<CredentialReference>` on `GetGitHubRepoArchive` and `GetGitLabRepoArchive`, caught during a post-#563 audit of remaining `@get:Internal Property<String>` credential fields on `DefaultTask` subclasses.
- `WorkAction.Parameters.token` fields in `GitHubRepoArchiveAction` and `GitLabRepoArchiveAction` remain `Property<String>` — they are populated at task-execution time and are never serialized to the configuration cache.
- Updates README examples and property tables accordingly.

## Test plan

- [x] `./gradlew :git-core:test` — all tests pass
- [x] `./gradlew :git-core:detekt` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)