### PR TITLE
feat: execution-time credential WorkActions for ECR, CodeArtifact, Azure, and STS

### DIFF
--- a/cores/aws-codeartifact-java-base/README.md
+++ b/cores/aws-codeartifact-java-base/README.md
@@ -122,6 +122,31 @@ Parameters: `service`, `domain`, `domainOwner`, `repository`, `namespace`, `pack
 
 ## WorkActions
 
+### `AbstractGetAuthorizationTokenWorkAction`
+
+Retrieves a CodeArtifact authorization token inside a `WorkAction`, keeping the token out of the
+Gradle configuration cache. Subclass and implement `doExecute` to use the token:
+
+```kotlin
+abstract class PublishAction : AbstractGetAuthorizationTokenWorkAction() {
+    override fun doExecute(token: String) {
+        // use token for Maven/npm/pip repository authentication
+    }
+}
+
+workerExecutor.noIsolation().submit(PublishAction::class) {
+    service.set(codeartifact)
+    domain.set("my-domain")
+    domainOwner.set("123456789012")
+    duration.set(3600L)
+}
+```
+
+Token validity is configurable up to 43200 seconds (12 hours). There is no explicit revocation
+API — `doExecute` provides the correct execution-time scope. The token must not escape `doExecute`:
+storing it in a WorkParameters property (even `@get:Internal`), a task input, or a shared file
+writes it to `.gradle/configuration-cache/` in plaintext.
+
 ### `GetGenericPackageVersionAssetAction`
 
 Downloads a single CodeArtifact generic-repo asset to a file:

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractGetAuthorizationTokenWorkAction.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractGetAuthorizationTokenWorkAction.kt
@@ -1,0 +1,91 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
+
+/**
+ * Abstract base [WorkAction] that retrieves a CodeArtifact authorization token at task execution
+ * time and passes it to [doExecute], keeping the token out of the Gradle configuration cache.
+ *
+ * The token is obtained inside [execute], which is marked `final` to ensure it always runs at task
+ * execution time.
+ *
+ * ## Token lifecycle
+ *
+ * CodeArtifact authorization tokens are valid for the duration specified by [Parameters.duration]
+ * (up to 43200 seconds / 12 hours). There is **no explicit revocation API** — the token
+ * self-expires at the end of the configured duration, regardless of whether [doExecute] returns
+ * normally or throws. This is unlike Vault dynamic credentials, which carry a lease that can be
+ * explicitly revoked in a `finally` block. [doExecute] therefore provides the correct and complete
+ * execution-time scope for this token.
+ *
+ * ## Configuration cache safety
+ *
+ * Do not let the token escape [doExecute]. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * Subclass and implement [doExecute] to use the token:
+ *
+ * ```kotlin
+ * abstract class PublishAction : AbstractGetAuthorizationTokenWorkAction() {
+ *     override fun doExecute(token: String) {
+ *         // use token for Maven/npm/pip repository authentication
+ *     }
+ * }
+ * ```
+ */
+abstract class AbstractGetAuthorizationTokenWorkAction :
+    WorkAction<AbstractGetAuthorizationTokenWorkAction.Parameters> {
+
+    /**
+     * Parameters for [AbstractGetAuthorizationTokenWorkAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the CodeArtifact client.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<CodeArtifactClientBuildService>
+
+        /** The CodeArtifact domain name. */
+        val domain: Property<String>
+
+        /** The 12-digit AWS account ID of the domain owner. */
+        val domainOwner: Property<String>
+
+        /**
+         * The token validity duration in seconds. Maximum is 43200 (12 hours).
+         *
+         * @see GetAuthorizationTokenRequest.durationSeconds
+         */
+        val duration: Property<Long>
+    }
+
+    final override fun execute() {
+        val request = GetAuthorizationTokenRequest.builder()
+            .domain(parameters.domain.get())
+            .domainOwner(parameters.domainOwner.get())
+            .durationSeconds(parameters.duration.get())
+            .build()
+        val token = parameters.service.get().getClient().getAuthorizationToken(request).authorizationToken()
+        doExecute(token)
+    }
+
+    /**
+     * Executes work using the retrieved authorization [token].
+     *
+     * Called at task execution time with a valid CodeArtifact token. The token self-expires after
+     * the configured [Parameters.duration] — there is no explicit revocation API.
+     *
+     * @param token The CodeArtifact authorization token.
+     */
+    protected abstract fun doExecute(token: String)
+}

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractGetAuthorizationTokenWorkActionSpec.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractGetAuthorizationTokenWorkActionSpec.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.codeartifact.CodeartifactClient
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenResponse
+
+class AbstractGetAuthorizationTokenWorkActionSpec : FunSpec() {
+    init {
+        test("execute - passes domain, domainOwner, duration to request and calls doExecute with token") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("codeartifact", MockCodeArtifactClientBuildService::class)
+
+            val requestSlot = slot<GetAuthorizationTokenRequest>()
+            val response = mockk<GetAuthorizationTokenResponse>()
+            every { response.authorizationToken() } returns "my-token"
+            every { client.getAuthorizationToken(capture(requestSlot)) } returns response
+
+            val params = project.objects.newInstance<AbstractGetAuthorizationTokenWorkAction.Parameters>()
+            params.service.set(service)
+            params.domain.set("my-domain")
+            params.domainOwner.set("123456789012")
+            params.duration.set(3600L)
+
+            var capturedToken: String? = null
+            val action = object : AbstractGetAuthorizationTokenWorkAction() {
+                override fun getParameters() = params
+                override fun doExecute(token: String) {
+                    capturedToken = token
+                }
+            }
+            action.execute()
+
+            val captured = requestSlot.captured
+            captured.domain() shouldBe "my-domain"
+            captured.domainOwner() shouldBe "123456789012"
+            captured.durationSeconds() shouldBe 3600L
+            capturedToken shouldBe "my-token"
+        }
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/README.md
+++ b/cores/aws-codeartifact-kotlin-base/README.md
@@ -62,7 +62,7 @@ Retrieves an AWS CodeArtifact authorization token.
 
 CodeArtifact tokens are valid for up to 12 hours (configurable via `--duration-seconds`). The threat model of the pre-generation pattern is equivalent to the CI environment variable attack surface — no new exposure.
 
-**Task-execution use cases**: use the `CodeArtifactClientBuildService` client directly inside a `WorkAction.execute()` body instead. The `ValueSource` abstraction adds no value there.
+**Task-execution use cases**: use the `AbstractGetAuthorizationTokenWorkAction` WorkAction or call the `CodeArtifactClientBuildService` client directly inside a `WorkAction.execute()` body. The `ValueSource` abstraction adds no value for task execution.
 
 Parameters:
 
@@ -122,6 +122,44 @@ val versions: Provider<List<String>> = providers.of(ListPackageVersionsValueSour
     }
 }
 ```
+
+## WorkAction: `AbstractGetAuthorizationTokenWorkAction`
+
+Abstract base class for WorkActions that retrieve a CodeArtifact authorization token and execute
+work with it, keeping the token out of the Gradle configuration cache.
+
+> **Configuration cache safe.** The token is retrieved at task execution time and passed to
+> [doExecute], which executes immediately. The token is never stored in the configuration cache.
+
+Extend this class and implement `doExecute(token: String)`:
+
+```kotlin
+abstract class PublishArtifactAction : AbstractGetAuthorizationTokenWorkAction() {
+    override fun doExecute(token: String) {
+        // use token for CodeArtifact authentication
+    }
+}
+
+tasks.register<DefaultTask>("publish") {
+    doLast {
+        workerExecutor.noIsolation().submit(PublishArtifactAction::class) {
+            service.set(codeArtifact)
+            domain.set("my-domain")
+            domainOwner.set("111122223333")
+            duration.set(3600L)
+        }
+    }
+}
+```
+
+Parameters:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CodeArtifactClientBuildService>` | Build service supplying the CodeArtifact client |
+| `domain` | `Property<String>` | CodeArtifact domain name |
+| `domainOwner` | `Property<String>` | AWS account ID owning the domain |
+| `duration` | `Property<Long>` | Token validity in seconds (900 to 43200) |
 
 ## WorkAction: `GetGenericPackageVersionAssetAction`
 

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetAuthorizationTokenWorkAction.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetAuthorizationTokenWorkAction.kt
@@ -1,0 +1,94 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import aws.sdk.kotlin.services.codeartifact.model.GetAuthorizationTokenRequest
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that retrieves a CodeArtifact authorization token and executes work
+ * with it, keeping the token out of the Gradle configuration cache.
+ *
+ * ## Token lifecycle
+ *
+ * CodeArtifact authorization tokens are valid for up to 12 hours and have no explicit revocation
+ * API. Unlike Vault's dynamic credentials (which support immediate lease revocation), CodeArtifact
+ * tokens expire passively. The token returned by this action should be used immediately within
+ * [doExecute] and not cached or persisted.
+ *
+ * ## Configuration cache safety
+ *
+ * Do not let the token escape [doExecute]. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * Subclass this action and implement [doExecute] to use the token:
+ *
+ * ```kotlin
+ * abstract class PublishArtifactAction : AbstractGetAuthorizationTokenWorkAction() {
+ *     override fun doExecute(token: String) {
+ *         // token is the authorization token suitable for CodeArtifact repository authentication
+ *     }
+ * }
+ * ```
+ */
+abstract class AbstractGetAuthorizationTokenWorkAction :
+    WorkAction<AbstractGetAuthorizationTokenWorkAction.Parameters> {
+
+    /**
+     * Parameters for [AbstractGetAuthorizationTokenWorkAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The CodeArtifact build service used to retrieve the authorization token.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<CodeArtifactClientBuildService>
+
+        /**
+         * The CodeArtifact domain name.
+         */
+        val domain: Property<String>
+
+        /**
+         * The 12-digit account number of the domain owner.
+         */
+        val domainOwner: Property<String>
+
+        /**
+         * The time, in seconds, that the authorization token is valid.
+         *
+         * Valid range is 900 to 43200 seconds (15 minutes to 12 hours).
+         */
+        val duration: Property<Long>
+    }
+
+    final override fun execute() {
+        val request = GetAuthorizationTokenRequest {
+            domain = parameters.domain.get()
+            domainOwner = parameters.domainOwner.get()
+            durationSeconds = parameters.duration.get()
+        }
+        val token = runBlocking {
+            parameters.service.get().getClient().getAuthorizationToken(request).authorizationToken
+        } ?: error("No authorization token returned from CodeArtifact")
+        doExecute(token)
+    }
+
+    /**
+     * Executes work using the retrieved [token].
+     *
+     * Called immediately after the token is retrieved. The token is valid for up to 12 hours
+     * and will be used within this method's execution context.
+     *
+     * @param token The authorization token suitable for use with CodeArtifact repository
+     *   authentication. This is not cached and is execution-time-only.
+     */
+    protected abstract fun doExecute(token: String)
+}

--- a/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetAuthorizationTokenWorkActionSpec.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractGetAuthorizationTokenWorkActionSpec.kt
@@ -1,0 +1,90 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import aws.sdk.kotlin.services.codeartifact.CodeartifactClient
+import aws.sdk.kotlin.services.codeartifact.model.GetAuthorizationTokenRequest
+import aws.sdk.kotlin.services.codeartifact.model.GetAuthorizationTokenResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class AbstractGetAuthorizationTokenWorkActionSpec : FunSpec() {
+    init {
+        test("execute - retrieves and passes token to doExecute") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "ca",
+                MockCodeArtifactClientBuildService::class
+            )
+
+            val requestSlot = slot<GetAuthorizationTokenRequest>()
+            val response = mockk<GetAuthorizationTokenResponse>()
+            coEvery { response.authorizationToken } returns "my-token"
+            coEvery { client.getAuthorizationToken(capture(requestSlot)) } returns response
+
+            var capturedToken: String? = null
+            val action = object : AbstractGetAuthorizationTokenWorkAction() {
+                override fun getParameters(): Parameters = run {
+                    val params = project.objects.newInstance<Parameters>()
+                    params.service.set(service)
+                    params.domain.set("my-domain")
+                    params.domainOwner.set("123456789012")
+                    params.duration.set(3600L)
+                    params
+                }
+
+                override fun doExecute(token: String) {
+                    capturedToken = token
+                }
+            }
+            action.execute()
+
+            capturedToken shouldBe "my-token"
+            requestSlot.captured.domain shouldBe "my-domain"
+            requestSlot.captured.domainOwner shouldBe "123456789012"
+            requestSlot.captured.durationSeconds shouldBe 3600L
+        }
+
+        test("execute - throws when authorizationToken is null") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "ca",
+                MockCodeArtifactClientBuildService::class
+            )
+
+            val response = mockk<GetAuthorizationTokenResponse>()
+            coEvery { response.authorizationToken } returns null
+            coEvery { client.getAuthorizationToken(any()) } returns response
+
+            val action = object : AbstractGetAuthorizationTokenWorkAction() {
+                override fun getParameters(): Parameters = run {
+                    val params = project.objects.newInstance<Parameters>()
+                    params.service.set(service)
+                    params.domain.set("my-domain")
+                    params.domainOwner.set("123456789012")
+                    params.duration.set(3600L)
+                    params
+                }
+
+                override fun doExecute(token: String) {
+                    /* test hook, do nothing */
+                }
+            }
+
+            shouldThrow<IllegalStateException> {
+                action.execute()
+            }
+        }
+    }
+}

--- a/cores/aws-ecr-java-base/README.md
+++ b/cores/aws-ecr-java-base/README.md
@@ -75,6 +75,29 @@ val repos: Provider<Map<String, String>> = providers.of(DescribeRepositoriesValu
 }
 ```
 
+## WorkAction: `AbstractGetAuthorizationTokenWorkAction`
+
+Retrieves an ECR authorization token inside a `WorkAction`, keeping the token out of the Gradle
+configuration cache. Subclass and implement `doExecute` to use the token:
+
+```kotlin
+abstract class DockerLoginAction : AbstractGetAuthorizationTokenWorkAction() {
+    override fun doExecute(token: String) {
+        // token is the base64-encoded "AWS:password" string suitable for docker login
+    }
+}
+
+// Submit:
+workerExecutor.noIsolation().submit(DockerLoginAction::class) {
+    service.set(ecr)
+}
+```
+
+ECR tokens are valid for up to 12 hours and have no explicit revocation API — `doExecute` provides
+the correct execution-time scope. The token must not escape `doExecute`: storing it in a
+WorkParameters property (even `@get:Internal`), a task input, or a shared file writes it to
+`.gradle/configuration-cache/` in plaintext.
+
 ## WorkAction: `BatchDeleteImageAction`
 
 Deletes a set of images by tag from an ECR repository:

--- a/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/AbstractGetAuthorizationTokenWorkAction.kt
+++ b/cores/aws-ecr-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/ecr/AbstractGetAuthorizationTokenWorkAction.kt
@@ -1,0 +1,70 @@
+package com.kelvsyc.gradle.aws.java.ecr
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest
+
+/**
+ * Abstract base [WorkAction] that retrieves an ECR authorization token and executes work with it,
+ * keeping the token out of the Gradle configuration cache.
+ *
+ * ## Token lifecycle
+ *
+ * ECR authorization tokens are valid for up to 12 hours and have no explicit revocation API.
+ * Unlike Vault's dynamic credentials (which support immediate lease revocation), ECR tokens
+ * expire passively. The token returned by this action should be used immediately within
+ * [doExecute] and not cached or persisted.
+ *
+ * ## Configuration cache safety
+ *
+ * Do not let the token escape [doExecute]. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * Subclass this action and implement [doExecute] to use the token:
+ *
+ * ```kotlin
+ * abstract class DockerLoginAction : AbstractGetAuthorizationTokenWorkAction() {
+ *     override fun doExecute(token: String) {
+ *         // token is the base64-encoded "AWS:password" string suitable for docker login
+ *     }
+ * }
+ * ```
+ */
+abstract class AbstractGetAuthorizationTokenWorkAction :
+    WorkAction<AbstractGetAuthorizationTokenWorkAction.Parameters> {
+
+    /** Parameters for [AbstractGetAuthorizationTokenWorkAction]. */
+    interface Parameters : WorkParameters {
+        /**
+         * The ECR build service used to retrieve the authorization token.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<EcrClientBuildService>
+    }
+
+    final override fun execute() {
+        val token = parameters.service.get().getClient()
+            .getAuthorizationToken(GetAuthorizationTokenRequest.builder().build())
+            .authorizationData().first().authorizationToken()
+        doExecute(token)
+    }
+
+    /**
+     * Executes work using the retrieved [token].
+     *
+     * Called immediately after the token is retrieved. The token is valid for up to 12 hours
+     * and will be used within this method's execution context.
+     *
+     * @param token The base64-encoded authorization token in the format "AWS:password", suitable
+     *   for use with `docker login` or repository authentication. This is not cached and is
+     *   execution-time-only.
+     */
+    protected abstract fun doExecute(token: String)
+}

--- a/cores/aws-ecr-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/ecr/AbstractGetAuthorizationTokenWorkActionSpec.kt
+++ b/cores/aws-ecr-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/ecr/AbstractGetAuthorizationTokenWorkActionSpec.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.aws.java.ecr
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.ecr.EcrClient
+import software.amazon.awssdk.services.ecr.model.AuthorizationData
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenRequest
+import software.amazon.awssdk.services.ecr.model.GetAuthorizationTokenResponse
+
+class AbstractGetAuthorizationTokenWorkActionSpec : FunSpec() {
+    init {
+        test("execute - retrieves and passes token to doExecute") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<EcrClient>()
+            MockEcrClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent("ecr", MockEcrClientBuildService::class)
+
+            val expectedToken = "QVdTOnRva2VuLXZhbHVl"
+            val authData = mockk<AuthorizationData>()
+            every { authData.authorizationToken() } returns expectedToken
+            val response = mockk<GetAuthorizationTokenResponse>()
+            every { response.authorizationData() } returns listOf(authData)
+            every { client.getAuthorizationToken(any<GetAuthorizationTokenRequest>()) } returns response
+
+            var capturedToken: String? = null
+            val action = object : AbstractGetAuthorizationTokenWorkAction() {
+                override fun getParameters(): Parameters = run {
+                    val params = project.objects.newInstance<Parameters>()
+                    params.service.set(service)
+                    params
+                }
+
+                override fun doExecute(token: String) {
+                    capturedToken = token
+                }
+            }
+            action.execute()
+
+            capturedToken shouldBe expectedToken
+            verify { client.getAuthorizationToken(any<GetAuthorizationTokenRequest>()) }
+        }
+    }
+}

--- a/cores/aws-ecr-kotlin-base/README.md
+++ b/cores/aws-ecr-kotlin-base/README.md
@@ -79,6 +79,28 @@ val repositories: Provider<Map<String, String>> = providers.of(DescribeRepositor
 
 ## WorkActions
 
+### `AbstractGetAuthorizationTokenWorkAction`
+
+Retrieves an ECR authorization token inside a `WorkAction`, keeping the token out of the Gradle
+configuration cache. Subclass and implement `doExecute` to use the token:
+
+```kotlin
+abstract class DockerLoginAction : AbstractGetAuthorizationTokenWorkAction() {
+    override fun doExecute(token: String) {
+        // token is the base64-encoded "AWS:password" string suitable for docker login
+    }
+}
+
+workerExecutor.noIsolation().submit(DockerLoginAction::class) {
+    service.set(ecr)
+}
+```
+
+ECR tokens are valid for up to 12 hours and have no explicit revocation API — `doExecute` provides
+the correct execution-time scope. The token must not escape `doExecute`: storing it in a
+WorkParameters property (even `@get:Internal`), a task input, or a shared file writes it to
+`.gradle/configuration-cache/` in plaintext.
+
 ### `BatchDeleteImageAction`
 
 Deletes a set of images, by tag, from an ECR repository:

--- a/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/AbstractGetAuthorizationTokenWorkAction.kt
+++ b/cores/aws-ecr-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/AbstractGetAuthorizationTokenWorkAction.kt
@@ -1,0 +1,79 @@
+package com.kelvsyc.gradle.aws.kotlin.ecr
+
+import aws.sdk.kotlin.services.ecr.model.GetAuthorizationTokenRequest
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that retrieves an ECR authorization token at task execution time and
+ * passes it to [doExecute], keeping the token out of the Gradle configuration cache.
+ *
+ * The token is obtained inside [execute], which is marked `final` to ensure it always runs at task
+ * execution time. The [runBlocking] call wraps the Kotlin SDK's suspend function.
+ *
+ * ## Token lifecycle
+ *
+ * ECR authorization tokens are valid for up to 12 hours. There is **no explicit revocation API** —
+ * the token self-expires at the end of its validity period, regardless of whether [doExecute]
+ * returns normally or throws. This is unlike Vault dynamic credentials, which carry a lease that
+ * can be explicitly revoked in a `finally` block. [doExecute] therefore provides the correct and
+ * complete execution-time scope for this token.
+ *
+ * ## Configuration cache safety
+ *
+ * Do not let the token escape [doExecute]. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * Subclass and implement [doExecute] to use the token:
+ *
+ * ```kotlin
+ * abstract class DockerLoginAction : AbstractGetAuthorizationTokenWorkAction() {
+ *     override fun doExecute(token: String) {
+ *         // token is the base64-encoded "AWS:password" string suitable for docker login
+ *     }
+ * }
+ * ```
+ */
+abstract class AbstractGetAuthorizationTokenWorkAction :
+    WorkAction<AbstractGetAuthorizationTokenWorkAction.Parameters> {
+
+    /**
+     * Parameters for [AbstractGetAuthorizationTokenWorkAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the ECR client.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<EcrClientBuildService>
+    }
+
+    final override fun execute() {
+        val token = runBlocking {
+            parameters.service.get().getClient()
+                .getAuthorizationToken(GetAuthorizationTokenRequest {})
+                .authorizationData
+                ?.first()
+                ?.authorizationToken
+        } ?: error("No authorization data returned from ECR")
+        doExecute(token)
+    }
+
+    /**
+     * Executes work using the retrieved authorization [token].
+     *
+     * Called at task execution time with a valid ECR token. The token self-expires after up to
+     * 12 hours — there is no explicit revocation API.
+     *
+     * @param token The base64-encoded `AWS:password` authorization token suitable for `docker login`.
+     */
+    protected abstract fun doExecute(token: String)
+}

--- a/cores/aws-ecr-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/AbstractGetAuthorizationTokenWorkActionSpec.kt
+++ b/cores/aws-ecr-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/ecr/AbstractGetAuthorizationTokenWorkActionSpec.kt
@@ -1,0 +1,47 @@
+package com.kelvsyc.gradle.aws.kotlin.ecr
+
+import aws.sdk.kotlin.services.ecr.EcrClient
+import aws.sdk.kotlin.services.ecr.model.AuthorizationData
+import aws.sdk.kotlin.services.ecr.model.GetAuthorizationTokenRequest
+import aws.sdk.kotlin.services.ecr.model.GetAuthorizationTokenResponse
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class AbstractGetAuthorizationTokenWorkActionSpec : FunSpec() {
+    init {
+        test("execute - retrieves token and passes it to doExecute") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<EcrClient>()
+            MockEcrClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("ecr", MockEcrClientBuildService::class)
+
+            val authData = mockk<AuthorizationData>()
+            every { authData.authorizationToken } returns "QVdTOnRva2VuLXZhbHVl"
+
+            val response = mockk<GetAuthorizationTokenResponse>()
+            every { response.authorizationData } returns listOf(authData)
+
+            coEvery { client.getAuthorizationToken(any<GetAuthorizationTokenRequest>()) } returns response
+
+            val params = project.objects.newInstance<AbstractGetAuthorizationTokenWorkAction.Parameters>()
+            params.service.set(service)
+
+            var capturedToken: String? = null
+            val action = object : AbstractGetAuthorizationTokenWorkAction() {
+                override fun getParameters() = params
+                override fun doExecute(token: String) {
+                    capturedToken = token
+                }
+            }
+            action.execute()
+
+            capturedToken shouldBe "QVdTOnRva2VuLXZhbHVl"
+        }
+    }
+}

--- a/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsSessionCredential.kt
+++ b/cores/aws-java-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/java/AwsSessionCredential.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java
+
+import java.time.Instant
+
+/**
+ * Temporary AWS session credentials issued by the AWS Security Token Service (STS) via an `AssumeRole` call.
+ *
+ * Instances of this class are produced at **task execution time** by [AbstractAssumeRoleWorkAction] subclasses
+ * and passed to [AbstractAssumeRoleWorkAction.doExecute]. They must be consumed entirely within the
+ * `doExecute` body — typically by constructing a short-lived AWS SDK client with a
+ * `StaticCredentialsProvider` backed by these values.
+ *
+ * ## Configuration cache safety
+ *
+ * This credential must not escape the body of `doExecute()`. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * The correct pattern is to create and close an SDK client within the same `doExecute` call:
+ *
+ * ```kotlin
+ * override fun doExecute(credential: AwsSessionCredential) {
+ *     KmsClient.builder()
+ *         .credentialsProvider(StaticCredentialsProvider.create(
+ *             AwsSessionCredentials.create(
+ *                 credential.accessKeyId,
+ *                 credential.secretAccessKey,
+ *                 credential.sessionToken,
+ *             )
+ *         ))
+ *         .build()
+ *         .use { client -> /* perform operation */ }
+ * }
+ * ```
+ *
+ * ## No explicit revocation
+ *
+ * Unlike Vault dynamic credentials, STS session credentials have no explicit revocation API.
+ * They self-expire at [expiration]. There is no `revokeSession` equivalent that can be called
+ * to invalidate them early. The credential is valid until its natural expiry regardless of whether
+ * `doExecute` returns normally or throws.
+ */
+data class AwsSessionCredential(
+    /** The AWS access key ID. */
+    val accessKeyId: String,
+    /** The AWS secret access key. */
+    val secretAccessKey: String,
+    /** The session token required for temporary-credential API calls. */
+    val sessionToken: String,
+    /** The instant at which this credential expires. */
+    val expiration: Instant,
+)

--- a/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsSessionCredential.kt
+++ b/cores/aws-kotlin-extensions/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/AwsSessionCredential.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.aws.kotlin
+
+import java.time.Instant
+
+/**
+ * Temporary AWS session credentials issued by the AWS Security Token Service (STS) via an `AssumeRole` call.
+ *
+ * Instances of this class are produced at **task execution time** by [AbstractAssumeRoleWorkAction] subclasses
+ * and passed to [AbstractAssumeRoleWorkAction.doExecute]. They must be consumed entirely within the
+ * `doExecute` body — typically by constructing a short-lived AWS SDK client with a
+ * `StaticCredentialsProvider` backed by these values.
+ *
+ * ## Configuration cache safety
+ *
+ * This credential must not escape the body of `doExecute()`. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * The correct pattern is to create and close an SDK client within the same `doExecute` call:
+ *
+ * ```kotlin
+ * override fun doExecute(credential: AwsSessionCredential) {
+ *     KmsClient { credentialsProvider = StaticCredentialsProvider {
+ *         accessKeyId = credential.accessKeyId
+ *         secretAccessKey = credential.secretAccessKey
+ *         sessionToken = credential.sessionToken
+ *     }}.use { client -> /* perform operation */ }
+ * }
+ * ```
+ *
+ * ## No explicit revocation
+ *
+ * Unlike Vault dynamic credentials, STS session credentials have no explicit revocation API.
+ * They self-expire at [expiration]. There is no `revokeSession` equivalent that can be called
+ * to invalidate them early. The credential is valid until its natural expiry regardless of whether
+ * `doExecute` returns normally or throws.
+ */
+data class AwsSessionCredential(
+    /** The AWS access key ID. */
+    val accessKeyId: String,
+    /** The AWS secret access key. */
+    val secretAccessKey: String,
+    /** The session token required for temporary-credential API calls. */
+    val sessionToken: String,
+    /** The instant at which this credential expires. */
+    val expiration: Instant,
+)

--- a/cores/aws-sts-java-base/README.md
+++ b/cores/aws-sts-java-base/README.md
@@ -71,6 +71,49 @@ val decoded: Provider<String> = providers.of(DecodeAuthorizationMessageValueSour
 Returns `null` and logs a warning if the call throws `StsException` (typically because the message has expired
 or the caller lacks `sts:DecodeAuthorizationMessage`).
 
+## WorkActions
+
+### `AbstractAssumeRoleWorkAction`
+
+Assumes an IAM role via STS and passes temporary credentials to `doExecute`. This provides
+an AWS-native alternative to Vault's `AbstractAwsCredentialWorkAction` when Vault is not available.
+
+```kotlin
+abstract class MyKmsAction : AbstractAssumeRoleWorkAction() {
+    override fun doExecute(credential: AwsSessionCredential) {
+        KmsClient.builder()
+            .credentialsProvider(StaticCredentialsProvider.create(
+                AwsSessionCredentials.create(
+                    credential.accessKeyId,
+                    credential.secretAccessKey,
+                    credential.sessionToken,
+                )
+            ))
+            .build()
+            .use { client -> /* perform KMS operation */ }
+    }
+}
+
+workerExecutor.noIsolation().submit(MyKmsAction::class) {
+    service.set(sts)
+    roleArn.set("arn:aws:iam::123456789012:role/MyRole")
+    roleSessionName.set("gradle-build")
+    duration.set(3600L)
+    // externalId.set("...") // optional, for cross-account trust
+}
+```
+
+> **When to use this vs `StsAssumeRoleCredentialsProvider`:** If you only need to configure the
+> assumed-role credentials on an existing `BuildService`-backed client, use
+> `StsAssumeRoleCredentialsProvider` on that client's `AwsBuildServiceParams` directly —
+> no `AbstractAssumeRoleWorkAction` is needed. Use this WorkAction when you need the raw
+> temporary credentials at task execution time, for example to create a client dynamically or
+> to pass credentials to a non-AWS API.
+
+STS credentials self-expire at the end of the `duration` and have no explicit revocation API. The
+credential must not escape `doExecute`: storing it in a WorkParameters property (even `@get:Internal`),
+a task input, or a shared file writes it to `.gradle/configuration-cache/` in plaintext.
+
 ## See Also
 
 - [clients-base](../clients-base) — The underlying service client infrastructure

--- a/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/AbstractAssumeRoleWorkAction.kt
+++ b/cores/aws-sts-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/sts/AbstractAssumeRoleWorkAction.kt
@@ -1,0 +1,133 @@
+package com.kelvsyc.gradle.aws.java.sts
+
+import com.kelvsyc.gradle.aws.java.AwsSessionCredential
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+
+/**
+ * Abstract WorkAction base class for assuming an IAM role via AWS STS and executing a task with the
+ * resulting temporary credentials.
+ *
+ * Subclasses must implement [doExecute] to consume the temporary [AwsSessionCredential].
+ *
+ * ## Why `execute()` is final
+ *
+ * The `execute()` method is final to enforce the lifecycle contract: the [AwsSessionCredential]
+ * is **only valid during task execution time** and must be consumed entirely within the `doExecute`
+ * call. Subclasses cannot override `execute()` and risk storing or serializing the credential.
+ *
+ * ## What `doExecute` receives
+ *
+ * The `doExecute` method receives an [AwsSessionCredential] containing:
+ * - [AwsSessionCredential.accessKeyId] — the AWS access key ID
+ * - [AwsSessionCredential.secretAccessKey] — the secret access key
+ * - [AwsSessionCredential.sessionToken] — the STS session token
+ * - [AwsSessionCredential.expiration] — the instant at which the credential expires
+ *
+ * ## Critical: credential must not escape doExecute
+ *
+ * The credential must be consumed **entirely within `doExecute`**. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * The correct pattern is to create a short-lived AWS SDK client using
+ * `StaticCredentialsProvider.create(AwsSessionCredentials.create(...))` and call `.use { ... }`
+ * on it to ensure proper resource cleanup:
+ *
+ * ```kotlin
+ * override fun doExecute(credential: AwsSessionCredential) {
+ *     KmsClient.builder()
+ *         .credentialsProvider(StaticCredentialsProvider.create(
+ *             AwsSessionCredentials.create(
+ *                 credential.accessKeyId,
+ *                 credential.secretAccessKey,
+ *                 credential.sessionToken,
+ *             )
+ *         ))
+ *         .build()
+ *         .use { client -> /* perform KMS operation */ }
+ * }
+ * ```
+ *
+ * ## No explicit revocation
+ *
+ * Unlike Vault dynamic credentials, STS session credentials have no explicit revocation API.
+ * They self-expire at [AwsSessionCredential.expiration]. There is no `revokeSession` equivalent
+ * that can be called to invalidate them early. The credential is valid until its natural expiry
+ * regardless of whether `doExecute` returns normally or throws.
+ */
+abstract class AbstractAssumeRoleWorkAction :
+    WorkAction<AbstractAssumeRoleWorkAction.Parameters> {
+
+    /**
+     * WorkParameters for [AbstractAssumeRoleWorkAction].
+     *
+     * All fields except [service] and [externalId] contribute to task up-to-date checks.
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The [StsClientBuildService] instance to use for the assume-role API call.
+         * Excluded from task snapshots to avoid serializing the underlying AWS SDK client.
+         */
+        @get:Internal
+        val service: Property<StsClientBuildService>
+
+        /**
+         * The ARN of the IAM role to assume.
+         * Contributes to task up-to-date checks.
+         */
+        val roleArn: Property<String>
+
+        /**
+         * The name to tag this session with (used in CloudTrail and other AWS logs).
+         * Contributes to task up-to-date checks.
+         */
+        val roleSessionName: Property<String>
+
+        /**
+         * The duration of the temporary credential in seconds.
+         * STS enforces a minimum of 900 seconds (15 minutes) and a maximum that varies by role.
+         * Contributes to task up-to-date checks.
+         */
+        val duration: Property<Long>
+
+        /**
+         * The external ID for cross-account trust (optional).
+         * If the role's trust policy requires an external ID, set it here.
+         * Excluded from task snapshots to prevent logging sensitive values.
+         */
+        @get:Internal
+        val externalId: Property<String>
+    }
+
+    final override fun execute() {
+        val request = AssumeRoleRequest.builder().apply {
+            roleArn(parameters.roleArn.get())
+            roleSessionName(parameters.roleSessionName.get())
+            durationSeconds(parameters.duration.get().toInt())
+            if (parameters.externalId.isPresent) externalId(parameters.externalId.get())
+        }.build()
+        val creds = parameters.service.get().getClient().assumeRole(request).credentials()
+        val credential = AwsSessionCredential(
+            accessKeyId = creds.accessKeyId(),
+            secretAccessKey = creds.secretAccessKey(),
+            sessionToken = creds.sessionToken(),
+            expiration = creds.expiration(),
+        )
+        doExecute(credential)
+    }
+
+    /**
+     * Executes the task with the temporary AWS credentials obtained from the assume-role call.
+     *
+     * @param credential The temporary AWS credentials. Must be consumed entirely within this call;
+     * typically used to construct a short-lived AWS SDK client with a `StaticCredentialsProvider`.
+     */
+    protected abstract fun doExecute(credential: AwsSessionCredential)
+}

--- a/cores/aws-sts-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/sts/AbstractAssumeRoleWorkActionSpec.kt
+++ b/cores/aws-sts-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/sts/AbstractAssumeRoleWorkActionSpec.kt
@@ -1,0 +1,103 @@
+package com.kelvsyc.gradle.aws.java.sts
+
+import com.kelvsyc.gradle.aws.java.AwsSessionCredential
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.sts.StsClient
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse
+import software.amazon.awssdk.services.sts.model.Credentials
+import java.time.Instant
+
+class AbstractAssumeRoleWorkActionSpec : FunSpec() {
+    init {
+        test("execute - passes roleArn, roleSessionName, duration to request and calls doExecute with credential") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<StsClient>()
+            MockStsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("sts", MockStsClientBuildService::class)
+
+            val expiration = Instant.parse("2099-01-01T00:00:00Z")
+            val sdkCreds = Credentials.builder()
+                .accessKeyId("AKIAIOSFODNN7EXAMPLE")
+                .secretAccessKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .sessionToken("AQoDYXdzEJr...")
+                .expiration(expiration)
+                .build()
+
+            val requestSlot = slot<AssumeRoleRequest>()
+            val response = mockk<AssumeRoleResponse>()
+            every { response.credentials() } returns sdkCreds
+            every { client.assumeRole(capture(requestSlot)) } returns response
+
+            val params = project.objects.newInstance<AbstractAssumeRoleWorkAction.Parameters>()
+            params.service.set(service)
+            params.roleArn.set("arn:aws:iam::123456789012:role/MyRole")
+            params.roleSessionName.set("gradle-build")
+            params.duration.set(3600L)
+
+            var capturedCredential: AwsSessionCredential? = null
+            val action = object : AbstractAssumeRoleWorkAction() {
+                override fun getParameters() = params
+                override fun doExecute(credential: AwsSessionCredential) {
+                    capturedCredential = credential
+                }
+            }
+            action.execute()
+
+            val captured = requestSlot.captured
+            captured.roleArn() shouldBe "arn:aws:iam::123456789012:role/MyRole"
+            captured.roleSessionName() shouldBe "gradle-build"
+            captured.durationSeconds() shouldBe 3600
+
+            capturedCredential shouldBe AwsSessionCredential(
+                accessKeyId = "AKIAIOSFODNN7EXAMPLE",
+                secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                sessionToken = "AQoDYXdzEJr...",
+                expiration = expiration,
+            )
+        }
+
+        test("execute - includes externalId in request when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<StsClient>()
+            MockStsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("sts", MockStsClientBuildService::class)
+
+            val expiration = Instant.parse("2099-01-01T00:00:00Z")
+            val sdkCreds = Credentials.builder()
+                .accessKeyId("AKIAIOSFODNN7EXAMPLE")
+                .secretAccessKey("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .sessionToken("AQoDYXdzEJr...")
+                .expiration(expiration)
+                .build()
+
+            val requestSlot = slot<AssumeRoleRequest>()
+            val response = mockk<AssumeRoleResponse>()
+            every { response.credentials() } returns sdkCreds
+            every { client.assumeRole(capture(requestSlot)) } returns response
+
+            val params = project.objects.newInstance<AbstractAssumeRoleWorkAction.Parameters>()
+            params.service.set(service)
+            params.roleArn.set("arn:aws:iam::123456789012:role/CrossAccountRole")
+            params.roleSessionName.set("gradle-build")
+            params.duration.set(3600L)
+            params.externalId.set("cross-account-external-id")
+
+            val action = object : AbstractAssumeRoleWorkAction() {
+                override fun getParameters() = params
+                override fun doExecute(credential: AwsSessionCredential) = Unit
+            }
+            action.execute()
+
+            val captured = requestSlot.captured
+            captured.externalId() shouldBe "cross-account-external-id"
+        }
+    }
+}

--- a/cores/aws-sts-kotlin-base/README.md
+++ b/cores/aws-sts-kotlin-base/README.md
@@ -73,6 +73,56 @@ val decoded: Provider<String> = providers.of(DecodeAuthorizationMessageValueSour
 Returns `null` and logs a warning if the call throws `StsException` (typically because the message has expired
 or the caller lacks `sts:DecodeAuthorizationMessage`).
 
+## WorkActions
+
+### `AbstractAssumeRoleWorkAction`
+
+Assumes an AWS IAM role and produces temporary session credentials via the STS AssumeRole API. Subclasses must
+implement `doExecute(credential: AwsSessionCredential)` to consume the credential at execution time.
+
+The credential is valid only within the `doExecute` call and must be used to construct a short-lived AWS SDK
+client. Storing the credential in any Gradle property or input violates configuration cache security guarantees —
+see [AwsSessionCredential](../aws-kotlin-extensions) for details.
+
+Example plugin using `AbstractAssumeRoleWorkAction`:
+
+```kotlin
+abstract class MyAssumeRoleTask : DefaultTask() {
+    @get:Internal
+    abstract val assumeRoleAction: Property<ProviderFactory>
+
+    @TaskAction
+    fun execute() {
+        val workers = workerExecutor.classLoaderIsolation {
+            classpath.from(configurations.runtimeClasspath)
+        }
+
+        workers.submit(MyAssumeRoleAction::class) {
+            service.set(sts)
+            roleArn.set("arn:aws:iam::123456789012:role/MyRole")
+            roleSessionName.set("my-build-session")
+            duration.set(3600L)
+        }
+    }
+}
+
+abstract class MyAssumeRoleAction : AbstractAssumeRoleWorkAction() {
+    override fun doExecute(credential: AwsSessionCredential) {
+        KmsClient {
+            credentialsProvider = StaticCredentialsProvider {
+                accessKeyId = credential.accessKeyId
+                secretAccessKey = credential.secretAccessKey
+                sessionToken = credential.sessionToken
+            }
+        }.use { client ->
+            client.describeKey(DescribeKeyRequest { keyId = "arn:aws:kms:us-east-1:..." })
+        }
+    }
+}
+```
+
+No explicit revocation is available for STS credentials — they self-expire at [AwsSessionCredential.expiration].
+
 ## See Also
 
 - [clients-base](../clients-base) — The underlying service client infrastructure

--- a/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/AbstractAssumeRoleWorkAction.kt
+++ b/cores/aws-sts-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/AbstractAssumeRoleWorkAction.kt
@@ -1,0 +1,90 @@
+package com.kelvsyc.gradle.aws.kotlin.sts
+
+import aws.sdk.kotlin.services.sts.model.AssumeRoleRequest
+import com.kelvsyc.gradle.aws.kotlin.AwsSessionCredential
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that assumes an AWS IAM role and produces an [AwsSessionCredential].
+ *
+ * Subclasses must implement [doExecute] to consume the resulting temporary credentials. The credential
+ * must not outlive [doExecute]: storing it in a WorkParameters property (even `@get:Internal`), a task
+ * input, or a shared file writes it to `.gradle/configuration-cache/` or disk in plaintext.
+ *
+ * This implementation wraps the AWS SDK for Kotlin coroutine API via [runBlocking].
+ */
+abstract class AbstractAssumeRoleWorkAction :
+    WorkAction<AbstractAssumeRoleWorkAction.Parameters> {
+
+    /**
+     * Parameters for [AbstractAssumeRoleWorkAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the STS client.
+         */
+        @get:Internal
+        val service: Property<StsClientBuildService>
+
+        /**
+         * The ARN of the IAM role to assume (e.g., `arn:aws:iam::123456789012:role/MyRole`).
+         */
+        val roleArn: Property<String>
+
+        /**
+         * The name of the session when assuming the role (e.g., `my-build-session`).
+         * AWS uses this to trace API calls back to the assumed role session.
+         */
+        val roleSessionName: Property<String>
+
+        /**
+         * The duration in seconds for which the assumed-role session is valid (900-3600 seconds;
+         * default 3600 if not specified).
+         */
+        val duration: Property<Long>
+
+        /**
+         * An optional external ID required by the role's trust policy.
+         * Leave unset if the role does not require one.
+         */
+        @get:Internal
+        val externalId: Property<String>
+    }
+
+    final override fun execute() {
+        val creds = runBlocking {
+            val request = AssumeRoleRequest {
+                roleArn = parameters.roleArn.get()
+                roleSessionName = parameters.roleSessionName.get()
+                durationSeconds = parameters.duration.get().toInt()
+                if (parameters.externalId.isPresent) externalId = parameters.externalId.get()
+            }
+            parameters.service.get().getClient().assumeRole(request).credentials
+                ?: error("No credentials returned by STS AssumeRole")
+        }
+        val credential = AwsSessionCredential(
+            accessKeyId = creds.accessKeyId,
+            secretAccessKey = creds.secretAccessKey,
+            sessionToken = creds.sessionToken,
+            expiration = Instant.ofEpochSecond(creds.expiration.epochSeconds, creds.expiration.nanosecondsOfSecond.toLong()),
+        )
+        doExecute(credential)
+    }
+
+    /**
+     * Consumes the temporary session credential produced by [execute].
+     *
+     * This method is called at task execution time with the credential freshly obtained from the STS
+     * AssumeRole call. The credential must be used entirely within this method — typically to construct
+     * an AWS SDK client with a `StaticCredentialsProvider`.
+     *
+     * The credential must not escape this method. See [AwsSessionCredential] for the specific leak
+     * vectors (WorkParameters, task inputs, shared files) and revocation semantics.
+     */
+    protected abstract fun doExecute(credential: AwsSessionCredential)
+}

--- a/cores/aws-sts-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/AbstractAssumeRoleWorkActionSpec.kt
+++ b/cores/aws-sts-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/sts/AbstractAssumeRoleWorkActionSpec.kt
@@ -1,0 +1,100 @@
+package com.kelvsyc.gradle.aws.kotlin.sts
+
+import aws.sdk.kotlin.services.sts.StsClient
+import aws.sdk.kotlin.services.sts.model.AssumeRoleRequest
+import aws.sdk.kotlin.services.sts.model.AssumeRoleResponse
+import aws.sdk.kotlin.services.sts.model.Credentials
+import aws.smithy.kotlin.runtime.time.Instant as SmithyInstant
+import com.kelvsyc.gradle.aws.kotlin.AwsSessionCredential
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.time.Instant
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class AbstractAssumeRoleWorkActionSpec : FunSpec() {
+    init {
+        test("execute - passes roleArn, roleSessionName, duration and calls doExecute with credential") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<StsClient>()
+            MockStsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("sts", MockStsClientBuildService::class)
+            val requestSlot = slot<AssumeRoleRequest>()
+
+            val smithyExpiration = SmithyInstant.fromEpochSeconds(4070908800L)
+            val sdkCreds = Credentials {
+                accessKeyId = "AKIAIOSFODNN7EXAMPLE"
+                secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                sessionToken = "AQoDYXdzEJr..."
+                expiration = smithyExpiration
+            }
+            val response = mockk<AssumeRoleResponse>()
+            every { response.credentials } returns sdkCreds
+            coEvery { client.assumeRole(capture(requestSlot)) } returns response
+
+            val params = project.objects.newInstance<AbstractAssumeRoleWorkAction.Parameters>()
+            params.service.set(service)
+            params.roleArn.set("arn:aws:iam::123456789012:role/TestRole")
+            params.roleSessionName.set("test-session")
+            params.duration.set(3600L)
+
+            var capturedCredential: AwsSessionCredential? = null
+            val action = object : AbstractAssumeRoleWorkAction() {
+                override fun getParameters() = params
+                override fun doExecute(credential: AwsSessionCredential) {
+                    capturedCredential = credential
+                }
+            }
+            action.execute()
+
+            val captured = requestSlot.captured
+            captured.roleArn shouldBe "arn:aws:iam::123456789012:role/TestRole"
+            captured.roleSessionName shouldBe "test-session"
+            captured.durationSeconds shouldBe 3600L
+
+            capturedCredential?.accessKeyId shouldBe "AKIAIOSFODNN7EXAMPLE"
+            capturedCredential?.secretAccessKey shouldBe "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+            capturedCredential?.sessionToken shouldBe "AQoDYXdzEJr..."
+            capturedCredential?.expiration shouldBe Instant.ofEpochSecond(4070908800L)
+        }
+
+        test("execute - includes externalId when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<StsClient>()
+            MockStsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("sts", MockStsClientBuildService::class)
+            val requestSlot = slot<AssumeRoleRequest>()
+
+            val smithyExpiration = SmithyInstant.fromEpochSeconds(4070908800L)
+            val sdkCreds = Credentials {
+                accessKeyId = "AKIAIOSFODNN7EXAMPLE"
+                secretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+                sessionToken = "AQoDYXdzEJr..."
+                expiration = smithyExpiration
+            }
+            val response = mockk<AssumeRoleResponse>()
+            every { response.credentials } returns sdkCreds
+            coEvery { client.assumeRole(capture(requestSlot)) } returns response
+
+            val params = project.objects.newInstance<AbstractAssumeRoleWorkAction.Parameters>()
+            params.service.set(service)
+            params.roleArn.set("arn:aws:iam::123456789012:role/TestRole")
+            params.roleSessionName.set("test-session")
+            params.duration.set(3600L)
+            params.externalId.set("my-external-id")
+
+            val action = object : AbstractAssumeRoleWorkAction() {
+                override fun getParameters() = params
+                override fun doExecute(credential: AwsSessionCredential) = Unit
+            }
+            action.execute()
+
+            requestSlot.captured.externalId shouldBe "my-external-id"
+        }
+    }
+}

--- a/cores/azure-managed-identity-base/README.md
+++ b/cores/azure-managed-identity-base/README.md
@@ -115,6 +115,31 @@ val signature: Provider<String> = providers.of(AzureAttestedDataValueSource::cla
 }
 ```
 
+## WorkActions
+
+### `AbstractGetAccessTokenWorkAction`
+
+Retrieves an OAuth2 access token inside a `WorkAction`, keeping the token out of the Gradle
+configuration cache. Subclass and implement `doExecute` to use the token:
+
+```kotlin
+abstract class CallAzureApiAction : AbstractGetAccessTokenWorkAction() {
+    override fun doExecute(token: String) {
+        // token is the raw OAuth2 bearer token for the requested scopes
+    }
+}
+
+workerExecutor.noIsolation().submit(CallAzureApiAction::class) {
+    service.set(mi)
+    scopes.add("https://management.azure.com/.default")
+}
+```
+
+Azure AD access tokens are typically valid for 1 hour and **cannot be explicitly revoked** —
+`doExecute` provides the correct execution-time scope. The token must not escape `doExecute`:
+storing it in a WorkParameters property (even `@get:Internal`), a task input, or a shared file
+writes it to `.gradle/configuration-cache/` in plaintext.
+
 ## See Also
 
 - [clients-base](../clients-base) — The underlying service client infrastructure

--- a/cores/azure-managed-identity-base/src/main/kotlin/com/kelvsyc/gradle/azure/identity/AbstractGetAccessTokenWorkAction.kt
+++ b/cores/azure-managed-identity-base/src/main/kotlin/com/kelvsyc/gradle/azure/identity/AbstractGetAccessTokenWorkAction.kt
@@ -1,0 +1,90 @@
+package com.kelvsyc.gradle.azure.identity
+
+import com.azure.core.credential.TokenRequestContext
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Abstract base [WorkAction] that retrieves an OAuth2 access token from Azure Managed Identity
+ * and executes work with it, keeping the token out of the Gradle configuration cache.
+ *
+ * ## Token lifecycle
+ *
+ * Azure AD access tokens are typically valid for 1 hour and have **no explicit revocation API**.
+ * Unlike Vault's dynamic credentials (which support immediate lease revocation), Azure AD tokens
+ * expire passively only. The token returned by this action should be used immediately within
+ * [doExecute] and not cached or persisted.
+ *
+ * ## Configuration cache safety
+ *
+ * Do not let the token escape [doExecute]. The ways it can leak:
+ *
+ * - **WorkParameters property** (even `@get:Internal`): Gradle serializes all WorkParameters to
+ *   `.gradle/configuration-cache/` in plaintext.
+ * - **Task input, output, or property**: same serialization path.
+ * - **Shared file or static field**: the value persists on disk beyond this build invocation.
+ *
+ * Subclass this action and implement [doExecute] to use the token:
+ *
+ * ```kotlin
+ * abstract class CallAzureApiAction : AbstractGetAccessTokenWorkAction() {
+ *     override fun doExecute(token: String) {
+ *         // token is the raw OAuth2 bearer token for the requested scopes
+ *     }
+ * }
+ * ```
+ *
+ * ## execute() is final
+ *
+ * The [execute] method is final to enforce the contract: retrieve the token via the parameters,
+ * pass it to [doExecute], and nothing else. Subclasses must implement [doExecute] to define
+ * work that uses the token.
+ */
+abstract class AbstractGetAccessTokenWorkAction :
+    WorkAction<AbstractGetAccessTokenWorkAction.Parameters> {
+
+    /**
+     * Parameters for [AbstractGetAccessTokenWorkAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The managed identity build service used to retrieve the access token.
+         * Excluded from task snapshots.
+         */
+        @get:Internal
+        val service: Property<ManagedIdentityCredentialBuildService>
+
+        /**
+         * OAuth2 scopes to request for the access token.
+         *
+         * At least one scope is required. Common values:
+         * - `https://management.azure.com/.default` — Azure Resource Manager
+         * - `https://graph.microsoft.com/.default` — Microsoft Graph
+         * - `https://vault.azure.net/.default` — Azure Key Vault
+         */
+        val scopes: ListProperty<String>
+    }
+
+    final override fun execute() {
+        val context = TokenRequestContext()
+        parameters.scopes.get().forEach { context.addScopes(it) }
+        val token = parameters.service.get().getClient().getToken(context).block()?.token
+            ?: error("No access token returned from managed identity endpoint")
+        doExecute(token)
+    }
+
+    /**
+     * Executes work using the retrieved access [token].
+     *
+     * Called immediately after the token is retrieved. The token is valid for approximately
+     * 1 hour and will be used within this method's execution context. The token cannot be
+     * explicitly revoked — it expires passively after its expiry time.
+     *
+     * @param token The raw OAuth2 bearer token string valid for the requested scopes.
+     *   This is not cached and is execution-time-only.
+     */
+    protected abstract fun doExecute(token: String)
+}

--- a/cores/azure-managed-identity-base/src/test/kotlin/com/kelvsyc/gradle/azure/identity/AbstractGetAccessTokenWorkActionSpec.kt
+++ b/cores/azure-managed-identity-base/src/test/kotlin/com/kelvsyc/gradle/azure/identity/AbstractGetAccessTokenWorkActionSpec.kt
@@ -1,0 +1,49 @@
+package com.kelvsyc.gradle.azure.identity
+
+import com.azure.core.credential.AccessToken
+import com.azure.core.credential.TokenRequestContext
+import com.azure.identity.ManagedIdentityCredential
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import reactor.core.publisher.Mono
+import java.time.OffsetDateTime
+
+class AbstractGetAccessTokenWorkActionSpec : FunSpec() {
+    init {
+        test("execute - retrieves and passes token to doExecute") {
+            val project = ProjectBuilder.builder().build()
+            val credential = mockk<ManagedIdentityCredential>()
+            MockManagedIdentityCredentialBuildService.mockClient = credential
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("mi", MockManagedIdentityCredentialBuildService::class)
+
+            val contextSlot = slot<TokenRequestContext>()
+            val accessToken = AccessToken("my-token-value", OffsetDateTime.now().plusHours(1))
+            every { credential.getToken(capture(contextSlot)) } returns Mono.just(accessToken)
+
+            var capturedToken: String? = null
+            val action = object : AbstractGetAccessTokenWorkAction() {
+                override fun getParameters(): Parameters = run {
+                    val params = project.objects.newInstance<Parameters>()
+                    params.service.set(service)
+                    params.scopes.add("https://management.azure.com/.default")
+                    params
+                }
+
+                override fun doExecute(token: String) {
+                    capturedToken = token
+                }
+            }
+            action.execute()
+
+            capturedToken shouldBe "my-token-value"
+            contextSlot.captured.scopes shouldBe listOf("https://management.azure.com/.default")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the gap from the config-cache security audit: five components had deprecated `ValueSource` implementations whose deprecation message said "use a WorkAction instead" but no WorkAction existed; `aws-sts-java-base` and `aws-sts-kotlin-base` had no WorkAction at all
- Adds `AbstractGetAuthorizationTokenWorkAction` (ECR Java/Kotlin, CodeArtifact Java/Kotlin), `AbstractGetAccessTokenWorkAction` (Azure Managed Identity), and `AbstractAssumeRoleWorkAction` (STS Java/Kotlin), each sealing `execute()` so credentials are scoped to `doExecute()` and never reach the configuration cache
- Adds `AwsSessionCredential` data classes to `aws-java-extensions` and `aws-kotlin-extensions` as the output type for the STS AssumeRole WorkActions
- Includes unit tests (MockK + Kotest) for all new WorkActions and README updates documenting the leak vectors (WorkParameters serialization, task inputs, shared files) with corrected language removing the misleading "BuildService registration" phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)