### PR TITLE
feat: add azure-service-bus-base component

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ since the two AWS SDKs are distinct libraries:
 | `azure-blob-storage-base` | Azure Blob Storage |
 | `azure-key-vault-base` | Azure Key Vault |
 | `azure-managed-identity-base` | Azure Managed Identity / IMDS |
+| `azure-service-bus-base` | Azure Service Bus |
 | `artifactory-base` | JFrog Artifactory |
 | `bitbucket-cloud-base` | Bitbucket Cloud REST API |
 | `bitbucket-data-center-base` | Bitbucket Data Center REST API |

--- a/cores/azure-service-bus-base/README.md
+++ b/cores/azure-service-bus-base/README.md
@@ -1,0 +1,149 @@
+# Azure Service Bus Base
+
+A Kotlin library providing managed Azure Service Bus client integration using the Azure SDK for Java,
+built on `clients-base`.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:azure-service-bus-base")
+}
+```
+
+## Build Services
+
+### `ServiceBusSenderClientBuildService`
+
+Manages a `ServiceBusSenderClient` scoped to a single queue or topic. Register one instance per
+entity you intend to send to.
+
+```kotlin
+val sender = gradle.sharedServices.registerIfAbsent("serviceBus", ServiceBusSenderClientBuildService::class) {
+    parameters {
+        namespace.set("myns.servicebus.windows.net")
+        queueName.set("my-queue")   // set this XOR topicName
+        // topicName.set("my-topic")
+        defaultCredential()
+        // managedIdentity()
+        // clientSecret(tenantId, clientId, clientSecret)
+    }
+}
+```
+
+The parameter shape extends `AzureBuildServiceParams` from
+[azure-extensions](../azure-extensions); use the extension functions on `AzureBuildServiceParams`
+to configure credentials atomically. Azure Service Bus only accepts `TokenCredential`-shaped
+credentials — attempting to configure with `sasToken()` or `sharedKey()` throws
+`IllegalArgumentException` at client construction time. Setting neither or both of `queueName` and
+`topicName` also throws at construction time.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `namespace` | `Property<String>` | Fully-qualified namespace hostname, e.g. `{namespace}.servicebus.windows.net` |
+| `queueName` | `Property<String>` | Queue name. Set this XOR `topicName`. |
+| `topicName` | `Property<String>` | Topic name. Set this XOR `queueName`. |
+| `credentialSource` | `Property<AzureCredentialSource>` | Which credential to construct. Set via the extension functions. |
+
+### `ServiceBusAdministrationClientBuildService`
+
+Manages a `ServiceBusAdministrationClient` for administrative operations such as listing queues,
+topics, and subscriptions. Register one instance per namespace.
+
+```kotlin
+val admin = gradle.sharedServices.registerIfAbsent("serviceBusAdmin", ServiceBusAdministrationClientBuildService::class) {
+    parameters {
+        namespace.set("myns.servicebus.windows.net")
+        defaultCredential()
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `namespace` | `Property<String>` | Fully-qualified namespace hostname, e.g. `{namespace}.servicebus.windows.net` |
+| `credentialSource` | `Property<AzureCredentialSource>` | Which credential to construct. Set via the extension functions. |
+
+## WorkAction: `SendMessageAction`
+
+Sends a single message to a Service Bus queue or topic.
+
+```kotlin
+workerExecutor.noIsolation().submit(SendMessageAction::class) {
+    service.set(sender)
+    body.set("Build complete.")
+    subject.set("CI Notification")      // optional
+    messageId.set("build-42")           // optional
+    sessionId.set("session-a")          // optional — for session-ordered delivery
+    partitionKey.set("partition-1")     // optional — for partitioned namespaces
+    applicationProperties.put("env", "prod")  // optional
+}
+```
+
+## Task: `SendMessageBatch`
+
+Sends an arbitrary number of messages using the Service Bus atomic batch API. Messages are
+automatically chunked to respect the namespace's per-batch size limit (256 KB for Standard tier,
+1 MB for Premium tier).
+
+```kotlin
+tasks.register<SendMessageBatch>("notify") {
+    service.set(sender)
+    registerEntry("module-a") { entry ->
+        entry.body.set("Module A built")
+    }
+    registerEntry("module-b") { entry ->
+        entry.body.set("Module B built")
+        entry.subject.set("Build update")
+        entry.sessionId.set("session-b")
+        entry.applicationProperties.put("severity", "info")
+    }
+}
+```
+
+## Value Sources
+
+All value sources require a `ServiceBusAdministrationClientBuildService` registered separately.
+
+### `ListQueuesValueSource`
+
+Returns a list of queue names within the namespace.
+
+```kotlin
+val queues: Provider<List<String>> = providers.of(ListQueuesValueSource::class) {
+    parameters {
+        service.set(admin)
+    }
+}
+```
+
+### `ListTopicsValueSource`
+
+Returns a list of topic names within the namespace.
+
+```kotlin
+val topics: Provider<List<String>> = providers.of(ListTopicsValueSource::class) {
+    parameters {
+        service.set(admin)
+    }
+}
+```
+
+### `ListSubscriptionsValueSource`
+
+Returns a list of subscription names for a given topic.
+
+```kotlin
+val subscriptions: Provider<List<String>> = providers.of(ListSubscriptionsValueSource::class) {
+    parameters {
+        service.set(admin)
+        topicName.set("my-topic")
+    }
+}
+```
+
+## See Also
+
+- [clients-base](../clients-base) — The underlying service client infrastructure
+- [azure-extensions](../azure-extensions) — Azure credential configuration
+- [azure-key-vault-base](../azure-key-vault-base) — Azure Key Vault variant

--- a/cores/azure-service-bus-base/build.gradle.kts
+++ b/cores/azure-service-bus-base/build.gradle.kts
@@ -1,0 +1,27 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("Azure Service Bus Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:azure-extensions")
+
+    api(libs.azure.core)
+    api(libs.azure.messaging.servicebus)
+
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    // FIXME https://github.com/gradle/gradle/issues/18647
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/azure-service-bus-base/settings.gradle.kts
+++ b/cores/azure-service-bus-base/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../azure-extensions")

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/AbstractSendMessageBatch.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/AbstractSendMessageBatch.kt
@@ -1,0 +1,111 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.ServiceBusMessage
+import com.azure.messaging.servicebus.ServiceBusSenderClient
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * Sends an arbitrary number of messages to an Azure Service Bus queue or topic.
+ *
+ * Messages are submitted using the Service Bus atomic batch API. The SDK enforces a size limit
+ * (256 KB for Standard tier, 1 MB for Premium tier) per batch via [tryAddMessage][com.azure.messaging.servicebus.ServiceBusMessageBatch.tryAddMessage];
+ * when a batch fills up it is flushed automatically and a new batch is started. A single message
+ * that exceeds the limit on its own will cause the task to fail.
+ *
+ * Specify entries using [registerEntry]. Each entry's name uniquely identifies it within this task.
+ * For session-ordered delivery, set [Entry.sessionId]. For partitioned namespaces, set
+ * [Entry.partitionKey].
+ */
+@DisableCachingByDefault(because = "Sending to an external service is not cacheable")
+abstract class AbstractSendMessageBatch @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * The [ServiceBusSenderClient] used to send messages.
+     */
+    @get:Internal
+    abstract val client: Property<ServiceBusSenderClient>
+
+    /**
+     * A single message entry in the batch.
+     */
+    interface Entry {
+        /** The message body as a UTF-8 string. */
+        @get:Input
+        val body: Property<String>
+
+        /** Optional message subject (analogous to SNS subject). */
+        @get:Input
+        @get:Optional
+        val subject: Property<String>
+
+        /** Optional message identifier. */
+        @get:Input
+        @get:Optional
+        val messageId: Property<String>
+
+        /** Optional session ID for session-ordered delivery. */
+        @get:Input
+        @get:Optional
+        val sessionId: Property<String>
+
+        /** Optional partition key for partitioned namespaces. */
+        @get:Input
+        @get:Optional
+        val partitionKey: Property<String>
+
+        /** Optional user-defined application properties. */
+        @get:Input
+        @get:Optional
+        val applicationProperties: MapProperty<String, String>
+    }
+
+    /** Entries to be sent. Users normally add to this collection through [registerEntry]. */
+    @get:Nested
+    abstract val entries: MapProperty<String, Entry>
+
+    /**
+     * Registers a new message entry. The supplied [name] identifies the entry within this task.
+     */
+    fun registerEntry(name: String, action: Action<in Entry>) {
+        val entry = objects.newInstance<Entry>().also { action.execute(it) }
+        entries.put(name, entry)
+    }
+
+    private fun toMessage(entry: Entry): ServiceBusMessage =
+        ServiceBusMessage(entry.body.get()).apply {
+            entry.subject.orNull?.let { setSubject(it) }
+            entry.messageId.orNull?.let { setMessageId(it) }
+            entry.sessionId.orNull?.let { setSessionId(it) }
+            entry.partitionKey.orNull?.let { setPartitionKey(it) }
+            applicationProperties.putAll(entry.applicationProperties.getOrElse(emptyMap()))
+        }
+
+    @TaskAction
+    fun run() {
+        val sender = client.get()
+        val allMessages = entries.get().values.map { toMessage(it) }
+        var batch = sender.createMessageBatch()
+        for (message in allMessages) {
+            if (!batch.tryAddMessage(message)) {
+                sender.sendMessages(batch)
+                batch = sender.createMessageBatch()
+                check(batch.tryAddMessage(message)) { "Message exceeds maximum batch size" }
+            }
+        }
+        if (batch.count > 0) sender.sendMessages(batch)
+    }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ListQueuesValueSource.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ListQueuesValueSource.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing a list of queue names within an Azure Service Bus namespace.
+ *
+ * Pagination is handled internally by the Azure SDK.
+ */
+abstract class ListQueuesValueSource : ValueSource<List<String>, ListQueuesValueSource.Parameters> {
+    /**
+     * Parameters for [ListQueuesValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the Service Bus administration client. */
+        @get:Internal
+        val service: Property<ServiceBusAdministrationClientBuildService>
+    }
+
+    override fun obtain(): List<String> =
+        parameters.service.get().getClient().listQueues().map { it.name }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ListSubscriptionsValueSource.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ListSubscriptionsValueSource.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing a list of subscription names for a given Azure Service Bus topic.
+ *
+ * Pagination is handled internally by the Azure SDK.
+ */
+abstract class ListSubscriptionsValueSource :
+    ValueSource<List<String>, ListSubscriptionsValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListSubscriptionsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the Service Bus administration client. */
+        @get:Internal
+        val service: Property<ServiceBusAdministrationClientBuildService>
+
+        /** The topic name (short name, not the full resource path). */
+        @get:Input
+        val topicName: Property<String>
+    }
+
+    override fun obtain(): List<String> =
+        parameters.service.get().getClient()
+            .listSubscriptions(parameters.topicName.get())
+            .map { it.subscriptionName }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ListTopicsValueSource.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ListTopicsValueSource.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing a list of topic names within an Azure Service Bus namespace.
+ *
+ * Pagination is handled internally by the Azure SDK.
+ */
+abstract class ListTopicsValueSource : ValueSource<List<String>, ListTopicsValueSource.Parameters> {
+    /**
+     * Parameters for [ListTopicsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the Service Bus administration client. */
+        @get:Internal
+        val service: Property<ServiceBusAdministrationClientBuildService>
+    }
+
+    override fun obtain(): List<String> =
+        parameters.service.get().getClient().listTopics().map { it.name }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/SendMessageAction.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/SendMessageAction.kt
@@ -1,0 +1,58 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.ServiceBusMessage
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation sending a single message to an Azure Service Bus queue or topic.
+ *
+ * The [Parameters.service] must reference a [ServiceBusSenderClientBuildService] configured
+ * with either [queueName][ServiceBusSenderClientBuildService.Params.queueName] or
+ * [topicName][ServiceBusSenderClientBuildService.Params.topicName].
+ *
+ * For session-ordered delivery, set [Parameters.sessionId]. For partitioned namespaces, set
+ * [Parameters.partitionKey].
+ */
+abstract class SendMessageAction : WorkAction<SendMessageAction.Parameters> {
+    /**
+     * Parameters for [SendMessageAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the Service Bus sender client. */
+        @get:Internal
+        val service: Property<ServiceBusSenderClientBuildService>
+
+        /** The message body as a UTF-8 string. */
+        val body: Property<String>
+
+        /** Optional message subject (analogous to SNS subject). */
+        val subject: Property<String>
+
+        /** Optional message identifier. */
+        val messageId: Property<String>
+
+        /** Optional session ID for session-ordered delivery. */
+        val sessionId: Property<String>
+
+        /** Optional partition key for partitioned namespaces. */
+        val partitionKey: Property<String>
+
+        /** Optional user-defined application properties. */
+        val applicationProperties: MapProperty<String, String>
+    }
+
+    override fun execute() {
+        val message = ServiceBusMessage(parameters.body.get()).apply {
+            parameters.subject.orNull?.let { setSubject(it) }
+            parameters.messageId.orNull?.let { setMessageId(it) }
+            parameters.sessionId.orNull?.let { setSessionId(it) }
+            parameters.partitionKey.orNull?.let { setPartitionKey(it) }
+            applicationProperties.putAll(parameters.applicationProperties.getOrElse(emptyMap()))
+        }
+        parameters.service.get().getClient().sendMessage(message)
+    }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/SendMessageBatch.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/SendMessageBatch.kt
@@ -1,0 +1,29 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * An [AbstractSendMessageBatch] task wired to a [com.azure.messaging.servicebus.ServiceBusSenderClient]
+ * supplied by a [ServiceBusSenderClientBuildService].
+ */
+@DisableCachingByDefault(because = "Sending to an external service is not cacheable")
+abstract class SendMessageBatch @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractSendMessageBatch(objects) {
+
+    /**
+     * Build service managing the Service Bus sender client to use.
+     */
+    @get:ServiceReference
+    abstract val service: Property<ServiceBusSenderClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ServiceBusAdministrationClientBuildService.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ServiceBusAdministrationClientBuildService.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClientBuilder
+import com.kelvsyc.gradle.azure.AbstractAzureClientBuildService
+import com.kelvsyc.gradle.azure.AzureBuildServiceParams
+import org.gradle.api.provider.Property
+
+/**
+ * Build service managing a [ServiceBusAdministrationClient] instance.
+ *
+ * Used for administrative operations: listing queues, topics, and subscriptions within a namespace.
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [Params.namespace] and the credential source via the [AzureBuildServiceParams]
+ * extension functions
+ * ([defaultCredential][com.kelvsyc.gradle.azure.defaultCredential],
+ * [managedIdentity][com.kelvsyc.gradle.azure.managedIdentity],
+ * [clientSecret][com.kelvsyc.gradle.azure.clientSecret]).
+ *
+ * Azure Service Bus only accepts `TokenCredential`-shaped credentials; configuring this service
+ * with [sasToken][com.kelvsyc.gradle.azure.sasToken] or
+ * [sharedKey][com.kelvsyc.gradle.azure.sharedKey] will fail at execution time with an
+ * [IllegalArgumentException] from [resolveTokenCredential].
+ */
+abstract class ServiceBusAdministrationClientBuildService :
+    AbstractAzureClientBuildService<ServiceBusAdministrationClient, ServiceBusAdministrationClientBuildService.Params>() {
+
+    /**
+     * Configuration parameters for [ServiceBusAdministrationClientBuildService].
+     */
+    interface Params : AzureBuildServiceParams {
+        /**
+         * Fully-qualified Service Bus namespace hostname,
+         * e.g. `{namespace}.servicebus.windows.net`.
+         */
+        val namespace: Property<String>
+    }
+
+    override fun createClient(): ServiceBusAdministrationClient {
+        val builder = ServiceBusAdministrationClientBuilder()
+            .endpoint("https://${parameters.namespace.get()}")
+        resolveTokenCredential()?.let { builder.credential(it) }
+        return builder.buildClient()
+    }
+}

--- a/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ServiceBusSenderClientBuildService.kt
+++ b/cores/azure-service-bus-base/src/main/kotlin/com/kelvsyc/gradle/azure/servicebus/ServiceBusSenderClientBuildService.kt
@@ -1,0 +1,66 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.ServiceBusClientBuilder
+import com.azure.messaging.servicebus.ServiceBusSenderClient
+import com.kelvsyc.gradle.azure.AbstractAzureClientBuildService
+import com.kelvsyc.gradle.azure.AzureBuildServiceParams
+import org.gradle.api.provider.Property
+
+/**
+ * Build service managing a [ServiceBusSenderClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [Params.namespace] and exactly one of [Params.queueName] or [Params.topicName],
+ * plus the credential source via the [AzureBuildServiceParams] extension functions
+ * ([defaultCredential][com.kelvsyc.gradle.azure.defaultCredential],
+ * [managedIdentity][com.kelvsyc.gradle.azure.managedIdentity],
+ * [clientSecret][com.kelvsyc.gradle.azure.clientSecret]).
+ *
+ * Azure Service Bus only accepts `TokenCredential`-shaped credentials; configuring this service
+ * with [sasToken][com.kelvsyc.gradle.azure.sasToken] or
+ * [sharedKey][com.kelvsyc.gradle.azure.sharedKey] will fail at execution time with an
+ * [IllegalArgumentException] from [resolveTokenCredential].
+ *
+ * Setting neither or both of [Params.queueName] and [Params.topicName] will fail at client
+ * construction time.
+ */
+abstract class ServiceBusSenderClientBuildService :
+    AbstractAzureClientBuildService<ServiceBusSenderClient, ServiceBusSenderClientBuildService.Params>() {
+
+    /**
+     * Configuration parameters for [ServiceBusSenderClientBuildService].
+     */
+    interface Params : AzureBuildServiceParams {
+        /**
+         * Fully-qualified Service Bus namespace hostname,
+         * e.g. `{namespace}.servicebus.windows.net`.
+         */
+        val namespace: Property<String>
+
+        /**
+         * Name of the queue to send messages to. Set this XOR [topicName].
+         */
+        val queueName: Property<String>
+
+        /**
+         * Name of the topic to send messages to. Set this XOR [queueName].
+         */
+        val topicName: Property<String>
+    }
+
+    override fun createClient(): ServiceBusSenderClient {
+        val outerBuilder = ServiceBusClientBuilder()
+            .fullyQualifiedNamespace(parameters.namespace.get())
+        resolveTokenCredential()?.let { outerBuilder.credential(it) }
+        val senderBuilder = outerBuilder.sender()
+        return when {
+            parameters.queueName.isPresent && !parameters.topicName.isPresent ->
+                senderBuilder.queueName(parameters.queueName.get())
+            parameters.topicName.isPresent && !parameters.queueName.isPresent ->
+                senderBuilder.topicName(parameters.topicName.get())
+            else -> error(
+                "Exactly one of queueName or topicName must be set on ServiceBusSenderClientBuildService"
+            )
+        }.buildClient()
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/AbstractSendMessageBatchSpec.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/AbstractSendMessageBatchSpec.kt
@@ -1,0 +1,122 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.ServiceBusMessage
+import com.azure.messaging.servicebus.ServiceBusMessageBatch
+import com.azure.messaging.servicebus.ServiceBusSenderClient
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+
+class AbstractSendMessageBatchSpec : FunSpec() {
+    init {
+        test("run - sends all entries as a single batch when they fit") {
+            val sender = mockk<ServiceBusSenderClient>()
+            val batch = mockk<ServiceBusMessageBatch>()
+            val capturedMessages = mutableListOf<ServiceBusMessage>()
+            every { sender.createMessageBatch() } returns batch
+            every { batch.tryAddMessage(capture(capturedMessages)) } returns true
+            every { batch.count } returns 2
+            every { sender.sendMessages(batch) } just runs
+
+            val project = ProjectBuilder.builder().build()
+            val task = project.tasks.register<AbstractSendMessageBatch>("sendBatch") {
+                client.set(sender)
+                registerEntry("e1") { it.body.set("msg 1") }
+                registerEntry("e2") { it.body.set("msg 2") }
+            }
+            task.get().run()
+
+            capturedMessages shouldHaveSize 2
+            capturedMessages[0].body.toBytes() shouldBe "msg 1".toByteArray()
+            capturedMessages[1].body.toBytes() shouldBe "msg 2".toByteArray()
+            verify(exactly = 1) { sender.sendMessages(batch) }
+        }
+
+        test("run - flushes batch and starts a new one when tryAddMessage returns false") {
+            val sender = mockk<ServiceBusSenderClient>()
+            val batch1 = mockk<ServiceBusMessageBatch>()
+            val batch2 = mockk<ServiceBusMessageBatch>()
+            every { sender.createMessageBatch() } returnsMany listOf(batch1, batch2)
+            every { batch1.tryAddMessage(any()) } returnsMany listOf(true, false)
+            every { batch1.count } returns 1
+            every { batch2.tryAddMessage(any()) } returns true
+            every { batch2.count } returns 1
+            every { sender.sendMessages(any<ServiceBusMessageBatch>()) } just runs
+
+            val project = ProjectBuilder.builder().build()
+            val task = project.tasks.register<AbstractSendMessageBatch>("sendBatch") {
+                client.set(sender)
+                registerEntry("e1") { it.body.set("msg 1") }
+                registerEntry("e2") { it.body.set("msg 2") }
+            }
+            task.get().run()
+
+            verify(exactly = 1) { sender.sendMessages(batch1) }
+            verify(exactly = 1) { sender.sendMessages(batch2) }
+        }
+
+        test("run - forwards subject and applicationProperties per entry") {
+            val sender = mockk<ServiceBusSenderClient>()
+            val batch = mockk<ServiceBusMessageBatch>()
+            val capturedMessages = mutableListOf<ServiceBusMessage>()
+            every { sender.createMessageBatch() } returns batch
+            every { batch.tryAddMessage(capture(capturedMessages)) } returns true
+            every { batch.count } returns 1
+            every { sender.sendMessages(batch) } just runs
+
+            val project = ProjectBuilder.builder().build()
+            val task = project.tasks.register<AbstractSendMessageBatch>("sendBatch") {
+                client.set(sender)
+                registerEntry("e1") { entry ->
+                    entry.body.set("msg")
+                    entry.subject.set("My Subject")
+                    entry.applicationProperties.put("k", "v")
+                }
+            }
+            task.get().run()
+
+            capturedMessages.single().subject shouldBe "My Subject"
+            capturedMessages.single().applicationProperties["k"] shouldBe "v"
+        }
+
+        test("run - throws when a single message exceeds maximum batch size") {
+            val sender = mockk<ServiceBusSenderClient>()
+            val batch = mockk<ServiceBusMessageBatch>()
+            every { sender.createMessageBatch() } returns batch
+            every { batch.tryAddMessage(any()) } returns false
+            every { batch.count } returns 0
+            every { sender.sendMessages(any<ServiceBusMessageBatch>()) } just runs
+
+            val project = ProjectBuilder.builder().build()
+            val task = project.tasks.register<AbstractSendMessageBatch>("sendBatch") {
+                client.set(sender)
+                registerEntry("e1") { it.body.set("oversized") }
+            }
+
+            shouldThrow<IllegalStateException> { task.get().run() }
+        }
+
+        test("run - does nothing when entries is empty") {
+            val sender = mockk<ServiceBusSenderClient>()
+            val batch = mockk<ServiceBusMessageBatch>()
+            every { sender.createMessageBatch() } returns batch
+            every { batch.count } returns 0
+
+            val project = ProjectBuilder.builder().build()
+            val task = project.tasks.register<AbstractSendMessageBatch>("sendBatch") {
+                client.set(sender)
+            }
+            task.get().run()
+
+            verify(exactly = 0) { sender.sendMessages(any<ServiceBusMessageBatch>()) }
+        }
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ListQueuesValueSourceSpec.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ListQueuesValueSourceSpec.kt
@@ -1,0 +1,35 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.core.http.rest.PagedIterable
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient
+import com.azure.messaging.servicebus.administration.models.QueueProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListQueuesValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns queue names from paginated response") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusAdministrationClient>()
+            MockServiceBusAdministrationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBusAdmin", MockServiceBusAdministrationClientBuildService::class)
+
+            val q1 = mockk<QueueProperties> { every { name } returns "queue-alpha" }
+            val q2 = mockk<QueueProperties> { every { name } returns "queue-bravo" }
+            val paged = mockk<PagedIterable<QueueProperties>>()
+            every { paged.iterator() } returns mutableListOf(q1, q2).iterator()
+            every { client.listQueues() } returns paged
+
+            val provider = project.providers.ofKt(ListQueuesValueSource::class) {
+                parameters.service.set(service)
+            }
+
+            provider.get() shouldBe listOf("queue-alpha", "queue-bravo")
+        }
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ListSubscriptionsValueSourceSpec.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ListSubscriptionsValueSourceSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.core.http.rest.PagedIterable
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient
+import com.azure.messaging.servicebus.administration.models.SubscriptionProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListSubscriptionsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns subscription names for the given topic") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusAdministrationClient>()
+            MockServiceBusAdministrationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBusAdmin", MockServiceBusAdministrationClientBuildService::class)
+
+            val s1 = mockk<SubscriptionProperties> { every { subscriptionName } returns "sub-a" }
+            val s2 = mockk<SubscriptionProperties> { every { subscriptionName } returns "sub-b" }
+            val paged = mockk<PagedIterable<SubscriptionProperties>>()
+            every { paged.iterator() } returns mutableListOf(s1, s2).iterator()
+
+            val topicSlot = slot<String>()
+            every { client.listSubscriptions(capture(topicSlot)) } returns paged
+
+            val provider = project.providers.ofKt(ListSubscriptionsValueSource::class) {
+                parameters.service.set(service)
+                parameters.topicName.set("my-topic")
+            }
+
+            provider.get() shouldBe listOf("sub-a", "sub-b")
+            topicSlot.captured shouldBe "my-topic"
+        }
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ListTopicsValueSourceSpec.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ListTopicsValueSourceSpec.kt
@@ -1,0 +1,35 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.core.http.rest.PagedIterable
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient
+import com.azure.messaging.servicebus.administration.models.TopicProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListTopicsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns topic names from paginated response") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusAdministrationClient>()
+            MockServiceBusAdministrationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBusAdmin", MockServiceBusAdministrationClientBuildService::class)
+
+            val t1 = mockk<TopicProperties> { every { name } returns "topic-alpha" }
+            val t2 = mockk<TopicProperties> { every { name } returns "topic-bravo" }
+            val paged = mockk<PagedIterable<TopicProperties>>()
+            every { paged.iterator() } returns mutableListOf(t1, t2).iterator()
+            every { client.listTopics() } returns paged
+
+            val provider = project.providers.ofKt(ListTopicsValueSource::class) {
+                parameters.service.set(service)
+            }
+
+            provider.get() shouldBe listOf("topic-alpha", "topic-bravo")
+        }
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/MockServiceBusAdministrationClientBuildService.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/MockServiceBusAdministrationClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.administration.ServiceBusAdministrationClient
+
+/**
+ * Test-only [ServiceBusAdministrationClientBuildService] that returns a pre-supplied mock client.
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockServiceBusAdministrationClientBuildService : ServiceBusAdministrationClientBuildService() {
+    override fun createClient(): ServiceBusAdministrationClient =
+        checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: ServiceBusAdministrationClient? = null
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/MockServiceBusSenderClientBuildService.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/MockServiceBusSenderClientBuildService.kt
@@ -1,0 +1,16 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.ServiceBusSenderClient
+
+/**
+ * Test-only [ServiceBusSenderClientBuildService] that returns a pre-supplied mock client.
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockServiceBusSenderClientBuildService : ServiceBusSenderClientBuildService() {
+    override fun createClient(): ServiceBusSenderClient = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: ServiceBusSenderClient? = null
+    }
+}

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ProviderFactoryExtensions.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/ProviderFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+// Workaround: under the kotlin-gradle-library convention, Kotlin does not treat Gradle's
+// Action<in T> as T.() -> Unit, so providers.of(...) { parameters.X } fails to resolve.
+internal fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit,
+) = of(valueSourceType, configuration)

--- a/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/SendMessageActionSpec.kt
+++ b/cores/azure-service-bus-base/src/test/kotlin/com/kelvsyc/gradle/azure/servicebus/SendMessageActionSpec.kt
@@ -1,0 +1,155 @@
+package com.kelvsyc.gradle.azure.servicebus
+
+import com.azure.messaging.servicebus.ServiceBusMessage
+import com.azure.messaging.servicebus.ServiceBusSenderClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class SendMessageActionSpec : FunSpec() {
+    init {
+        test("execute - sends message with the specified body") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusSenderClient>()
+            MockServiceBusSenderClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBus", MockServiceBusSenderClientBuildService::class)
+
+            val messageSlot = slot<ServiceBusMessage>()
+            every { client.sendMessage(capture(messageSlot)) } just runs
+
+            val params = project.objects.newInstance<SendMessageAction.Parameters>()
+            params.service.set(service)
+            params.body.set("Hello, Service Bus!")
+
+            val action = object : SendMessageAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            messageSlot.captured.body.toBytes() shouldBe "Hello, Service Bus!".toByteArray()
+        }
+
+        test("execute - includes subject when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusSenderClient>()
+            MockServiceBusSenderClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBus", MockServiceBusSenderClientBuildService::class)
+
+            val messageSlot = slot<ServiceBusMessage>()
+            every { client.sendMessage(capture(messageSlot)) } just runs
+
+            val params = project.objects.newInstance<SendMessageAction.Parameters>()
+            params.service.set(service)
+            params.body.set("msg")
+            params.subject.set("Build Notification")
+
+            val action = object : SendMessageAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            messageSlot.captured.subject shouldBe "Build Notification"
+        }
+
+        test("execute - includes messageId when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusSenderClient>()
+            MockServiceBusSenderClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBus", MockServiceBusSenderClientBuildService::class)
+
+            val messageSlot = slot<ServiceBusMessage>()
+            every { client.sendMessage(capture(messageSlot)) } just runs
+
+            val params = project.objects.newInstance<SendMessageAction.Parameters>()
+            params.service.set(service)
+            params.body.set("msg")
+            params.messageId.set("build-42")
+
+            val action = object : SendMessageAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            messageSlot.captured.messageId shouldBe "build-42"
+        }
+
+        test("execute - includes sessionId when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusSenderClient>()
+            MockServiceBusSenderClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBus", MockServiceBusSenderClientBuildService::class)
+
+            val messageSlot = slot<ServiceBusMessage>()
+            every { client.sendMessage(capture(messageSlot)) } just runs
+
+            val params = project.objects.newInstance<SendMessageAction.Parameters>()
+            params.service.set(service)
+            params.body.set("msg")
+            params.sessionId.set("session-a")
+
+            val action = object : SendMessageAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            messageSlot.captured.sessionId shouldBe "session-a"
+        }
+
+        test("execute - includes partitionKey when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusSenderClient>()
+            MockServiceBusSenderClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBus", MockServiceBusSenderClientBuildService::class)
+
+            val messageSlot = slot<ServiceBusMessage>()
+            every { client.sendMessage(capture(messageSlot)) } just runs
+
+            val params = project.objects.newInstance<SendMessageAction.Parameters>()
+            params.service.set(service)
+            params.body.set("msg")
+            params.partitionKey.set("partition-1")
+
+            val action = object : SendMessageAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            messageSlot.captured.partitionKey shouldBe "partition-1"
+        }
+
+        test("execute - includes applicationProperties when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServiceBusSenderClient>()
+            MockServiceBusSenderClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("serviceBus", MockServiceBusSenderClientBuildService::class)
+
+            val messageSlot = slot<ServiceBusMessage>()
+            every { client.sendMessage(capture(messageSlot)) } just runs
+
+            val params = project.objects.newInstance<SendMessageAction.Parameters>()
+            params.service.set(service)
+            params.body.set("msg")
+            params.applicationProperties.put("env", "prod")
+
+            val action = object : SendMessageAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            messageSlot.captured.applicationProperties["env"] shouldBe "prod"
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ azure-core = { module = "com.azure:azure-core" } # version from BOM 'azure-sdk-b
 azure-identity = { module = "com.azure:azure-identity" } # version from BOM 'azure-sdk-bom'
 azure-storage-blob = { module = "com.azure:azure-storage-blob" } # version from BOM 'azure-sdk-bom'
 azure-security-keyvault-secrets = { module = "com.azure:azure-security-keyvault-secrets" } # version from BOM 'azure-sdk-bom'
+azure-messaging-servicebus = { module = "com.azure:azure-messaging-servicebus" } # version from BOM 'azure-sdk-bom'
 azure-storage-common = { module = "com.azure:azure-storage-common" } # version from BOM 'azure-sdk-bom'
 aws-auth-java = { module = "software.amazon.awssdk:auth" } # version from BOM 'aws-java-sdk-bom'
 aws-config-kotlin = { module = "aws.sdk.kotlin:aws-config" } # version from BOM 'aws-kotlin-sdk-bom'


### PR DESCRIPTION
## Summary

- Adds `azure-service-bus-base`, a new Gradle library providing managed Azure Service Bus client integration built on `clients-base` and `azure-extensions`
- Two build services: `ServiceBusSenderClientBuildService` (entity-scoped to one queue or topic) and `ServiceBusAdministrationClientBuildService` (namespace-scoped for admin operations)
- `SendMessageAction` WorkAction and `AbstractSendMessageBatch`/`SendMessageBatch` task pair using the native size-based `ServiceBusMessageBatch` API with automatic flush-on-full chunking
- Three `ValueSource` implementations for listing queues, topics, and subscriptions; all WorkActions and ValueSources covered by unit tests following the mock-service pattern
- Adds `azure-messaging-servicebus` to the version catalog and registers the component in the root README

## Test plan

- [ ] `./gradlew :azure-service-bus-base:test` — all unit tests pass
- [ ] `./gradlew :azure-service-bus-base:detekt` — no lint violations
- [ ] `./gradlew :azure-service-bus-base:build` — full build including Dokka succeeds
- [ ] `./gradlew :test` — no regressions in other components

🤖 Generated with [Claude Code](https://claude.com/claude-code)