### PR TITLE
feat(karakum-core): add Gradle plugin for TypeScript → Kotlin external-declaration codegen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Architectural reference for this Gradle composite build. See `AGENTS.md` for bui
 - **Tests and detekt must pass** before any task is complete: `./gradlew :test` and `./gradlew :detekt`.
 - **KDocs are required** on every `DefaultTask` subclass, `WorkAction` implementation, and `ValueSource` implementation, including their individual properties and parameters.
 - **Every `WorkAction` implementation must have a unit test.** Follow the `MockXyzClientBuildService` pattern: create a test-only service subclass in `src/test/kotlin` that overrides `createClient()` to return a mock client (see `MockSecretsManagerClientBuildService` as reference). Instantiate the action as an anonymous subclass with `getParameters()` overridden, then call `execute()` directly. WorkActions that call external services (AWS, GCP, Azure, Vault) are fully unit-testable against mocked clients — do not defer tests on the grounds that integration tests are required.
-- **README must stay current** when adding or modifying public-facing components (tasks, `WorkAction`/`ValueSource` implementations, extensions, plugin behaviour).
+- **Every `cores/` component must have a `README.md`** — it is not optional. Create it when scaffolding a new component and keep it current when adding or modifying public-facing API (tasks, `WorkAction`/`ValueSource` implementations, extensions, plugin behaviour).
 - **Root README must stay current** when adding a new component — add it to the appropriate table in `README.md` (cores, bases, or extensions).
 
 ## Build Commands

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Standalone Gradle plugins that solve a specific build problem. Apply them direct
 | `dokka-dash` | `com.kelvsyc.gradle.dokka-dash` | Packages Dokka HTML output into Dash docset bundles |
 | `git-core` | `com.kelvsyc.gradle.git-core` | Git archival tasks and JGit extensions for remote repositories |
 | `jfrog-cli-core` | `com.kelvsyc.gradle.jfrog-cli-core` | Gradle tasks wrapping the JFrog CLI |
+| `karakum-core` | `com.kelvsyc.gradle.karakum-core` | Karakum TypeScript → Kotlin external-declaration codegen, with automatic Kotlin/JS and KMP source-set wiring |
 
 All plugin IDs are prefixed with `com.kelvsyc.gradle.`.
 

--- a/cores/karakum-core/README.md
+++ b/cores/karakum-core/README.md
@@ -1,0 +1,123 @@
+# Karakum Core
+
+A Gradle plugin that integrates [Karakum](https://github.com/karakum-team/karakum) TypeScript `.d.ts` → Kotlin external-declaration generation into the build lifecycle.
+
+When applied alongside `kotlin("js")` or `kotlin("multiplatform")`, the plugin automatically registers a generation task and wires its output into the appropriate Kotlin source set.
+
+## Applying the Plugin
+
+```kotlin
+plugins {
+    id("com.kelvsyc.gradle.karakum-core")
+}
+```
+
+## Extension: `karakum`
+
+The plugin registers a `karakum` extension for project-level configuration.
+
+### `karakumVersion`
+
+Pins the npm package version used in npx-based invocations. Analogous to `toolVersion` in JVM code-quality plugins.
+
+```kotlin
+karakum {
+    karakumVersion.set("1.2.3")   // produces: npx karakum@1.2.3
+}
+```
+
+When unset, the latest published version is used. Has no effect when `useSystem()` or `useNodeModules()` is active.
+
+### Invocation presets
+
+| Method | Invoked as | Notes |
+|--------|-----------|-------|
+| `useNpx()` | `npx karakum[@ver]` | Default (global); bootstrapping-friendly, hits npm on each run |
+| `useNpx(npxBinary)` | `<binary> karakum[@ver]` | Used automatically when KMP Node.js plugin is detected |
+| `useNodeModules()` | `node_modules/.bin/karakum` | Reproducible; requires a `karakum` entry in `package.json` |
+| `useNodeModules(nodeBinary)` | `<binary> node_modules/.bin/karakum` | Reproducible with explicit Node.js binary |
+| `useSystem()` | `karakum` (PATH lookup) | No Node.js management; requires a global install |
+
+The plugin default is `useNpx()` (system `npx`). When a `kotlin("js")` or `kotlin("multiplatform")` project also applies the Kotlin Node.js plugin, the default is automatically upgraded to route through the KMP-managed `npx` binary. Call a preset method explicitly in the `karakum {}` block to override:
+
+```kotlin
+karakum {
+    useNodeModules()   // reproducible builds once karakum is in package.json
+}
+```
+
+## Auto-Registered Tasks
+
+When a Kotlin plugin is detected, `KarakumPlugin` registers a generation task and wires its output into the Kotlin source set.
+
+### `generateKotlinExternals` (Kotlin/JS, single-platform)
+
+Registered when `kotlin("js")` is applied. Outputs to `build/generated/karakum/main`; wired into the `main` source set automatically.
+
+### `generateKotlinJsExternals` (Kotlin Multiplatform)
+
+Registered when `kotlin("multiplatform")` is applied. Outputs to `build/generated/karakum/jsMain`; wired into the `jsMain` source set when a JS target is configured.
+
+Configure either auto-registered task by name:
+
+```kotlin
+tasks.named<KarakumTask>("generateKotlinExternals") {
+    // Direct mode: list .d.ts files or directories
+    inputFiles.from("node_modules/@types/my-lib")
+
+    // Config-file mode: delegate all input routing to a JSON config
+    // configFile.set(layout.projectDirectory.file("karakum.config.json"))
+}
+```
+
+## `KarakumTask`
+
+`KarakumTask` is a `@CacheableTask`. Register additional instances manually when more than one generation step is needed:
+
+```kotlin
+tasks.register<KarakumTask>("generateExtraExternals") {
+    inputFiles.from("src/extra-types")
+    outputDirectory.set(layout.buildDirectory.dir("generated/extra-externals"))
+}
+```
+
+### Properties
+
+| Property | Type | Description |
+|---|---|---|
+| `inputFiles` | `ConfigurableFileCollection` | `.d.ts` files or directories. Ignored when `configFile` is set. |
+| `configFile` | `RegularFileProperty` | Path to a `karakum.config.json`. When set, Karakum is invoked with `--config` and input/output flags are omitted. |
+| `outputDirectory` | `DirectoryProperty` | Directory for generated Kotlin sources. Wired into source sets automatically for the plugin-registered tasks. |
+| `karakumCommand` | `ListProperty<String>` | Full invocation command. Supplied by the `karakum` extension convention; override here for per-task customisation. |
+
+## `RunKarakumAction`
+
+Each `KarakumTask` delegates to `RunKarakumAction` via `WorkerExecutor.noIsolation()`. Use it directly when composing Karakum invocation inside a custom task:
+
+```kotlin
+abstract class MyTask @Inject constructor(private val workers: WorkerExecutor) : DefaultTask() {
+    @TaskAction
+    fun run() {
+        workers.noIsolation().submit(RunKarakumAction::class) {
+            karakumCommand.set(listOf("npx", "karakum@1.2.3"))
+            inputFiles.from(layout.projectDirectory.dir("src/types"))
+            outputDirectory.set(layout.buildDirectory.get().asFile.resolve("generated/karakum").absolutePath)
+        }
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `karakumCommand` | `ListProperty<String>` | Full command tokens. First token is the executable; remaining tokens are prepended to Karakum's own arguments (e.g. `["npx", "karakum@1.2.3"]`). |
+| `inputFiles` | `ConfigurableFileCollection` | TypeScript declaration files or directories. Ignored when `configFile` is set. |
+| `configFile` | `Property<String>` | Absolute path to a `karakum.config.json`. When present, Karakum is invoked with `--config` and input/output flags are not passed. |
+| `outputDirectory` | `Property<String>` | Absolute path to the output directory. Ignored when `configFile` is set. |
+
+## See Also
+
+- [Karakum repository](https://github.com/karakum-team/karakum) — TypeScript-to-Kotlin external declaration generator
+- [Kotlin/JS overview](https://kotlinlang.org/docs/js-overview.html)
+- [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html)

--- a/cores/karakum-core/build.gradle.kts
+++ b/cores/karakum-core/build.gradle.kts
@@ -1,0 +1,26 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-plugin")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("Karakum Core")
+}
+
+gradlePlugin {
+    plugins.register("karakum-core") {
+        id = "com.kelvsyc.gradle.karakum-core"
+        implementationClass = "com.kelvsyc.gradle.plugins.KarakumPlugin"
+    }
+}
+
+dependencies {
+    compileOnly(libs.kotlin.plugin)
+
+    testImplementation(libs.kotlin.plugin)
+    testImplementation(libs.mockk)
+}

--- a/cores/karakum-core/settings.gradle.kts
+++ b/cores/karakum-core/settings.gradle.kts
@@ -1,0 +1,7 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}

--- a/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/KarakumExtension.kt
+++ b/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/KarakumExtension.kt
@@ -1,0 +1,98 @@
+package com.kelvsyc.gradle.karakum
+
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import javax.inject.Inject
+
+/**
+ * Project-level configuration for the Karakum code-generation plugin.
+ *
+ * The default invocation is `npx karakum` (optionally pinned via [karakumVersion]).
+ * Call one of the preset methods to switch modes; assign [karakumCommand] directly for exotic
+ * configurations not covered by the presets.
+ *
+ * Analogous to `toolVersion` in JVM code-quality plugins: [karakumVersion] drives the npm package
+ * version used in npx-based invocations without requiring a global Karakum installation.
+ */
+abstract class KarakumExtension @Inject constructor(private val providers: ProviderFactory) {
+
+    /**
+     * npm package version to pin for npx-based invocations, e.g. `"1.2.3"` produces
+     * `npx karakum@1.2.3`. When unset, the latest published version is used. Has no effect
+     * when [useSystem] or [useNodeModules] is active.
+     */
+    abstract val karakumVersion: Property<String>
+
+    /**
+     * Full invocation command tokens. The first token is the executable; any additional tokens
+     * are prepended to Karakum's own arguments (e.g. `["npx", "karakum@1.2.3"]`).
+     * Normally set via a preset method; assign directly only for exotic configurations.
+     */
+    abstract val karakumCommand: ListProperty<String>
+
+    /**
+     * Invoke `npx karakum[@version]` using the system `npx` binary.
+     *
+     * This is the bootstrapping-friendly default — no global Karakum installation required.
+     * The resolved package is `karakum@[karakumVersion]` when [karakumVersion] is set, or plain
+     * `karakum` otherwise.
+     */
+    fun useNpx() {
+        karakumCommand.set(
+            karakumVersion.map { listOf("npx", "karakum@$it") }.orElse(listOf("npx", "karakum"))
+        )
+    }
+
+    /**
+     * Invoke `npx karakum[@version]` via [npxBinary].
+     *
+     * Use this to route through the `npx` executable managed by the Kotlin Multiplatform plugin's
+     * Node.js toolchain rather than the system binary. The plugin wires this automatically when
+     * a JS target is detected; call it explicitly only when custom routing is needed.
+     */
+    fun useNpx(npxBinary: Provider<RegularFile>) {
+        karakumCommand.set(
+            npxBinary.zip(karakumVersion.map { "karakum@$it" }.orElse("karakum")) { npx, pkg ->
+                listOf(npx.asFile.absolutePath, pkg)
+            }
+        )
+    }
+
+    /**
+     * Invoke `node_modules/.bin/karakum` directly.
+     *
+     * Requires Karakum to be listed as a `devDependency` in `package.json` so that
+     * `kotlinNpmInstall` places the wrapper script in `node_modules/.bin/`. Offers fully
+     * reproducible builds because the exact version is pinned in `package.json`.
+     */
+    fun useNodeModules() {
+        karakumCommand.set(listOf("node_modules/.bin/karakum"))
+    }
+
+    /**
+     * Invoke `node_modules/.bin/karakum` via [nodeBinary].
+     *
+     * Combines the reproducibility of [useNodeModules] with explicit routing through a specific
+     * `node` executable — typically the one managed by the Kotlin Multiplatform plugin's toolchain.
+     */
+    fun useNodeModules(nodeBinary: Provider<RegularFile>) {
+        karakumCommand.set(
+            nodeBinary.map { node ->
+                listOf(node.asFile.absolutePath, "node_modules/.bin/karakum")
+            }
+        )
+    }
+
+    /**
+     * Invoke the `karakum` binary resolved from `PATH`.
+     *
+     * Use this when Karakum is installed globally (e.g. in a CI environment with a pre-configured
+     * tool cache). Requires no Node.js management but ties the build to an externally managed tool.
+     */
+    fun useSystem() {
+        karakumCommand.set(providers.which("karakum").map { listOf(it) })
+    }
+}

--- a/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/KarakumTask.kt
+++ b/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/KarakumTask.kt
@@ -1,0 +1,85 @@
+package com.kelvsyc.gradle.karakum
+
+import com.kelvsyc.gradle.karakum.actions.RunKarakumAction
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.submit
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Task that invokes the Karakum TypeScript-to-Kotlin external-declaration generator as part of
+ * the Gradle build.
+ *
+ * Supports two invocation modes:
+ * - **Direct mode**: declare [inputFiles] (TypeScript `.d.ts` files or directories) and
+ *   [outputDirectory]; Karakum is called with `--input`/`--output` flags.
+ * - **Config-file mode**: set [configFile] to a `karakum.config.json`; all input routing is
+ *   delegated to that file.
+ *
+ * The [karakumCommand] property defaults to the convention supplied by [com.kelvsyc.gradle.plugins.KarakumPlugin]
+ * (system `npx`, or the KMP-managed `npx` when a JS target is detected). Override it or call a
+ * preset method on the `karakum` extension to change the invocation strategy.
+ *
+ * The implementation delegates to [RunKarakumAction] via [WorkerExecutor.noIsolation].
+ */
+@CacheableTask
+abstract class KarakumTask @Inject constructor(private val workers: WorkerExecutor) : DefaultTask() {
+
+    /**
+     * TypeScript declaration files or directories to pass as `--input` arguments.
+     * Ignored when [configFile] is set.
+     */
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val inputFiles: ConfigurableFileCollection
+
+    /**
+     * Optional path to a `karakum.config.json` file. When set, Karakum is invoked in config-file
+     * mode and [inputFiles] / [outputDirectory] are not passed on the command line.
+     */
+    @get:InputFile
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val configFile: RegularFileProperty
+
+    /**
+     * Directory into which Karakum writes the generated Kotlin external declarations.
+     * Automatically wired into the appropriate Kotlin source set by [com.kelvsyc.gradle.plugins.KarakumPlugin].
+     */
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
+
+    /**
+     * Full invocation command tokens (e.g. `["npx", "karakum@1.2.3"]`). Provided by the plugin
+     * extension convention; override here or via the `karakum` extension for project-wide changes.
+     *
+     * @see [RunKarakumAction.Parameters.karakumCommand]
+     */
+    @get:Internal
+    abstract val karakumCommand: ListProperty<String>
+
+    @TaskAction
+    fun run() {
+        workers.noIsolation().submit(RunKarakumAction::class) {
+            karakumCommand.set(this@KarakumTask.karakumCommand)
+            inputFiles.from(this@KarakumTask.inputFiles)
+            if (this@KarakumTask.configFile.isPresent) {
+                configFile.set(this@KarakumTask.configFile.get().asFile.absolutePath)
+            }
+            outputDirectory.set(this@KarakumTask.outputDirectory.get().asFile.absolutePath)
+        }
+    }
+}

--- a/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/ShellProviderExtensions.kt
+++ b/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/ShellProviderExtensions.kt
@@ -1,0 +1,8 @@
+package com.kelvsyc.gradle.karakum
+
+import org.gradle.api.provider.ProviderFactory
+
+internal fun ProviderFactory.which(command: String) = exec {
+    executable("which")
+    args(listOf(command))
+}.standardOutput.asText.map { it.trim() }

--- a/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/actions/RunKarakumAction.kt
+++ b/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/karakum/actions/RunKarakumAction.kt
@@ -1,0 +1,75 @@
+package com.kelvsyc.gradle.karakum.actions
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.process.ExecOperations
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import javax.inject.Inject
+
+/**
+ * [WorkAction] that invokes the Karakum TypeScript-to-Kotlin external-declaration generator.
+ *
+ * Supports two invocation modes:
+ * - **Direct mode** (default): passes each file in [Parameters.inputFiles] as `--input` and
+ *   [Parameters.outputDirectory] as `--output`.
+ * - **Config-file mode**: passes [Parameters.configFile] as `--config`; all other input options
+ *   are ignored. Use this when Karakum configuration is complex enough to warrant a JSON config.
+ */
+abstract class RunKarakumAction @Inject constructor(
+    private val exec: ExecOperations,
+) : WorkAction<RunKarakumAction.Parameters> {
+
+    /**
+     * Parameters for [RunKarakumAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * Full invocation command tokens. The first token is used as the executable; any
+         * remaining tokens are prepended to the CLI argument list before Karakum-specific flags
+         * (e.g. `["npx", "karakum@1.2.3"]` runs `npx` with `karakum@1.2.3` as its first arg).
+         */
+        val karakumCommand: ListProperty<String>
+
+        /**
+         * TypeScript declaration files or directories to pass as `--input` arguments.
+         * Ignored when [configFile] is set.
+         */
+        val inputFiles: ConfigurableFileCollection
+
+        /**
+         * Absolute path to a `karakum.config.json` file. When present, Karakum is invoked with
+         * `--config <path>` and [inputFiles] / [outputDirectory] are not passed on the command line.
+         */
+        val configFile: Property<String>
+
+        /**
+         * Absolute path to the directory where Karakum writes generated Kotlin source files.
+         * Ignored when [configFile] is set.
+         */
+        val outputDirectory: Property<String>
+    }
+
+    override fun execute() {
+        val command = parameters.karakumCommand.get()
+        val cliArgs = buildList {
+            addAll(command.drop(1))
+            if (parameters.configFile.isPresent) {
+                add("--config")
+                add(parameters.configFile.get())
+            } else {
+                parameters.inputFiles.forEach { file ->
+                    add("--input")
+                    add(file.absolutePath)
+                }
+                add("--output")
+                add(parameters.outputDirectory.get())
+            }
+        }
+        exec.exec {
+            executable(command.first())
+            args(cliArgs)
+        }
+    }
+}

--- a/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/plugins/KarakumPlugin.kt
+++ b/cores/karakum-core/src/main/kotlin/com/kelvsyc/gradle/plugins/KarakumPlugin.kt
@@ -1,0 +1,83 @@
+package com.kelvsyc.gradle.plugins
+
+import com.kelvsyc.gradle.karakum.KarakumExtension
+import com.kelvsyc.gradle.karakum.KarakumTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsProjectExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
+
+/**
+ * Gradle plugin that integrates Karakum TypeScript-to-Kotlin external-declaration generation
+ * into the build lifecycle.
+ *
+ * When applied, the plugin:
+ * 1. Registers a `karakum` [KarakumExtension] with a default `npx karakum` invocation command.
+ * 2. Propagates the extension convention to all [KarakumTask] instances.
+ * 3. Reacts to `kotlin("js")` and `kotlin("multiplatform")` plugins: registers a generation task,
+ *    wires its output into the appropriate Kotlin source set, and upgrades the command convention
+ *    to use the KMP-managed Node.js `npx` binary when the Kotlin Node.js plugin is applied.
+ */
+class KarakumPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.create("karakum", KarakumExtension::class.java)
+
+        extension.karakumCommand.convention(
+            extension.karakumVersion.map { listOf("npx", "karakum@$it") }
+                .orElse(listOf("npx", "karakum"))
+        )
+
+        project.tasks.withType<KarakumTask>().configureEach {
+            karakumCommand.convention(extension.karakumCommand)
+        }
+
+        project.pluginManager.withPlugin("org.jetbrains.kotlin.js") {
+            wireKotlinJs(project, extension)
+        }
+
+        project.pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+            wireKotlinMultiplatform(project, extension)
+        }
+    }
+
+    private fun wireKotlinJs(project: Project, extension: KarakumExtension) {
+        val kotlin = project.extensions.getByType(KotlinJsProjectExtension::class.java)
+        upgradeToManagedNpx(project, extension)
+
+        val generateTask = project.tasks.register("generateKotlinExternals", KarakumTask::class.java) {
+            outputDirectory.convention(project.layout.buildDirectory.dir("generated/karakum/main"))
+        }
+        kotlin.sourceSets.getByName("main").kotlin.srcDir(generateTask.map { it.outputDirectory })
+    }
+
+    private fun wireKotlinMultiplatform(project: Project, extension: KarakumExtension) {
+        val kotlin = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+        upgradeToManagedNpx(project, extension)
+
+        val generateTask = project.tasks.register("generateKotlinJsExternals", KarakumTask::class.java) {
+            outputDirectory.convention(project.layout.buildDirectory.dir("generated/karakum/jsMain"))
+        }
+        kotlin.sourceSets.matching { it.name == "jsMain" }.configureEach {
+            this.kotlin.srcDir(generateTask.map { it.outputDirectory })
+        }
+    }
+
+    private fun upgradeToManagedNpx(project: Project, extension: KarakumExtension) {
+        project.rootProject.plugins.withType<NodeJsRootPlugin> {
+            val nodeJsRoot = project.rootProject.extensions.getByType(NodeJsRootExtension::class.java)
+            val managedNpx = project.layout.file(
+                nodeJsRoot.nodeJsSetupTaskProvider.flatMap { task ->
+                    task.destinationProvider.map { it.asFile.resolve("bin/npx") }
+                }
+            )
+            extension.karakumCommand.convention(
+                managedNpx.zip(
+                    extension.karakumVersion.map { "karakum@$it" }.orElse("karakum")
+                ) { npx, pkg -> listOf(npx.asFile.absolutePath, pkg) }
+            )
+        }
+    }
+}

--- a/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/karakum/KarakumExtensionSpec.kt
+++ b/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/karakum/KarakumExtensionSpec.kt
@@ -1,0 +1,84 @@
+package com.kelvsyc.gradle.karakum
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.testfixtures.ProjectBuilder
+
+class KarakumExtensionSpec : FunSpec() {
+    init {
+        context("KarakumExtension - useNpx()") {
+            test("sets command to npx karakum when no version is set") {
+                val project = ProjectBuilder.builder().build()
+                val ext = project.objects.newInstance<KarakumExtension>()
+
+                ext.useNpx()
+
+                ext.karakumCommand.get() shouldBe listOf("npx", "karakum")
+            }
+
+            test("sets command to npx karakum@version when version is set") {
+                val project = ProjectBuilder.builder().build()
+                val ext = project.objects.newInstance<KarakumExtension>()
+                ext.karakumVersion.set("1.2.3")
+
+                ext.useNpx()
+
+                ext.karakumCommand.get() shouldBe listOf("npx", "karakum@1.2.3")
+            }
+        }
+
+        context("KarakumExtension - useNpx(npxBinary)") {
+            test("sets command using the provided npx binary path without version") {
+                val project = ProjectBuilder.builder().build()
+                val ext = project.objects.newInstance<KarakumExtension>()
+                val npxFile = project.objects.fileProperty().also {
+                    it.set(project.file("/managed/node/bin/npx"))
+                }
+
+                ext.useNpx(npxFile)
+
+                ext.karakumCommand.get() shouldBe listOf("/managed/node/bin/npx", "karakum")
+            }
+
+            test("sets command using the provided npx binary path with version") {
+                val project = ProjectBuilder.builder().build()
+                val ext = project.objects.newInstance<KarakumExtension>()
+                ext.karakumVersion.set("2.0.0")
+                val npxFile = project.objects.fileProperty().also {
+                    it.set(project.file("/managed/node/bin/npx"))
+                }
+
+                ext.useNpx(npxFile)
+
+                ext.karakumCommand.get() shouldBe listOf("/managed/node/bin/npx", "karakum@2.0.0")
+            }
+        }
+
+        context("KarakumExtension - useNodeModules()") {
+            test("sets command to node_modules/.bin/karakum") {
+                val project = ProjectBuilder.builder().build()
+                val ext = project.objects.newInstance<KarakumExtension>()
+
+                ext.useNodeModules()
+
+                ext.karakumCommand.get() shouldBe listOf("node_modules/.bin/karakum")
+            }
+        }
+
+        context("KarakumExtension - useNodeModules(nodeBinary)") {
+            test("sets command using the provided node binary path") {
+                val project = ProjectBuilder.builder().build()
+                val ext = project.objects.newInstance<KarakumExtension>()
+                val nodeFile = project.objects.fileProperty().also {
+                    it.set(project.file("/managed/node/bin/node"))
+                }
+
+                ext.useNodeModules(nodeFile)
+
+                ext.karakumCommand.get() shouldBe
+                    listOf("/managed/node/bin/node", "node_modules/.bin/karakum")
+            }
+        }
+    }
+}

--- a/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/karakum/KarakumTaskSpec.kt
+++ b/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/karakum/KarakumTaskSpec.kt
@@ -1,0 +1,48 @@
+package com.kelvsyc.gradle.karakum
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+
+class KarakumTaskSpec : FunSpec() {
+    init {
+        context("KarakumTask - property configuration") {
+            test("karakumCommand can be set and retrieved") {
+                val project = ProjectBuilder.builder().build()
+                val task = project.tasks.register<KarakumTask>("gen").get()
+
+                task.karakumCommand.set(listOf("npx", "karakum@1.0.0"))
+
+                task.karakumCommand.get() shouldBe listOf("npx", "karakum@1.0.0")
+            }
+
+            test("outputDirectory can be set and retrieved") {
+                val project = ProjectBuilder.builder().build()
+                val task = project.tasks.register<KarakumTask>("gen").get()
+                val dir = project.layout.buildDirectory.dir("generated/karakum").get()
+
+                task.outputDirectory.set(dir)
+
+                task.outputDirectory.get() shouldBe dir
+            }
+
+            test("configFile is absent by default") {
+                val project = ProjectBuilder.builder().build()
+                val task = project.tasks.register<KarakumTask>("gen").get()
+
+                task.configFile.isPresent shouldBe false
+            }
+
+            test("configFile can be set and retrieved") {
+                val project = ProjectBuilder.builder().build()
+                val task = project.tasks.register<KarakumTask>("gen").get()
+                val cfg = project.layout.projectDirectory.file("karakum.config.json")
+
+                task.configFile.set(cfg)
+
+                task.configFile.get() shouldBe cfg
+            }
+        }
+    }
+}

--- a/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/karakum/actions/RunKarakumActionSpec.kt
+++ b/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/karakum/actions/RunKarakumActionSpec.kt
@@ -1,0 +1,155 @@
+package com.kelvsyc.gradle.karakum.actions
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+import org.gradle.testfixtures.ProjectBuilder
+
+class RunKarakumActionSpec : FunSpec() {
+    private fun captureArgs(execSpec: ExecSpec): MutableList<Any?> {
+        val captured = mutableListOf<Any?>()
+        every { execSpec.args(any<Iterable<*>>()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            captured.addAll(firstArg<Iterable<*>>().toList())
+            execSpec
+        }
+        return captured
+    }
+
+    private fun mockExecOps(execSpec: ExecSpec): ExecOperations {
+        val execOps = mockk<ExecOperations>()
+        every { execOps.exec(any()) } answers {
+            firstArg<Action<ExecSpec>>().execute(execSpec)
+            mockk(relaxed = true)
+        }
+        return execOps
+    }
+
+    init {
+        context("RunKarakumAction - direct input mode") {
+            test("uses first command token as executable") {
+                val project = ProjectBuilder.builder().build()
+                val execSpec = mockk<ExecSpec>(relaxed = true)
+                val execOps = mockExecOps(execSpec)
+
+                val params = project.objects.newInstance<RunKarakumAction.Parameters>()
+                params.karakumCommand.set(listOf("karakum"))
+                params.inputFiles.from(project.file("src/types/index.d.ts"))
+                params.outputDirectory.set("build/generated/karakum")
+
+                object : RunKarakumAction(execOps) {
+                    override fun getParameters() = params
+                }.execute()
+
+                verify { execSpec.executable("karakum") }
+            }
+
+            test("npx prefix tokens are passed as leading args before --input/--output") {
+                val project = ProjectBuilder.builder().build()
+                val execSpec = mockk<ExecSpec>(relaxed = true)
+                val capturedArgs = captureArgs(execSpec)
+                val execOps = mockExecOps(execSpec)
+
+                val params = project.objects.newInstance<RunKarakumAction.Parameters>()
+                params.karakumCommand.set(listOf("npx", "karakum@1.2.3"))
+                params.inputFiles.from(project.file("types/lib.d.ts"))
+                params.outputDirectory.set("build/generated/karakum")
+
+                object : RunKarakumAction(execOps) {
+                    override fun getParameters() = params
+                }.execute()
+
+                capturedArgs.first() shouldBe "karakum@1.2.3"
+                verify { execSpec.executable("npx") }
+            }
+
+            test("emits --input for each file and --output for the output directory") {
+                val project = ProjectBuilder.builder().build()
+                val execSpec = mockk<ExecSpec>(relaxed = true)
+                val capturedArgs = captureArgs(execSpec)
+                val execOps = mockExecOps(execSpec)
+
+                val inputFile = project.file("src/types/index.d.ts")
+                val outDir = "build/generated/karakum"
+
+                val params = project.objects.newInstance<RunKarakumAction.Parameters>()
+                params.karakumCommand.set(listOf("karakum"))
+                params.inputFiles.from(inputFile)
+                params.outputDirectory.set(outDir)
+
+                object : RunKarakumAction(execOps) {
+                    override fun getParameters() = params
+                }.execute()
+
+                capturedArgs shouldBe listOf("--input", inputFile.absolutePath, "--output", outDir)
+            }
+
+            test("emits --input for each file when multiple inputs provided") {
+                val project = ProjectBuilder.builder().build()
+                val execSpec = mockk<ExecSpec>(relaxed = true)
+                val capturedArgs = captureArgs(execSpec)
+                val execOps = mockExecOps(execSpec)
+
+                val file1 = project.file("types/a.d.ts")
+                val file2 = project.file("types/b.d.ts")
+
+                val params = project.objects.newInstance<RunKarakumAction.Parameters>()
+                params.karakumCommand.set(listOf("karakum"))
+                params.inputFiles.from(file1, file2)
+                params.outputDirectory.set("build/generated/karakum")
+
+                object : RunKarakumAction(execOps) {
+                    override fun getParameters() = params
+                }.execute()
+
+                val inputArgs = capturedArgs.chunked(2).filter { it.first() == "--input" }
+                inputArgs.map { it[1] } shouldBe listOf(file1.absolutePath, file2.absolutePath)
+            }
+        }
+
+        context("RunKarakumAction - config file mode") {
+            test("emits --config with the config file path when configFile is set") {
+                val project = ProjectBuilder.builder().build()
+                val execSpec = mockk<ExecSpec>(relaxed = true)
+                val capturedArgs = captureArgs(execSpec)
+                val execOps = mockExecOps(execSpec)
+
+                val configPath = "/project/karakum.config.json"
+
+                val params = project.objects.newInstance<RunKarakumAction.Parameters>()
+                params.karakumCommand.set(listOf("karakum"))
+                params.configFile.set(configPath)
+
+                object : RunKarakumAction(execOps) {
+                    override fun getParameters() = params
+                }.execute()
+
+                capturedArgs shouldBe listOf("--config", configPath)
+            }
+
+            test("config file mode does not emit --input or --output") {
+                val project = ProjectBuilder.builder().build()
+                val execSpec = mockk<ExecSpec>(relaxed = true)
+                val capturedArgs = captureArgs(execSpec)
+                val execOps = mockExecOps(execSpec)
+
+                val params = project.objects.newInstance<RunKarakumAction.Parameters>()
+                params.karakumCommand.set(listOf("karakum"))
+                params.configFile.set("/project/karakum.config.json")
+
+                object : RunKarakumAction(execOps) {
+                    override fun getParameters() = params
+                }.execute()
+
+                capturedArgs.contains("--input") shouldBe false
+                capturedArgs.contains("--output") shouldBe false
+            }
+        }
+    }
+}

--- a/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/plugins/KarakumPluginSpec.kt
+++ b/cores/karakum-core/src/test/kotlin/com/kelvsyc/gradle/plugins/KarakumPluginSpec.kt
@@ -1,0 +1,75 @@
+package com.kelvsyc.gradle.plugins
+
+import com.kelvsyc.gradle.karakum.KarakumExtension
+import com.kelvsyc.gradle.karakum.KarakumTask
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+
+class KarakumPluginSpec : FunSpec() {
+    init {
+        context("KarakumPlugin - extension") {
+            test("registers a karakum extension on the project") {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply(KarakumPlugin::class)
+
+                project.extensions.findByType<KarakumExtension>() shouldNotBe null
+            }
+
+            test("karakumCommand convention defaults to npx karakum when no version is set") {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply(KarakumPlugin::class)
+                val ext = project.extensions.findByType<KarakumExtension>()!!
+
+                ext.karakumCommand.get() shouldBe listOf("npx", "karakum")
+            }
+
+            test("karakumCommand convention includes version when karakumVersion is set") {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply(KarakumPlugin::class)
+                val ext = project.extensions.findByType<KarakumExtension>()!!
+
+                ext.karakumVersion.set("1.5.0")
+
+                ext.karakumCommand.get() shouldBe listOf("npx", "karakum@1.5.0")
+            }
+        }
+
+        context("KarakumPlugin - task convention") {
+            test("KarakumTask inherits karakumCommand convention from extension") {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply(KarakumPlugin::class)
+
+                val task = project.tasks.register<KarakumTask>("gen").get()
+
+                task.karakumCommand.get() shouldBe listOf("npx", "karakum")
+            }
+
+            test("explicit karakumCommand on task overrides extension convention") {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply(KarakumPlugin::class)
+
+                val task = project.tasks.register<KarakumTask>("gen") {
+                    karakumCommand.set(listOf("karakum"))
+                }.get()
+
+                task.karakumCommand.get() shouldBe listOf("karakum")
+            }
+
+            test("changing extension karakumVersion after task registration is reflected in task") {
+                val project = ProjectBuilder.builder().build()
+                project.pluginManager.apply(KarakumPlugin::class)
+                val ext = project.extensions.findByType<KarakumExtension>()!!
+                val task = project.tasks.register<KarakumTask>("gen").get()
+
+                ext.karakumVersion.set("2.0.0")
+
+                task.karakumCommand.get() shouldBe listOf("npx", "karakum@2.0.0")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `karakum-core` (`com.kelvsyc.gradle.karakum-core`), a new Gradle plugin wrapping the [Karakum](https://github.com/karakum-team/karakum) TypeScript `.d.ts` → Kotlin external-declaration CLI as a cacheable `KarakumTask` with flexible invocation presets (`useNpx`, `useNodeModules`, `useSystem`).
- Auto-registers `generateKotlinExternals` / `generateKotlinJsExternals` tasks and wires their output into the appropriate Kotlin source sets for both `kotlin("js")` and `kotlin("multiplatform")` projects; when the KMP Node.js plugin is applied, the default command is automatically upgraded to the KMP-managed `npx` binary.
- Includes component `README.md`, 22 unit tests, and updates `CLAUDE.md` to mandate per-component READMEs across all `cores/` components.

## Test plan

- [ ] `./gradlew :karakum-core:test` — 22 unit tests pass (RunKarakumAction, KarakumExtension presets, KarakumTask properties, KarakumPlugin extension/convention wiring)
- [ ] `./gradlew :karakum-core:detekt` — no lint violations
- [ ] `./gradlew :karakum-core:build` — full build including Dokka and JaCoCo succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)