### PR TITLE
feat: add nexus-base component for Sonatype Nexus Repository Manager 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ Architectural reference for this Gradle composite build. See `AGENTS.md` for bui
 
 ## Requirements
 
+- **Do not commit intermediary design documents** (e.g., `docs/superpowers/specs/*-design.md`). These are working files used during planning; only the resulting code and component `README.md` belong in the repo.
+
 - **Tests and detekt must pass** before any task is complete: `./gradlew :test` and `./gradlew :detekt`.
 - **KDocs are required** on every `DefaultTask` subclass, `WorkAction` implementation, and `ValueSource` implementation, including their individual properties and parameters.
 - **Every `WorkAction` implementation must have a unit test.** Follow the `MockXyzClientBuildService` pattern: create a test-only service subclass in `src/test/kotlin` that overrides `createClient()` to return a mock client (see `MockSecretsManagerClientBuildService` as reference). Instantiate the action as an anonymous subclass with `getParameters()` overridden, then call `execute()` directly. WorkActions that call external services (AWS, GCP, Azure, Vault) are fully unit-testable against mocked clients — do not defer tests on the grounds that integration tests are required.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ since the two AWS SDKs are distinct libraries:
 | `azure-managed-identity-base` | Azure Managed Identity / IMDS |
 | `azure-service-bus-base` | Azure Service Bus |
 | `artifactory-base` | JFrog Artifactory |
+| `nexus-base` | Sonatype Nexus Repository Manager 3 |
 | `bitbucket-cloud-base` | Bitbucket Cloud REST API |
 | `bitbucket-data-center-base` | Bitbucket Data Center REST API |
 

--- a/cores/nexus-base/README.md
+++ b/cores/nexus-base/README.md
@@ -1,0 +1,125 @@
+# Nexus Base
+
+A Kotlin library providing managed Sonatype Nexus Repository Manager 3 client infrastructure,
+built on `clients-base` with a Retrofit/OkHttp transport layer.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:nexus-base")
+}
+```
+
+## Build Service
+
+| Class | Client type |
+|---|---|
+| `NexusClientBuildService` | `NexusService` (internal Retrofit interface) |
+
+Register an instance via `BuildServiceRegistry.registerIfAbsent`, then share it across value
+sources and work actions.
+
+### Anonymous (unauthenticated) access
+
+```kotlin
+val nexus = gradle.sharedServices.registerIfAbsent("nexus", NexusClientBuildService::class) {
+    parameters.baseUrl.set("https://nexus.example.com/")
+    parameters.anonymous()
+}
+```
+
+### Basic authentication (username + password / user token)
+
+```kotlin
+val nexus = gradle.sharedServices.registerIfAbsent("nexus", NexusClientBuildService::class) {
+    parameters.baseUrl.set("https://nexus.example.com/")
+    parameters.basicAuth(
+        username = "ci-user",
+        // Defaults to CredentialReference.EnvironmentVariable("NEXUS_PASSWORD")
+    )
+}
+```
+
+Nexus user tokens (generated via **Security → User Tokens** in the Nexus UI) are presented as a
+username/password pair and consumed through `basicAuth()` without API difference.
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `baseUrl` | `Property<String>` | Yes | Base URL of your Nexus instance (include trailing `/`) |
+| `username` | `Property<String>` | No | Username; leave unset for anonymous access |
+| `passwordRef` | `Property<CredentialReference>` | No | Credential reference for the password; set via `basicAuth()` |
+
+## Value Source: `AbstractNexusArtifactValueSource`
+
+Extend to download an artifact from a raw repository and transform the bytes at configuration time:
+
+```kotlin
+abstract class VersionManifestValueSource :
+    AbstractNexusArtifactValueSource<String>() {
+    override fun doObtain(input: InputStream): String = input.bufferedReader().readText()
+}
+
+// In your plugin or build script:
+val manifest = providers.of(VersionManifestValueSource::class) {
+    parameters.service.set(nexus)
+    parameters.repository.set("generic-local")
+    parameters.path.set("releases/manifest.txt")
+}
+```
+
+> **Configuration cache and sensitive artifacts:** `AbstractNexusArtifactValueSource` serializes
+> its result to the Gradle configuration cache in plaintext. Do not use it to fetch artifacts whose
+> contents are sensitive (credentials, private keys, tokens). Fetch sensitive content inside a
+> `WorkAction` at task execution time instead — the result is resolved after the cache has been
+> read and is never written to it.
+
+## WorkActions
+
+### `DownloadArtifactAction`
+
+Downloads a single artifact from a Nexus raw repository to a local file. The response body is
+streamed to avoid buffering large artifacts in heap.
+
+### `UploadArtifactAction`
+
+Uploads a single local file to a Nexus raw repository. The target `path` is split on the last
+`/` to derive `raw.directory` and `raw.asset1.filename` for the Nexus REST v1 multipart format.
+
+## Tasks
+
+### `BatchDownloadFromNexus` / `BatchUploadToNexus`
+
+Download or upload multiple artifacts concurrently via `WorkerExecutor.noIsolation()`.
+`AbstractBatchDownloadFromNexus` / `AbstractBatchUploadToNexus` are the same tasks minus the
+`@get:ServiceReference` annotation, for use when you manage the service property yourself.
+
+```kotlin
+tasks.register<BatchDownloadFromNexus>("downloadAssets") {
+    service.set(nexus)
+    registerArtifact("settings") { artifact ->
+        artifact.repository.set("generic-local")
+        artifact.path.set("config/settings.json")
+        artifact.outputFile.set(layout.buildDirectory.file("config/settings.json"))
+    }
+    registerArtifact("schema") { artifact ->
+        artifact.repository.set("generic-local")
+        artifact.path.set("schema/api.json")
+        artifact.outputFile.set(layout.buildDirectory.file("schema/api.json"))
+    }
+}
+
+tasks.register<BatchUploadToNexus>("publishAssets") {
+    service.set(nexus)
+    registerArtifact("dist") { artifact ->
+        artifact.repository.set("generic-releases")
+        artifact.path.set("com/example/1.0/dist-1.0.zip")
+        artifact.inputFile.set(layout.buildDirectory.file("distributions/dist-1.0.zip"))
+    }
+}
+```
+
+## See Also
+
+- [clients-base](../clients-base) — The underlying build service and credential infrastructure
+- [artifactory-base](../artifactory-base) — JFrog Artifactory (same pattern, native SDK)

--- a/cores/nexus-base/build.gradle.kts
+++ b/cores/nexus-base/build.gradle.kts
@@ -1,0 +1,27 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("Nexus Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api(libs.retrofit)
+    api(libs.moshi)
+    implementation(libs.moshi.kotlin)
+    implementation(libs.okhttp)
+    implementation(libs.retrofit.converter.moshi)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    // FIXME https://github.com/gradle/gradle/issues/18647
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/nexus-base/settings.gradle.kts
+++ b/cores/nexus-base/settings.gradle.kts
@@ -1,0 +1,9 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/AbstractBatchDownloadFromNexus.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/AbstractBatchDownloadFromNexus.kt
@@ -1,0 +1,104 @@
+package com.kelvsyc.gradle.nexus
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.Named
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Downloads a set of artifacts from Nexus raw repositories concurrently.
+ *
+ * Each artifact is identified by a name, repository, and path. Specify artifacts using
+ * [registerArtifact]. All artifacts are downloaded in parallel via [DownloadArtifactAction].
+ *
+ * Subclass this task if you need to manage the `service` property yourself (e.g. when composing
+ * with a custom build service registration). For the common case, use [BatchDownloadFromNexus]
+ * which adds `@get:ServiceReference` so Gradle tracks the service as a task dependency
+ * automatically.
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class AbstractBatchDownloadFromNexus @Inject constructor(
+    private val objects: ObjectFactory,
+    private val providers: ProviderFactory,
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Nexus client to use for all downloads in this task.
+     */
+    @get:Internal
+    abstract val service: Property<NexusClientBuildService>
+
+    /**
+     * A single artifact entry registered for download.
+     */
+    abstract class Artifact @Inject constructor(private val name: String) : Named {
+        override fun getName() = name
+
+        /**
+         * The name of the Nexus repository containing the artifact.
+         */
+        abstract val repository: Property<String>
+
+        /**
+         * The path to the artifact within the repository.
+         */
+        abstract val path: Property<String>
+
+        /**
+         * The local file to which the artifact will be written.
+         */
+        abstract val outputFile: RegularFileProperty
+    }
+
+    /**
+     * The registered artifacts to download.
+     *
+     * Populated by [registerArtifact]; modifying this map directly is not recommended.
+     */
+    @get:Internal
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers a new artifact to be downloaded.
+     */
+    fun registerArtifact(name: String, configureAction: Action<in Artifact>) {
+        artifacts.put(name, providers.provider {
+            objects.newInstance<Artifact>(name).also { configureAction.execute(it) }
+        })
+    }
+
+    /**
+     * The output files produced by this task, keyed by artifact name.
+     *
+     * Provided as a convenience for wiring the output of this task to other task inputs.
+     */
+    @Suppress("LeakingThis")
+    @get:OutputFiles
+    val outputFiles = artifacts.map { it.mapValues { entry -> entry.value.outputFile.get() } }
+
+    /** Downloads all registered artifacts concurrently. */
+    @TaskAction
+    fun run() {
+        val queue = workerExecutor.noIsolation()
+        artifacts.get().forEach { (_, artifact) ->
+            queue.submit(DownloadArtifactAction::class.java) { params ->
+                params.service.set(this@AbstractBatchDownloadFromNexus.service)
+                params.repository.set(artifact.repository)
+                params.path.set(artifact.path)
+                params.outputFile.set(artifact.outputFile)
+            }
+        }
+    }
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/AbstractBatchUploadToNexus.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/AbstractBatchUploadToNexus.kt
@@ -1,0 +1,106 @@
+package com.kelvsyc.gradle.nexus
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.Named
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Uploads a set of artifacts to Nexus raw repositories concurrently.
+ *
+ * Each artifact is identified by a name, repository, and path. Specify artifacts using
+ * [registerArtifact]. All artifacts are uploaded in parallel via [UploadArtifactAction].
+ *
+ * Subclass this task if you need to manage the `service` property yourself. For the common case,
+ * use [BatchUploadToNexus] which adds `@get:ServiceReference` so Gradle tracks the service as a
+ * task dependency automatically.
+ */
+@DisableCachingByDefault(because = "Uploading to an external service is not cacheable")
+abstract class AbstractBatchUploadToNexus @Inject constructor(
+    private val objects: ObjectFactory,
+    private val providers: ProviderFactory,
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Nexus client to use for all uploads in this task.
+     */
+    @get:Internal
+    abstract val service: Property<NexusClientBuildService>
+
+    /**
+     * A single artifact entry registered for upload.
+     */
+    abstract class Artifact @Inject constructor(private val name: String) : Named {
+        override fun getName() = name
+
+        /**
+         * The name of the Nexus repository to upload to.
+         */
+        abstract val repository: Property<String>
+
+        /**
+         * The target path within the repository (e.g. `com/example/1.0/artifact-1.0.jar`).
+         */
+        abstract val path: Property<String>
+
+        /**
+         * The local file to upload.
+         */
+        abstract val inputFile: RegularFileProperty
+    }
+
+    /**
+     * The registered artifacts to upload.
+     *
+     * Populated by [registerArtifact]; modifying this map directly is not recommended.
+     */
+    @get:Internal
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers a new artifact to be uploaded.
+     */
+    fun registerArtifact(name: String, configureAction: Action<in Artifact>) {
+        artifacts.put(name, providers.provider {
+            objects.newInstance<Artifact>(name).also { configureAction.execute(it) }
+        })
+    }
+
+    /**
+     * The input files consumed by this task, keyed by artifact name.
+     *
+     * Provided as a convenience for wiring other task outputs to this task's inputs.
+     */
+    @Suppress("LeakingThis")
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    val inputFiles = artifacts.map { it.mapValues { entry -> entry.value.inputFile.get() } }
+
+    /** Uploads all registered artifacts concurrently. */
+    @TaskAction
+    fun run() {
+        val queue = workerExecutor.noIsolation()
+        artifacts.get().forEach { (_, artifact) ->
+            queue.submit(UploadArtifactAction::class.java) { params ->
+                params.service.set(this@AbstractBatchUploadToNexus.service)
+                params.repository.set(artifact.repository)
+                params.path.set(artifact.path)
+                params.inputFile.set(artifact.inputFile)
+            }
+        }
+    }
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/AbstractNexusArtifactValueSource.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/AbstractNexusArtifactValueSource.kt
@@ -1,0 +1,69 @@
+package com.kelvsyc.gradle.nexus
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+import java.io.InputStream
+
+/**
+ * Base class for [ValueSource] implementations that provide a value by downloading an artifact
+ * from a Nexus raw repository at configuration time.
+ *
+ * Subclasses implement [doObtain] to transform the response [InputStream] into the desired type.
+ *
+ * **Configuration cache and sensitive artifacts:** Gradle serializes the result of every
+ * [ValueSource.obtain] call to the configuration cache in plaintext when the cache is written.
+ * Whatever [doObtain] returns — including any sensitive content the artifact may contain
+ * (credentials, private keys, tokens) — will be stored in `.gradle/configuration-cache/` and is
+ * readable by any process with access to the build directory. This applies regardless of how the
+ * resulting [org.gradle.api.provider.Provider] is stored: wiring it into a task `@Input` property,
+ * a `@get:Internal` property, or a private `val` all cause `obtain()` to run at configuration time
+ * and the result to be cached.
+ *
+ * If the fetched artifact may contain sensitive data, call the [NexusClientBuildService] client
+ * directly inside a [org.gradle.workers.WorkAction.execute] body instead, where the result is
+ * never written to the cache. Non-sensitive artifacts (version manifests, metadata, changelogs)
+ * are safe to use at configuration time.
+ */
+abstract class AbstractNexusArtifactValueSource<T : Any> :
+    ValueSource<T, AbstractNexusArtifactValueSource.Parameters> {
+
+    /**
+     * Parameters for [AbstractNexusArtifactValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the Nexus client.
+         */
+        @get:Internal
+        val service: Property<NexusClientBuildService>
+
+        /**
+         * The name of the Nexus repository containing the artifact.
+         */
+        val repository: Property<String>
+
+        /**
+         * The path to the artifact within the repository (e.g. `com/example/1.0/artifact-1.0.jar`).
+         */
+        val path: Property<String>
+    }
+
+    /**
+     * Transforms the artifact bytes downloaded from Nexus.
+     *
+     * Called once per [obtain] invocation with the response [InputStream]. The stream is
+     * closed after this method returns.
+     *
+     * @return The transformed value, or `null` if the data cannot be transformed.
+     */
+    abstract fun doObtain(input: InputStream): T?
+
+    override fun obtain(): T? {
+        val response = parameters.service.get().getClient()
+            .downloadAsset(parameters.repository.get(), parameters.path.get())
+            .execute()
+        return response.body()?.byteStream()?.use { doObtain(it) }
+    }
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/BatchDownloadFromNexus.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/BatchDownloadFromNexus.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.nexus
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractBatchDownloadFromNexus] that adds the `@get:ServiceReference`
+ * annotation to the [service] property so Gradle automatically tracks the build service as a
+ * task dependency.
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class BatchDownloadFromNexus @Inject constructor(
+    objects: ObjectFactory,
+    providers: ProviderFactory,
+    workerExecutor: WorkerExecutor,
+) : AbstractBatchDownloadFromNexus(objects, providers, workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<NexusClientBuildService>
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/BatchUploadToNexus.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/BatchUploadToNexus.kt
@@ -1,0 +1,25 @@
+package com.kelvsyc.gradle.nexus
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractBatchUploadToNexus] that adds the `@get:ServiceReference`
+ * annotation to the [service] property so Gradle automatically tracks the build service as a
+ * task dependency.
+ */
+@DisableCachingByDefault(because = "Uploading to an external service is not cacheable")
+abstract class BatchUploadToNexus @Inject constructor(
+    objects: ObjectFactory,
+    providers: ProviderFactory,
+    workerExecutor: WorkerExecutor,
+) : AbstractBatchUploadToNexus(objects, providers, workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<NexusClientBuildService>
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/DownloadArtifactAction.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/DownloadArtifactAction.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.nexus
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Gradle [WorkAction] for downloading a single artifact from a Nexus raw repository.
+ *
+ * The response body is streamed directly to [Parameters.outputFile], keeping heap usage constant
+ * regardless of artifact size.
+ */
+abstract class DownloadArtifactAction : WorkAction<DownloadArtifactAction.Parameters> {
+
+    /**
+     * Parameters for [DownloadArtifactAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Nexus client.
+         */
+        @get:Internal
+        val service: Property<NexusClientBuildService>
+
+        /**
+         * The name of the Nexus repository containing the artifact.
+         */
+        val repository: Property<String>
+
+        /**
+         * The path to the artifact within the repository (e.g. `com/example/1.0/artifact-1.0.jar`).
+         */
+        val path: Property<String>
+
+        /**
+         * The local file to which the artifact will be written.
+         */
+        val outputFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val response = parameters.service.get().getClient()
+            .downloadAsset(parameters.repository.get(), parameters.path.get())
+            .execute()
+        response.body()?.byteStream()?.use { input ->
+            val outputFile = parameters.outputFile.get().asFile
+            outputFile.parentFile.mkdirs()
+            outputFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/NexusClientBuildService.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/NexusClientBuildService.kt
@@ -1,0 +1,81 @@
+package com.kelvsyc.gradle.nexus
+
+import com.kelvsyc.gradle.clients.AbstractClientBuildService
+import com.kelvsyc.gradle.clients.CredentialReference
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.Credentials
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildServiceParameters
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+/**
+ * Build service managing a [NexusService] Retrofit client for a Sonatype Nexus Repository Manager 3 instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * [Params.baseUrl] and optionally [Params.username] and [Params.passwordRef] via the [anonymous] or
+ * [basicAuth] extension functions. The same registration can then be shared with value sources and
+ * work actions via a `Property<NexusClientBuildService>` parameter.
+ */
+abstract class NexusClientBuildService :
+    AbstractClientBuildService<NexusService, NexusClientBuildService.Params>() {
+
+    /**
+     * Configuration parameters for [NexusClientBuildService].
+     */
+    interface Params : BuildServiceParameters {
+        /**
+         * The base URL of the Nexus Repository Manager instance (e.g. `https://nexus.example.com/`).
+         * Must include a trailing slash.
+         */
+        val baseUrl: Property<String>
+
+        /**
+         * The Nexus username for basic authentication. Leave unset for anonymous access.
+         */
+        val username: Property<String>
+
+        /**
+         * Reference to where the Nexus password can be found. Ignored when [username] is absent.
+         *
+         * Stores a [CredentialReference] pointing to an environment variable or system property
+         * whose value is the password. Set via the [basicAuth] extension function.
+         */
+        val passwordRef: Property<CredentialReference>
+    }
+
+    override fun createClient(): NexusService {
+        val moshi = Moshi.Builder()
+            .addLast(KotlinJsonAdapterFactory())
+            .build()
+
+        val httpClientBuilder = OkHttpClient.Builder()
+
+        if (parameters.username.isPresent) {
+            val authInterceptor = Interceptor { chain ->
+                val request = chain.request().newBuilder()
+                    .header(
+                        "Authorization",
+                        Credentials.basic(
+                            parameters.username.get(),
+                            parameters.passwordRef.orNull?.resolve() ?: "",
+                        ),
+                    )
+                    .build()
+                chain.proceed(request)
+            }
+            httpClientBuilder.addInterceptor(authInterceptor)
+        }
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl(parameters.baseUrl.get())
+            .client(httpClientBuilder.build())
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+
+        return retrofit.create(NexusService::class.java)
+    }
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/NexusClientBuildServiceParamsExtensions.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/NexusClientBuildServiceParamsExtensions.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.nexus
+
+import com.kelvsyc.gradle.clients.CredentialReference
+
+/**
+ * Configures anonymous (unauthenticated) access. This is the default when
+ * [NexusClientBuildService.Params.username] is not set.
+ */
+fun NexusClientBuildService.Params.anonymous() {
+    // no-op: anonymous is the default when username is unset
+}
+
+/**
+ * Configures basic-auth access with a fixed [username] and a [CredentialReference] for the
+ * password.
+ *
+ * [username] is a non-sensitive identifier stored as a plain string. [password] is a
+ * [CredentialReference] pointing to an environment variable or system property whose value is
+ * the password — by default `NEXUS_PASSWORD`. The credential value is resolved at build execution
+ * time and never enters the Gradle configuration cache.
+ *
+ * Nexus user tokens (generated via the Nexus UI) are presented as a username/password pair and
+ * can be supplied here without API difference.
+ */
+fun NexusClientBuildService.Params.basicAuth(
+    username: String,
+    password: CredentialReference = CredentialReference.EnvironmentVariable("NEXUS_PASSWORD"),
+) {
+    this.username.set(username)
+    this.passwordRef.set(password)
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/NexusService.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/NexusService.kt
@@ -1,0 +1,37 @@
+package com.kelvsyc.gradle.nexus
+
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+import retrofit2.http.Path
+import retrofit2.http.Query
+import retrofit2.http.Streaming
+
+interface NexusService {
+    /**
+     * Downloads an artifact from a raw repository by full path, streaming the response body.
+     */
+    @Streaming
+    @GET("repository/{repository}/{path}")
+    fun downloadAsset(
+        @Path("repository") repository: String,
+        @Path("path", encoded = true) path: String,
+    ): Call<ResponseBody>
+
+    /**
+     * Uploads a file to a raw repository using the Nexus REST v1 multipart format.
+     */
+    @Multipart
+    @POST("service/rest/v1/components")
+    fun uploadRawAsset(
+        @Query("repository") repository: String,
+        @Part("raw.directory") directory: RequestBody,
+        @Part("raw.asset1.filename") filename: RequestBody,
+        @Part raw: MultipartBody.Part,
+    ): Call<ResponseBody>
+}

--- a/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/UploadArtifactAction.kt
+++ b/cores/nexus-base/src/main/kotlin/com/kelvsyc/gradle/nexus/UploadArtifactAction.kt
@@ -1,0 +1,73 @@
+package com.kelvsyc.gradle.nexus
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * Gradle [WorkAction] for uploading a single file to a Nexus raw repository.
+ *
+ * The caller provides a `repository` and a `path` in the form `directory/filename` (e.g.
+ * `com/example/1.0/artifact-1.0.jar`). The path is split on the last `/` to produce the
+ * `raw.directory` and `raw.asset1.filename` multipart fields required by the Nexus REST v1 API.
+ * A path with no `/` (root-level file) sends an empty string for `raw.directory`.
+ */
+abstract class UploadArtifactAction : WorkAction<UploadArtifactAction.Parameters> {
+
+    /**
+     * Parameters for [UploadArtifactAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Nexus client.
+         */
+        @get:Internal
+        val service: Property<NexusClientBuildService>
+
+        /**
+         * The name of the Nexus repository to upload to.
+         */
+        val repository: Property<String>
+
+        /**
+         * The target path within the repository (e.g. `com/example/1.0/artifact-1.0.jar`).
+         * Split on the last `/` to derive `raw.directory` and `raw.asset1.filename`.
+         */
+        val path: Property<String>
+
+        /**
+         * The local file to upload.
+         */
+        val inputFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val path = parameters.path.get()
+        val lastSlash = path.lastIndexOf('/')
+        val directory = if (lastSlash >= 0) path.substring(0, lastSlash) else ""
+        val filename = if (lastSlash >= 0) path.substring(lastSlash + 1) else path
+
+        val textMediaType = "text/plain".toMediaType()
+        val file = parameters.inputFile.get().asFile
+        val rawPart = MultipartBody.Part.createFormData(
+            "raw.asset1",
+            filename,
+            file.asRequestBody("application/octet-stream".toMediaType()),
+        )
+
+        parameters.service.get().getClient()
+            .uploadRawAsset(
+                parameters.repository.get(),
+                directory.toRequestBody(textMediaType),
+                filename.toRequestBody(textMediaType),
+                rawPart,
+            )
+            .execute()
+    }
+}

--- a/cores/nexus-base/src/test/kotlin/com/kelvsyc/gradle/nexus/DownloadArtifactActionSpec.kt
+++ b/cores/nexus-base/src/test/kotlin/com/kelvsyc/gradle/nexus/DownloadArtifactActionSpec.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.nexus
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.ResponseBody
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import retrofit2.Call
+import retrofit2.Response
+import java.io.File
+
+class DownloadArtifactActionSpec : FunSpec() {
+    init {
+        test("streams response body to outputFile") {
+            val project = ProjectBuilder.builder().build()
+            val mockService = mockk<NexusService>()
+            MockNexusClientBuildService.mockClient = mockService
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "nexus",
+                MockNexusClientBuildService::class,
+            )
+
+            val expectedBytes = "artifact content".toByteArray()
+            val responseBody = mockk<ResponseBody>()
+            every { responseBody.byteStream() } returns expectedBytes.inputStream()
+            val call = mockk<Call<ResponseBody>>()
+            every { call.execute() } returns Response.success(responseBody)
+            every { mockService.downloadAsset("my-repo", "path/to/artifact.jar") } returns call
+
+            val tmpFile = File.createTempFile("test-artifact", ".jar")
+            tmpFile.deleteOnExit()
+
+            val params = project.objects.newInstance<DownloadArtifactAction.Parameters>()
+            params.service.set(service)
+            params.repository.set("my-repo")
+            params.path.set("path/to/artifact.jar")
+            params.outputFile.set(tmpFile)
+
+            val action = object : DownloadArtifactAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            tmpFile.readBytes() shouldBe expectedBytes
+        }
+    }
+}

--- a/cores/nexus-base/src/test/kotlin/com/kelvsyc/gradle/nexus/MockNexusClientBuildService.kt
+++ b/cores/nexus-base/src/test/kotlin/com/kelvsyc/gradle/nexus/MockNexusClientBuildService.kt
@@ -1,0 +1,12 @@
+package com.kelvsyc.gradle.nexus
+
+/**
+ * Test-only [NexusClientBuildService] that returns a pre-supplied mock [NexusService].
+ */
+abstract class MockNexusClientBuildService : NexusClientBuildService() {
+    override fun createClient(): NexusService = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: NexusService? = null
+    }
+}

--- a/cores/nexus-base/src/test/kotlin/com/kelvsyc/gradle/nexus/UploadArtifactActionSpec.kt
+++ b/cores/nexus-base/src/test/kotlin/com/kelvsyc/gradle/nexus/UploadArtifactActionSpec.kt
@@ -1,0 +1,112 @@
+package com.kelvsyc.gradle.nexus
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import okio.Buffer
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import retrofit2.Call
+import retrofit2.Response
+import java.io.File
+
+class UploadArtifactActionSpec : FunSpec() {
+    init {
+        test("calls uploadRawAsset with correct repository, directory, and filename") {
+            val project = ProjectBuilder.builder().build()
+            val mockService = mockk<NexusService>()
+            MockNexusClientBuildService.mockClient = mockService
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "nexus",
+                MockNexusClientBuildService::class,
+            )
+
+            val repositorySlot = slot<String>()
+            val directorySlot = slot<RequestBody>()
+            val filenameSlot = slot<RequestBody>()
+            val partSlot = slot<MultipartBody.Part>()
+            val mockCall = mockk<Call<ResponseBody>>()
+            every { mockCall.execute() } returns Response.success(mockk<ResponseBody>())
+            every {
+                mockService.uploadRawAsset(
+                    capture(repositorySlot),
+                    capture(directorySlot),
+                    capture(filenameSlot),
+                    capture(partSlot),
+                )
+            } returns mockCall
+
+            val tmpFile = File.createTempFile("artifact", ".jar")
+            tmpFile.deleteOnExit()
+            tmpFile.writeBytes("content".toByteArray())
+
+            val params = project.objects.newInstance<UploadArtifactAction.Parameters>()
+            params.service.set(service)
+            params.repository.set("my-repo")
+            params.path.set("com/example/1.0/artifact-1.0.jar")
+            params.inputFile.set(tmpFile)
+
+            val action = object : UploadArtifactAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            repositorySlot.captured shouldBe "my-repo"
+            directorySlot.captured.readText() shouldBe "com/example/1.0"
+            filenameSlot.captured.readText() shouldBe "artifact-1.0.jar"
+        }
+
+        test("path with no slash sends empty directory") {
+            val project = ProjectBuilder.builder().build()
+            val mockService = mockk<NexusService>()
+            MockNexusClientBuildService.mockClient = mockService
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "nexus2",
+                MockNexusClientBuildService::class,
+            )
+
+            val directorySlot = slot<RequestBody>()
+            val filenameSlot = slot<RequestBody>()
+            val mockCall = mockk<Call<ResponseBody>>()
+            every { mockCall.execute() } returns Response.success(mockk<ResponseBody>())
+            every {
+                mockService.uploadRawAsset(
+                    any(),
+                    capture(directorySlot),
+                    capture(filenameSlot),
+                    any(),
+                )
+            } returns mockCall
+
+            val tmpFile = File.createTempFile("artifact", ".jar")
+            tmpFile.deleteOnExit()
+            tmpFile.writeBytes("content".toByteArray())
+
+            val params = project.objects.newInstance<UploadArtifactAction.Parameters>()
+            params.service.set(service)
+            params.repository.set("my-repo")
+            params.path.set("artifact.jar")
+            params.inputFile.set(tmpFile)
+
+            val action = object : UploadArtifactAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            directorySlot.captured.readText() shouldBe ""
+            filenameSlot.captured.readText() shouldBe "artifact.jar"
+        }
+    }
+
+    private fun RequestBody.readText(): String {
+        val buffer = Buffer()
+        writeTo(buffer)
+        return buffer.readUtf8()
+    }
+}

--- a/docs/superpowers/specs/2026-05-16-nexus-base-design.md
+++ b/docs/superpowers/specs/2026-05-16-nexus-base-design.md
@@ -1,0 +1,249 @@
+# Design: `nexus-base`
+
+**Date:** 2026-05-16
+**Status:** Approved
+
+## Overview
+
+`nexus-base` is a Gradle library component that provides managed Sonatype Nexus Repository Manager 3
+client infrastructure for use in Gradle builds. It supports generic artifact upload and download
+(including parallel batch operations) and a configuration-time ValueSource for artifacts whose
+contents can fit in memory. Integration with `RepositoryHandler` or Gradle's publishing framework
+is explicitly out of scope.
+
+The component is a peer of `artifactory-base` in the dependency hierarchy: both depend on
+`clients-base` and follow the same BuildService / ValueSource / WorkAction / Task pattern. The
+implementation difference is that `nexus-base` uses Retrofit + OkHttp rather than a native SDK,
+following the pattern established by `bitbucket-cloud-base`.
+
+## Architecture
+
+### Position in the dependency graph
+
+```
+clients-base  (AbstractClientBuildService, CredentialReference)
+    └── nexus-base
+```
+
+No intermediate extensions layer is needed — Nexus is a single vendor with one HTTP surface.
+
+### Module location
+
+`cores/nexus-base`
+
+### Convention plugin
+
+`com.kelvsyc.internal.kotlin-gradle-library` — same as `artifactory-base` and all other service
+base components.
+
+### Dependencies
+
+| Scope | Artifact | Rationale |
+|---|---|---|
+| `api` | `com.kelvsyc.gradle:clients-base` | `AbstractClientBuildService`, `CredentialReference` |
+| `api` | `retrofit` | Kept as `api` to preserve a future Option B expansion path (see Future Work) |
+| `api` | `moshi` | Kept as `api` for the same reason |
+| `implementation` | `okhttp` | Transport detail; not part of the public API shape |
+| `implementation` | `moshi-kotlin` | `KotlinJsonAdapterFactory` is a wiring detail |
+| `implementation` | `retrofit-converter-moshi` | Converter registration is internal |
+| `testImplementation` | `mockk` | WorkAction unit tests |
+
+All dependencies are already present in the version catalog. No new BOM entries are required.
+
+### Internal Retrofit interface
+
+`NexusService` is the Retrofit service interface. It is `internal` — callers interact exclusively
+through the typed BuildService, ValueSources, and tasks. Relevant endpoints:
+
+- `@Streaming @GET("repository/{repository}/{path}") downloadAsset(...)` — streams artifact bytes
+  from a raw repository by full path.
+- `@Multipart @POST("service/rest/v1/components") uploadRawAsset(...)` — uploads a file to a raw
+  repository using the Nexus REST v1 multipart format (`raw.directory`, `raw.asset1.filename`,
+  `raw.asset1`).
+
+## BuildService
+
+### `NexusClientBuildService`
+
+Extends `AbstractClientBuildService<NexusService, NexusClientBuildService.Params>`.
+
+**Parameters:**
+
+| Property | Type | Required | Notes |
+|---|---|---|---|
+| `baseUrl` | `Property<String>` | Yes | Always self-hosted; no default |
+| `username` | `Property<String>` | No | Absent = anonymous access |
+| `passwordRef` | `Property<CredentialReference>` | No | Ignored when `username` is absent |
+
+`createClient()` builds an OkHttp client and wraps it in a Retrofit instance pointing at `baseUrl`.
+If `username` is present, a basic-auth `Interceptor` is added to the OkHttp client; otherwise the
+client is built without authentication (anonymous access).
+
+**Extension functions on `Params`:**
+
+```kotlin
+/** Configures anonymous (unauthenticated) access. */
+fun NexusClientBuildService.Params.anonymous()
+
+/**
+ * Configures HTTP Basic authentication.
+ *
+ * [password] defaults to [CredentialReference.EnvironmentVariable] resolving `NEXUS_PASSWORD`.
+ * The credential value is resolved at build execution time and never enters the Gradle
+ * configuration cache.
+ */
+fun NexusClientBuildService.Params.basicAuth(
+    username: String,
+    password: CredentialReference = CredentialReference.EnvironmentVariable("NEXUS_PASSWORD"),
+)
+```
+
+Nexus user tokens (generated via the Nexus UI) are presented as a username/password pair and
+consumed through `basicAuth()` without API difference.
+
+## ValueSource
+
+### `AbstractNexusArtifactValueSource<T : Any>`
+
+A configuration-time ValueSource that downloads a single artifact by repository and path and
+returns a caller-supplied transformation of the response bytes.
+
+**Parameters:**
+
+| Property | Type |
+|---|---|
+| `service` | `Property<NexusClientBuildService>` |
+| `repository` | `Property<String>` |
+| `path` | `Property<String>` |
+
+`obtain()` calls `NexusService.downloadAsset()` with `@Streaming` (prevents OkHttp from buffering
+the full response body in the JVM heap), then passes the response `InputStream` to the abstract
+`doObtain(InputStream): T?` method. Callers subclass and implement `doObtain`.
+
+**KDoc disclaimer (required on this class):**
+
+> **Configuration cache and sensitive artifacts:** Gradle serializes the result of every
+> `ValueSource.obtain()` call to the configuration cache in plaintext when the cache is written.
+> Whatever `doObtain` returns — including any sensitive content the artifact may contain
+> (credentials, private keys, tokens) — will be stored in `.gradle/configuration-cache/` and is
+> readable by any process with access to the build directory. This applies regardless of how the
+> resulting `Provider` is stored: wiring it into a task `@Input` property, a `@get:Internal`
+> property, or a private `val` all cause `obtain()` to run at configuration time and the result to
+> be cached.
+>
+> If the fetched artifact may contain sensitive data, call the `NexusClientBuildService` client
+> directly inside a `WorkAction.execute()` body instead, where the result is never written to the
+> cache. Non-sensitive artifacts (version manifests, metadata, changelogs) are safe to use at
+> configuration time.
+
+## WorkActions
+
+Both WorkActions use `Property<NexusClientBuildService>` (no `@ServiceReference` — that annotation
+applies to `DefaultTask` properties, not `WorkParameters`).
+
+### `DownloadArtifactAction`
+
+**Parameters:** `service`, `repository`, `path`, `outputFile: RegularFileProperty`
+
+`execute()` calls `downloadAsset()` with `@Streaming` and pipes the response `InputStream` to
+`outputFile` via `InputStream.copyTo(OutputStream)`, keeping heap usage constant regardless of
+artifact size.
+
+### `UploadArtifactAction`
+
+**Parameters:** `service`, `repository`, `path`, `inputFile: RegularFileProperty`
+
+`execute()` splits `path` on the last `/`:
+- Everything before the last `/` becomes `raw.directory` in the multipart body.
+- The tail becomes `raw.asset1.filename`.
+- A path with no `/` (root-level file) sends an empty string for `raw.directory`.
+- `raw.directory` does **not** carry a leading `/` — the split produces `com/example/1.0` not
+  `/com/example/1.0`. This matches the Nexus REST v1 examples in the official documentation.
+
+This split is an internal implementation detail of the Nexus raw-format REST API and is not part
+of the caller-facing API. The caller-facing coordinate is always `repository` + `path`.
+
+## Tasks
+
+Two abstract/concrete pairs, following the `artifactory-base` pattern exactly.
+
+### Download pair
+
+**`AbstractBatchDownloadFromNexus`** — `DefaultTask` with:
+- Inner class `Artifact(name: String) : Named` with `repository: Property<String>`,
+  `path: Property<String>`, `outputFile: RegularFileProperty`.
+- `fun registerArtifact(name: String, action: Action<Artifact>)`
+- `@get:OutputFiles val outputFiles: FileCollection`
+- `@TaskAction` submits one `DownloadArtifactAction` per registered artifact via
+  `WorkerExecutor.noIsolation()`.
+
+**`BatchDownloadFromNexus`** — concrete subclass that adds:
+- `@get:ServiceReference val service: Property<NexusClientBuildService>`
+
+### Upload pair
+
+**`AbstractBatchUploadToNexus`** — same structure with `inputFile: RegularFileProperty` and
+`@get:InputFiles @get:PathSensitive(PathSensitivity.NONE) val inputFiles`.
+
+**`BatchUploadToNexus`** — concrete subclass with `@get:ServiceReference`.
+
+## Testing
+
+### `MockNexusClientBuildService`
+
+Located in `src/test/kotlin`. Overrides `createClient()` to return `mockk<NexusService>()`. Since
+`NexusService` is `internal`, it is visible from test sources within the same module.
+
+### `DownloadArtifactActionTest`
+
+Instantiates `DownloadArtifactAction` as an anonymous subclass with `getParameters()` overridden.
+Stubs `mockNexusService.downloadAsset(any(), any())` to return a mock `ResponseBody` backed by a
+fixed byte array. Calls `execute()` and asserts `outputFile` contains the expected bytes.
+
+### `UploadArtifactActionTest`
+
+Same structure. Stubs `uploadRawAsset(...)` to return a successful empty response. After
+`execute()`, verifies:
+- `uploadRawAsset` was called with the expected `repository`.
+- The `raw.directory` and `raw.asset1.filename` multipart fields correctly reflect the split of the
+  input `path`.
+- Edge case: a `path` containing no `/` results in an empty `raw.directory` and a `raw.asset1.filename`
+  equal to the full path.
+
+No integration tests for v1 — there is no hosted Nexus instance available in CI. Integration tests
+can be added when a test environment is provisioned.
+
+## README
+
+The component README must include:
+
+1. A usage example showing `BuildServiceRegistry.registerIfAbsent` for `NexusClientBuildService`
+   with both `basicAuth()` and `anonymous()` configurations.
+2. A usage example for `BatchDownloadFromNexus` and `BatchUploadToNexus` task registration.
+3. A usage example showing how to implement `AbstractNexusArtifactValueSource`.
+4. A configuration cache safety callout:
+
+> **Configuration cache and sensitive artifacts:** `AbstractNexusArtifactValueSource` serializes
+> its result to the Gradle configuration cache in plaintext. Do not use it to fetch artifacts whose
+> contents are sensitive (credentials, private keys, tokens). Fetch sensitive content inside a
+> `WorkAction` at task execution time instead — the result is resolved after the cache has been
+> read and is never written to it.
+
+## Future Work
+
+### Option C — Search-based asset discovery
+
+Add a `SearchAssetsValueSource` wrapping `GET /service/rest/v1/search/assets`. Callers could
+discover artifact paths at configuration time by querying repository, name, version, and other
+criteria rather than supplying the full path statically. Requires a Moshi data model for search
+result pages and pagination handling.
+
+### Option B — Arbitrary REST ValueSource
+
+Add an `AbstractNexusRequestValueSource<T>` for arbitrary Nexus REST GET calls (Moshi-parsed
+response). Deferred unless there is a concrete need to expand the underlying Retrofit client
+surface. If pursued, `NexusService` would need to be promoted from `internal` to public.
+
+### GitLab Generic Packages and Azure Artifacts Universal Packages
+
+Companion components following this same design (Option A only), to be designed separately.


### PR DESCRIPTION
## Summary

- Adds `cores/nexus-base`, a new Gradle library providing managed Sonatype Nexus Repository Manager 3 client infrastructure built on `clients-base` with a Retrofit/OkHttp transport.
- Implements `NexusClientBuildService` (with `anonymous()`/`basicAuth()` extension functions), `AbstractNexusArtifactValueSource`, `DownloadArtifactAction`, `UploadArtifactAction`, and `AbstractBatchDownloadFromNexus`/`BatchDownloadFromNexus` and `AbstractBatchUploadToNexus`/`BatchUploadToNexus` task pairs — mirroring the `artifactory-base` pattern with Retrofit/OkHttp following `bitbucket-cloud-base`.
- Includes `DownloadArtifactActionSpec` and `UploadArtifactActionSpec` unit tests (using `MockNexusClientBuildService`), a component `README.md`, and a root `README.md` entry.

## Test Plan

- [x] `./gradlew :nexus-base:test` — all tests pass
- [x] `./gradlew :nexus-base:detekt` — clean
- [x] `./gradlew :nexus-base:build` — compiles, Dokka docs generated, JaCoCo report produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)