### PR TITLE
fix: pin opentelemetry-bom to 1.62.0 to remediate CVE-2026-45292

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ aws-java-sdk-bom = "software.amazon.awssdk:bom:2.44.0"
 aws-kotlin-sdk-bom = "aws.sdk.kotlin:bom:1.6.59"
 azure-sdk-bom = "com.azure:azure-sdk-bom:1.3.6"
 google-cloud-libraries-bom = "com.google.cloud:libraries-bom:26.82.0"
+opentelemetry-bom = "io.opentelemetry:opentelemetry-bom:1.62.0"
 jackson-bom = "com.fasterxml.jackson:jackson-bom:2.21.3"
 kotlin-gradle-plugins-bom = { module = "org.jetbrains.kotlin:kotlin-gradle-plugins-bom", version.ref = "kotlin" }
 kotlin-tools-bom = { module = "com.kelvsyc.kotlin:bom", version.ref = "kotlin-tools" }

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     api(platform(libs.aws.java.sdk.bom))
     api(platform(libs.aws.kotlin.sdk.bom))
     api(platform(libs.google.cloud.libraries.bom))
+    api(platform(libs.opentelemetry.bom))
     api(platform(libs.jackson.bom))
     api(platform(libs.kotest.bom))
     api(platform(libs.netty.bom))


### PR DESCRIPTION
## Summary

- The GCP `libraries-bom` transitively pins `io.opentelemetry:opentelemetry-api` to 1.57.0, which is vulnerable to unbounded memory allocation in W3C Baggage Propagation (CVE-2026-45292, Dependabot alert #31).
- Bumping the GCP BOM alone does not fix this — both 26.82.0 and 26.83.0 use the same `google-cloud-storage-bom:2.68.0` which pins the old version.
- Adding `io.opentelemetry:opentelemetry-bom:1.62.0` as a sibling `platform()` import in the internal platform BOM causes Gradle to upgrade all `io.opentelemetry:*` modules from 1.57.0 → 1.62.0.

## Test plan

- [x] Verified `io.opentelemetry:opentelemetry-api` resolves to 1.62.0 via `./gradlew :google-cloud-storage-base:dependencies`
- [x] `./gradlew :check` passes (all tests + detekt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)