### PR TITLE
feat: split and expand RepositoryHandler extensions in gradle-extensions

### DIFF
--- a/cores/gradle-extensions/README.md
+++ b/cores/gradle-extensions/README.md
@@ -67,19 +67,68 @@ val cachedValue: Provider<String> = someExpensiveProvider.cached(objects)
 | `Provider<Map<K, V>>.orElseEmpty` | Falls back to empty map |
 | `Provider<Properties>.asMap` | Converts `Properties` to `Map<String, String>` |
 
-## Repository Handler Extensions (`RepositoryHandlerExtensions`)
+## Repository Handler Extensions
 
-Convenience methods for common Maven repository configurations:
+Convenience extension functions for common Maven and Ivy repository configurations. All are extensions on
+`RepositoryHandler` and accept an optional trailing action lambda for further configuration (e.g. credentials).
+
+### Git platform registries (`GitRegistryRepositoryHandlerExtensions`)
 
 ```kotlin
 repositories {
+    // GitHub Packages
     gitHubPackages("MyRepo", "owner", "repo-name") {
         credentials(PasswordCredentials::class.java)
     }
+    // GitLab Package Registry
     gitLabPackages("MyGitLabRepo", "12345678")
+    // Gitea / Forgejo — baseUrl is the server root, not the /api/v1 REST base
+    giteaPackages("MyGiteaRepo", "https://gitea.example.com", "myorg")
+}
+```
+
+### AWS (`AwsRepositoryHandlerExtensions`)
+
+```kotlin
+repositories {
     awsCodeArtifact("MyCodeArtifact", "my-domain", "111122223333", "us-east-1", "my-repo")
 }
 ```
+
+### GCP (`GcpRepositoryHandlerExtensions`)
+
+```kotlin
+repositories {
+    gcpArtifactRegistry("MyGAR", "us-central1", "my-gcp-project", "my-repo")
+}
+```
+
+### Sonatype Nexus (`NexusRepositoryHandlerExtensions`)
+
+```kotlin
+repositories {
+    nexusMaven("MyNexus", "https://nexus.example.com", "releases")
+}
+```
+
+`baseUrl` accepts with or without a trailing slash.
+
+### JFrog Artifactory and JFrog Cloud (`ArtifactoryRepositoryHandlerExtensions`)
+
+```kotlin
+repositories {
+    // Self-hosted Artifactory — Maven
+    artifactoryMaven("MyArtifactory", "https://artifactory.example.com/artifactory", "libs-release")
+    // Self-hosted Artifactory — Ivy (use action to configure layout patterns)
+    artifactoryIvy("MyArtifactoryIvy", "https://artifactory.example.com/artifactory", "libs-ivy")
+    // JFrog Cloud — Maven
+    jfrogCloudMaven("MyJFrogMaven", "mycompany", "libs-release")
+    // JFrog Cloud — Ivy
+    jfrogCloudIvy("MyJFrogIvy", "mycompany", "libs-ivy")
+}
+```
+
+`serverUrl` for self-hosted Artifactory accepts with or without a trailing slash.
 
 ## Task Extensions
 

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/ArtifactoryRepositoryHandlerExtensions.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/ArtifactoryRepositoryHandlerExtensions.kt
@@ -1,0 +1,134 @@
+package com.kelvsyc.gradle.providers
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import java.net.URI
+
+/**
+ * Adds and configures a self-hosted JFrog Artifactory Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param serverUrl The Artifactory server URL including the context path
+ *   (e.g. `https://artifactory.example.com/artifactory`), with or without a trailing slash
+ * @param repoKey The Artifactory repository key
+ */
+fun RepositoryHandler.artifactoryMaven(name: String, serverUrl: String, repoKey: String) = mavenKt {
+    this.name = name
+    url = URI.create("${serverUrl.trimEnd('/')}/$repoKey")
+}
+
+/**
+ * Adds and configures a self-hosted JFrog Artifactory Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param serverUrl The Artifactory server URL including the context path
+ *   (e.g. `https://artifactory.example.com/artifactory`), with or without a trailing slash
+ * @param repoKey The Artifactory repository key
+ * @param action Configuration action for further configuration of the artifact repository
+ */
+fun RepositoryHandler.artifactoryMaven(
+    name: String,
+    serverUrl: String,
+    repoKey: String,
+    action: MavenArtifactRepository.() -> Unit
+) = mavenKt {
+    this.name = name
+    url = URI.create("${serverUrl.trimEnd('/')}/$repoKey")
+    action(this)
+}
+
+/**
+ * Adds and configures a self-hosted JFrog Artifactory Ivy repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param serverUrl The Artifactory server URL including the context path
+ *   (e.g. `https://artifactory.example.com/artifactory`), with or without a trailing slash
+ * @param repoKey The Artifactory repository key
+ */
+fun RepositoryHandler.artifactoryIvy(name: String, serverUrl: String, repoKey: String) = ivyKt {
+    this.name = name
+    url = URI.create("${serverUrl.trimEnd('/')}/$repoKey")
+}
+
+/**
+ * Adds and configures a self-hosted JFrog Artifactory Ivy repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param serverUrl The Artifactory server URL including the context path
+ *   (e.g. `https://artifactory.example.com/artifactory`), with or without a trailing slash
+ * @param repoKey The Artifactory repository key
+ * @param action Configuration action for further configuration of the artifact repository, including layout patterns
+ */
+fun RepositoryHandler.artifactoryIvy(
+    name: String,
+    serverUrl: String,
+    repoKey: String,
+    action: IvyArtifactRepository.() -> Unit
+) = ivyKt {
+    this.name = name
+    url = URI.create("${serverUrl.trimEnd('/')}/$repoKey")
+    action(this)
+}
+
+/**
+ * Adds and configures a JFrog Cloud Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param orgName The JFrog Cloud organisation name (the subdomain of `jfrog.io`)
+ * @param repoKey The Artifactory repository key
+ */
+fun RepositoryHandler.jfrogCloudMaven(name: String, orgName: String, repoKey: String) = mavenKt {
+    this.name = name
+    url = URI.create("https://$orgName.jfrog.io/artifactory/$repoKey")
+}
+
+/**
+ * Adds and configures a JFrog Cloud Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param orgName The JFrog Cloud organisation name (the subdomain of `jfrog.io`)
+ * @param repoKey The Artifactory repository key
+ * @param action Configuration action for further configuration of the artifact repository
+ */
+fun RepositoryHandler.jfrogCloudMaven(
+    name: String,
+    orgName: String,
+    repoKey: String,
+    action: MavenArtifactRepository.() -> Unit
+) = mavenKt {
+    this.name = name
+    url = URI.create("https://$orgName.jfrog.io/artifactory/$repoKey")
+    action(this)
+}
+
+/**
+ * Adds and configures a JFrog Cloud Ivy repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param orgName The JFrog Cloud organisation name (the subdomain of `jfrog.io`)
+ * @param repoKey The Artifactory repository key
+ */
+fun RepositoryHandler.jfrogCloudIvy(name: String, orgName: String, repoKey: String) = ivyKt {
+    this.name = name
+    url = URI.create("https://$orgName.jfrog.io/artifactory/$repoKey")
+}
+
+/**
+ * Adds and configures a JFrog Cloud Ivy repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param orgName The JFrog Cloud organisation name (the subdomain of `jfrog.io`)
+ * @param repoKey The Artifactory repository key
+ * @param action Configuration action for further configuration of the artifact repository, including layout patterns
+ */
+fun RepositoryHandler.jfrogCloudIvy(
+    name: String,
+    orgName: String,
+    repoKey: String,
+    action: IvyArtifactRepository.() -> Unit
+) = ivyKt {
+    this.name = name
+    url = URI.create("https://$orgName.jfrog.io/artifactory/$repoKey")
+    action(this)
+}

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/AwsRepositoryHandlerExtensions.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/AwsRepositoryHandlerExtensions.kt
@@ -1,0 +1,49 @@
+package com.kelvsyc.gradle.providers
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import java.net.URI
+
+/**
+ * Adds and configures an AWS CodeArtifact repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param domain The CodeArtifact domain name
+ * @param domainOwner The AWS account ID that owns the domain
+ * @param region The AWS region
+ * @param repo The CodeArtifact repository name
+ */
+fun RepositoryHandler.awsCodeArtifact(
+    name: String,
+    domain: String,
+    domainOwner: String,
+    region: String,
+    repo: String
+) = mavenKt {
+    this.name = name
+    url = URI.create("https://$domain-$domainOwner.d.codeartifact.$region.amazonaws.com/maven/$repo")
+}
+
+/**
+ * Adds and configures an AWS CodeArtifact repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param domain The CodeArtifact domain name
+ * @param domainOwner The AWS account ID that owns the domain
+ * @param region The AWS region
+ * @param repo The CodeArtifact repository name
+ * @param action Configuration action for further configuration of the artifact repository
+ */
+@Suppress("detekt:LongParameterList")
+fun RepositoryHandler.awsCodeArtifact(
+    name: String,
+    domain: String,
+    domainOwner: String,
+    region: String,
+    repo: String,
+    action: MavenArtifactRepository.() -> Unit
+) = mavenKt {
+    this.name = name
+    url = URI.create("https://$domain-$domainOwner.d.codeartifact.$region.amazonaws.com/maven/$repo")
+    action(this)
+}

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/GcpRepositoryHandlerExtensions.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/GcpRepositoryHandlerExtensions.kt
@@ -1,0 +1,44 @@
+package com.kelvsyc.gradle.providers
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import java.net.URI
+
+/**
+ * Adds and configures a GCP Artifact Registry Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param region The GCP region (e.g. `us-central1`)
+ * @param project The GCP project ID
+ * @param repo The Artifact Registry repository name
+ */
+fun RepositoryHandler.gcpArtifactRegistry(
+    name: String,
+    region: String,
+    project: String,
+    repo: String
+) = mavenKt {
+    this.name = name
+    url = URI.create("https://$region-maven.pkg.dev/$project/$repo/")
+}
+
+/**
+ * Adds and configures a GCP Artifact Registry Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param region The GCP region (e.g. `us-central1`)
+ * @param project The GCP project ID
+ * @param repo The Artifact Registry repository name
+ * @param action Configuration action for further configuration of the artifact repository
+ */
+fun RepositoryHandler.gcpArtifactRegistry(
+    name: String,
+    region: String,
+    project: String,
+    repo: String,
+    action: MavenArtifactRepository.() -> Unit
+) = mavenKt {
+    this.name = name
+    url = URI.create("https://$region-maven.pkg.dev/$project/$repo/")
+    action(this)
+}

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/GitRegistryRepositoryHandlerExtensions.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/GitRegistryRepositoryHandlerExtensions.kt
@@ -1,11 +1,13 @@
 package com.kelvsyc.gradle.providers
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import java.net.URI
 
-// Internal workaround since Gradle libraries do not treat Action<in T> as T.() -> Unit
+// Internal workarounds since Gradle libraries do not treat Action<in T> as T.() -> Unit
 internal fun RepositoryHandler.mavenKt(action: MavenArtifactRepository.() -> Unit) = maven(action)
+internal fun RepositoryHandler.ivyKt(action: IvyArtifactRepository.() -> Unit) = ivy(action)
 
 /**
  * Adds and configures a GitHub Packages repository.
@@ -67,45 +69,32 @@ fun RepositoryHandler.gitLabPackages(
 }
 
 /**
- * Adds and configures an AWS CodeArtifact repository.
+ * Adds and configures a Gitea or Forgejo Maven package registry repository.
  *
  * @param name The Gradle name of the repository
- * @param domain The AWS domain
- * @param domainOwner The ID of the AWS domain owner
- * @param region The AWS region
- * @param repo The repo name
+ * @param baseUrl The Gitea/Forgejo server root URL (e.g. `https://gitea.example.com`), without a trailing slash
+ * @param owner The Gitea/Forgejo user or organisation that owns the package namespace
  */
-fun RepositoryHandler.awsCodeArtifact(
-    name: String,
-    domain: String,
-    domainOwner: String,
-    region: String,
-    repo: String
-) = mavenKt {
+fun RepositoryHandler.giteaPackages(name: String, baseUrl: String, owner: String) = mavenKt {
     this.name = name
-    url = URI.create("https://$domain-$domainOwner.d.codeartifact.$region.amazonaws.com/maven/$repo")
+    url = URI.create("$baseUrl/api/packages/$owner/maven")
 }
 
 /**
- * Adds and configures an AWS CodeArtifact repository.
+ * Adds and configures a Gitea or Forgejo Maven package registry repository.
  *
  * @param name The Gradle name of the repository
- * @param domain The AWS domain
- * @param domainOwner The ID of the AWS domain owner
- * @param region The AWS region
- * @param repo The repo name
+ * @param baseUrl The Gitea/Forgejo server root URL (e.g. `https://gitea.example.com`), without a trailing slash
+ * @param owner The Gitea/Forgejo user or organisation that owns the package namespace
  * @param action Configuration action for further configuration of the artifact repository
  */
-@Suppress("detekt:LongParameterList")
-fun RepositoryHandler.awsCodeArtifact(
+fun RepositoryHandler.giteaPackages(
     name: String,
-    domain: String,
-    domainOwner: String,
-    region: String,
-    repo: String,
+    baseUrl: String,
+    owner: String,
     action: MavenArtifactRepository.() -> Unit
 ) = mavenKt {
     this.name = name
-    url = URI.create("https://$domain-$domainOwner.d.codeartifact.$region.amazonaws.com/maven/$repo")
+    url = URI.create("$baseUrl/api/packages/$owner/maven")
     action(this)
 }

--- a/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/NexusRepositoryHandlerExtensions.kt
+++ b/cores/gradle-extensions/src/main/kotlin/com/kelvsyc/gradle/providers/NexusRepositoryHandlerExtensions.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.providers
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import java.net.URI
+
+/**
+ * Adds and configures a Sonatype Nexus Repository Manager 3 Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param baseUrl The Nexus server URL (e.g. `https://nexus.example.com`), with or without a trailing slash
+ * @param repoName The name of the Nexus Maven repository
+ */
+fun RepositoryHandler.nexusMaven(name: String, baseUrl: String, repoName: String) = mavenKt {
+    this.name = name
+    url = URI.create("${baseUrl.trimEnd('/')}/repository/$repoName")
+}
+
+/**
+ * Adds and configures a Sonatype Nexus Repository Manager 3 Maven repository.
+ *
+ * @param name The Gradle name of the repository
+ * @param baseUrl The Nexus server URL (e.g. `https://nexus.example.com`), with or without a trailing slash
+ * @param repoName The name of the Nexus Maven repository
+ * @param action Configuration action for further configuration of the artifact repository
+ */
+fun RepositoryHandler.nexusMaven(
+    name: String,
+    baseUrl: String,
+    repoName: String,
+    action: MavenArtifactRepository.() -> Unit
+) = mavenKt {
+    this.name = name
+    url = URI.create("${baseUrl.trimEnd('/')}/repository/$repoName")
+    action(this)
+}

--- a/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/ArtifactoryRepositoryHandlerExtensionsSpec.kt
+++ b/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/ArtifactoryRepositoryHandlerExtensionsSpec.kt
@@ -1,0 +1,119 @@
+package com.kelvsyc.gradle.providers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.api.artifacts.repositories.IvyArtifactRepository
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.testfixtures.ProjectBuilder
+import java.net.URI
+
+class ArtifactoryRepositoryHandlerExtensionsSpec : FunSpec() {
+    init {
+        test("artifactoryMaven sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.artifactoryMaven("MyRepo", "https://artifactory.example.com/artifactory", "libs-release")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://artifactory.example.com/artifactory/libs-release")
+        }
+
+        test("artifactoryMaven with trailing slash in serverUrl sets correct URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.artifactoryMaven("MyRepo", "https://artifactory.example.com/artifactory/", "libs-release")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://artifactory.example.com/artifactory/libs-release")
+        }
+
+        test("artifactoryMaven with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.artifactoryMaven("MyRepo", "https://artifactory.example.com/artifactory", "libs-release") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://artifactory.example.com/artifactory/libs-release")
+            actionInvoked shouldBeEqual true
+        }
+
+        test("artifactoryIvy sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.artifactoryIvy("MyRepo", "https://artifactory.example.com/artifactory", "libs-ivy")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<IvyArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://artifactory.example.com/artifactory/libs-ivy")
+        }
+
+        test("artifactoryIvy with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.artifactoryIvy("MyRepo", "https://artifactory.example.com/artifactory", "libs-ivy") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<IvyArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://artifactory.example.com/artifactory/libs-ivy")
+            actionInvoked shouldBeEqual true
+        }
+
+        test("jfrogCloudMaven sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.jfrogCloudMaven("MyRepo", "mycompany", "libs-release")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://mycompany.jfrog.io/artifactory/libs-release")
+        }
+
+        test("jfrogCloudMaven with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.jfrogCloudMaven("MyRepo", "mycompany", "libs-release") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://mycompany.jfrog.io/artifactory/libs-release")
+            actionInvoked shouldBeEqual true
+        }
+
+        test("jfrogCloudIvy sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.jfrogCloudIvy("MyRepo", "mycompany", "libs-ivy")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<IvyArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://mycompany.jfrog.io/artifactory/libs-ivy")
+        }
+
+        test("jfrogCloudIvy with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.jfrogCloudIvy("MyRepo", "mycompany", "libs-ivy") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<IvyArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://mycompany.jfrog.io/artifactory/libs-ivy")
+            actionInvoked shouldBeEqual true
+        }
+    }
+}

--- a/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/AwsRepositoryHandlerExtensionsSpec.kt
+++ b/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/AwsRepositoryHandlerExtensionsSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.providers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.testfixtures.ProjectBuilder
+import java.net.URI
+
+class AwsRepositoryHandlerExtensionsSpec : FunSpec() {
+    init {
+        test("awsCodeArtifact sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.awsCodeArtifact("MyRepo", "mydomain", "123456789", "us-east-1", "myrepo")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create(
+                "https://mydomain-123456789.d.codeartifact.us-east-1.amazonaws.com/maven/myrepo"
+            )
+        }
+
+        test("awsCodeArtifact with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.awsCodeArtifact("MyRepo", "mydomain", "123456789", "us-east-1", "myrepo") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create(
+                "https://mydomain-123456789.d.codeartifact.us-east-1.amazonaws.com/maven/myrepo"
+            )
+            actionInvoked shouldBeEqual true
+        }
+    }
+}

--- a/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/GcpRepositoryHandlerExtensionsSpec.kt
+++ b/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/GcpRepositoryHandlerExtensionsSpec.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.providers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.testfixtures.ProjectBuilder
+import java.net.URI
+
+class GcpRepositoryHandlerExtensionsSpec : FunSpec() {
+    init {
+        test("gcpArtifactRegistry sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.gcpArtifactRegistry("MyRepo", "us-central1", "my-project", "my-repo")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://us-central1-maven.pkg.dev/my-project/my-repo/")
+        }
+
+        test("gcpArtifactRegistry with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.gcpArtifactRegistry("MyRepo", "us-central1", "my-project", "my-repo") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://us-central1-maven.pkg.dev/my-project/my-repo/")
+            actionInvoked shouldBeEqual true
+        }
+    }
+}

--- a/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/GitRegistryRepositoryHandlerExtensionsSpec.kt
+++ b/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/GitRegistryRepositoryHandlerExtensionsSpec.kt
@@ -7,7 +7,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.testfixtures.ProjectBuilder
 import java.net.URI
 
-class RepositoryHandlerExtensionsSpec : FunSpec() {
+class GitRegistryRepositoryHandlerExtensionsSpec : FunSpec() {
     init {
         test("gitHubPackages sets name and URL") {
             val project = ProjectBuilder.builder().build()
@@ -57,31 +57,27 @@ class RepositoryHandlerExtensionsSpec : FunSpec() {
             actionInvoked shouldBeEqual true
         }
 
-        test("awsCodeArtifact sets name and URL") {
+        test("giteaPackages sets name and URL") {
             val project = ProjectBuilder.builder().build()
 
-            project.repositories.awsCodeArtifact("MyRepo", "mydomain", "123456789", "us-east-1", "myrepo")
+            project.repositories.giteaPackages("MyRepo", "https://gitea.example.com", "myorg")
 
             val repo = project.repositories.findByName("MyRepo")
             repo.shouldBeInstanceOf<MavenArtifactRepository>()
-            repo.url shouldBeEqual URI.create(
-                "https://mydomain-123456789.d.codeartifact.us-east-1.amazonaws.com/maven/myrepo"
-            )
+            repo.url shouldBeEqual URI.create("https://gitea.example.com/api/packages/myorg/maven")
         }
 
-        test("awsCodeArtifact with action sets name, URL, and invokes action") {
+        test("giteaPackages with action sets name, URL, and invokes action") {
             val project = ProjectBuilder.builder().build()
             var actionInvoked = false
 
-            project.repositories.awsCodeArtifact("MyRepo", "mydomain", "123456789", "us-east-1", "myrepo") {
+            project.repositories.giteaPackages("MyRepo", "https://gitea.example.com", "myorg") {
                 actionInvoked = true
             }
 
             val repo = project.repositories.findByName("MyRepo")
             repo.shouldBeInstanceOf<MavenArtifactRepository>()
-            repo.url shouldBeEqual URI.create(
-                "https://mydomain-123456789.d.codeartifact.us-east-1.amazonaws.com/maven/myrepo"
-            )
+            repo.url shouldBeEqual URI.create("https://gitea.example.com/api/packages/myorg/maven")
             actionInvoked shouldBeEqual true
         }
     }

--- a/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/NexusRepositoryHandlerExtensionsSpec.kt
+++ b/cores/gradle-extensions/src/test/kotlin/com/kelvsyc/gradle/providers/NexusRepositoryHandlerExtensionsSpec.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.providers
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
+import org.gradle.testfixtures.ProjectBuilder
+import java.net.URI
+
+class NexusRepositoryHandlerExtensionsSpec : FunSpec() {
+    init {
+        test("nexusMaven sets name and URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.nexusMaven("MyRepo", "https://nexus.example.com", "releases")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://nexus.example.com/repository/releases")
+        }
+
+        test("nexusMaven with trailing slash in baseUrl sets correct URL") {
+            val project = ProjectBuilder.builder().build()
+
+            project.repositories.nexusMaven("MyRepo", "https://nexus.example.com/", "releases")
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://nexus.example.com/repository/releases")
+        }
+
+        test("nexusMaven with action sets name, URL, and invokes action") {
+            val project = ProjectBuilder.builder().build()
+            var actionInvoked = false
+
+            project.repositories.nexusMaven("MyRepo", "https://nexus.example.com", "releases") {
+                actionInvoked = true
+            }
+
+            val repo = project.repositories.findByName("MyRepo")
+            repo.shouldBeInstanceOf<MavenArtifactRepository>()
+            repo.url shouldBeEqual URI.create("https://nexus.example.com/repository/releases")
+            actionInvoked shouldBeEqual true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Splits `RepositoryHandlerExtensions.kt` into five vendor-focused files: git-platform registries (GitHub Packages, GitLab, Gitea/Forgejo), AWS CodeArtifact, GCP Artifact Registry, Sonatype Nexus, and Artifactory/JFrog Cloud.
- Adds new `RepositoryHandler` extension functions for Gitea/Forgejo, GCP Artifact Registry, Nexus Maven, Artifactory Maven+Ivy, and JFrog Cloud Maven+Ivy — each with no-action and action-lambda overloads.
- Adds an `ivyKt` internal shim alongside the existing `mavenKt` shim to support Ivy repository registration.
- Updates `gradle-extensions/README.md` with per-category documentation and usage examples.

## Test plan

- [x] `./gradlew :gradle-extensions:test` — all tests pass (including new specs for each vendor category)
- [x] `./gradlew :gradle-extensions:detekt` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)