### PR TITLE
feat: add google-cloud-functions-base component for Cloud Functions Gen 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ since the two AWS SDKs are distinct libraries:
 | Component | Description |
 |-----------|-------------|
 | `google-cloud-artifact-registry-base` | GCP Artifact Registry |
+| `google-cloud-functions-base` | GCP Cloud Functions (Gen 2) |
 | `google-cloud-storage-base` | GCP Cloud Storage |
 | `google-cloud-secret-manager-base` | GCP Secret Manager |
 | `google-cloud-pubsub-base` | GCP Pub/Sub |

--- a/cores/google-cloud-functions-base/README.md
+++ b/cores/google-cloud-functions-base/README.md
@@ -1,0 +1,152 @@
+# Google Cloud Functions Base
+
+A Kotlin library providing managed Cloud Functions Gen 2 client integration using the Google Cloud
+Java SDK, built on `clients-base` and `google-cloud-extensions`.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:google-cloud-functions-base")
+}
+```
+
+## Build Service
+
+| Class | Client type |
+|---|---|
+| `FunctionServiceClientBuildService` | `FunctionServiceClient` (Cloud Functions v2 admin API) |
+
+```kotlin
+val functions = gradle.sharedServices.registerIfAbsent(
+    "functions",
+    FunctionServiceClientBuildService::class,
+) {
+    parameters {
+        projectId.set("my-project")
+        applicationDefault()
+    }
+}
+```
+
+Both `projectId` and the credentials call are optional. See
+[google-cloud-extensions](../google-cloud-extensions) for the full set of credential configuration
+functions.
+
+## Value Sources
+
+### `GetFunctionValueSource`
+
+Retrieves the HTTPS trigger URI of a Gen 2 function. Returns `null` if the function has no URI
+(e.g. still provisioning):
+
+```kotlin
+val functionUri: Provider<String> = providers.of(GetFunctionValueSource::class) {
+    parameters {
+        service.set(functions)
+        functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+    }
+}
+```
+
+### `ListFunctionsValueSource`
+
+Lists all Gen 2 functions in a project and location, returning a `Map<String, String>` keyed by
+short function name with the HTTPS trigger URI as the value. Pagination is handled internally:
+
+```kotlin
+val allFunctions: Provider<Map<String, String>> = providers.of(ListFunctionsValueSource::class) {
+    parameters {
+        service.set(functions)
+        projectId.set("my-project")
+        location.set("us-central1")
+    }
+}
+```
+
+## WorkActions
+
+### `CallFunctionAction`
+
+Invokes a Gen 2 function via HTTP POST. The response body is discarded. Provide an OIDC identity
+token via `identityToken` for authenticated functions:
+
+```kotlin
+workerExecutor.noIsolation().submit(CallFunctionAction::class) {
+    uri.set("https://us-central1-my-project.cloudfunctions.net/my-function")
+    identityToken.set(CredentialReference.EnvironmentVariable("FUNCTION_IDENTITY_TOKEN"))
+    payload.set("""{"event":"deploy"}""")  // optional
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `uri` | `Property<String>` | Full HTTPS trigger URL |
+| `identityToken` | `Property<CredentialReference>` | Optional OIDC token reference for `Authorization: Bearer` |
+| `payload` | `Property<String>` | Optional request body |
+
+### `UpdateFunctionAction`
+
+Updates a function's source to a zip already staged in Google Cloud Storage:
+
+```kotlin
+workerExecutor.noIsolation().submit(UpdateFunctionAction::class) {
+    service.set(functions)
+    functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+    bucket.set("my-deploy-bucket")
+    storageObject.set("releases/v1.2.3/function.zip")
+    storageGeneration.set(1234567890L)  // optional
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<FunctionServiceClientBuildService>` | Build service supplying the admin client |
+| `functionName` | `Property<String>` | Full resource name of the function |
+| `bucket` | `Property<String>` | GCS bucket containing the deployment zip |
+| `storageObject` | `Property<String>` | GCS object name of the deployment zip |
+| `storageGeneration` | `Property<Long>` | Optional object generation to pin |
+
+### `UploadAndUpdateFunctionAction`
+
+Uploads a local zip via a signed URL and updates the function in one step. Equivalent to calling
+`generateUploadUrl`, HTTP PUT the zip, then `updateFunction`:
+
+```kotlin
+workerExecutor.noIsolation().submit(UploadAndUpdateFunctionAction::class) {
+    service.set(functions)
+    functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+    zipFile.set(layout.buildDirectory.file("dist/function.zip"))
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<FunctionServiceClientBuildService>` | Build service supplying the admin client |
+| `functionName` | `Property<String>` | Full resource name of the function |
+| `zipFile` | `RegularFileProperty` | Local zip to upload |
+
+## Tasks
+
+### `DeployFunctionFromZip` / `AbstractDeployFunctionFromZip`
+
+A `DefaultTask` wrapper around `UploadAndUpdateFunctionAction` that declares `zipFile` as an
+`@InputFile`, enabling Gradle up-to-date checking and wiring to an upstream task that produces
+the zip:
+
+```kotlin
+tasks.register<DeployFunctionFromZip>("deploy") {
+    service.set(functions)
+    functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+    zipFile.set(tasks.named<Zip>("packageFunction").flatMap { it.archiveFile })
+}
+```
+
+Use `AbstractDeployFunctionFromZip` only when you need to supply a custom `service` binding
+without `@ServiceReference` tracking.
+
+## See Also
+
+- [clients-base](../clients-base) — The underlying service client infrastructure
+- [google-cloud-extensions](../google-cloud-extensions) — `GcpBuildServiceParams` and credential extensions
+- [google-cloud-storage-base](../google-cloud-storage-base) — Upload zips to GCS before using `UpdateFunctionAction`

--- a/cores/google-cloud-functions-base/build.gradle.kts
+++ b/cores/google-cloud-functions-base/build.gradle.kts
@@ -1,0 +1,27 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("Google Cloud Functions Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:google-cloud-extensions")
+    api(libs.google.cloud.functions)
+    api(libs.google.gax)
+    implementation(libs.google.cloud.functions.proto)
+    implementation(libs.google.protobuf.java)
+    implementation(libs.okhttp)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/google-cloud-functions-base/settings.gradle.kts
+++ b/cores/google-cloud-functions-base/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../google-cloud-extensions")

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/AbstractDeployFunctionFromZip.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/AbstractDeployFunctionFromZip.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Task that uploads a local zip file to Cloud Functions Gen 2 as a new deployment.
+ *
+ * Internally delegates to [UploadAndUpdateFunctionAction], which calls `generateUploadUrl`, HTTP
+ * PUT the zip, then waits for `updateFunction` to complete. The [zipFile] is declared as an
+ * `@InputFile` so Gradle tracks it for up-to-date checking and can wire it to an upstream task
+ * that produces the zip.
+ *
+ * Prefer [DeployFunctionFromZip] for direct task registration. Subclass this abstract form only
+ * when you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Deploying to an external service is not cacheable")
+abstract class AbstractDeployFunctionFromZip @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /** The build service managing the Cloud Functions client. */
+    @get:Internal
+    abstract val service: Property<FunctionServiceClientBuildService>
+
+    /**
+     * The full resource name of the function to update, e.g.
+     * `projects/my-project/locations/us-central1/functions/my-function`.
+     */
+    @get:Input
+    abstract val functionName: Property<String>
+
+    /** The local zip file to upload and deploy. */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val zipFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        workerExecutor.noIsolation().submit(UploadAndUpdateFunctionAction::class.java) { params ->
+            params.service.set(service)
+            params.functionName.set(functionName)
+            params.zipFile.set(zipFile)
+        }
+    }
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/CallFunctionAction.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/CallFunctionAction.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.kelvsyc.gradle.clients.CredentialReference
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.gradle.api.provider.Property
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that invokes a Cloud Functions Gen 2 function via HTTP POST.
+ *
+ * Gen 2 functions are HTTPS endpoints backed by Cloud Run. This action sends a POST request to
+ * the function's trigger URI, optionally including an OIDC identity token for authentication and
+ * a request payload. The response body is discarded.
+ *
+ * To obtain the function URI at configuration time, use [GetFunctionValueSource].
+ */
+abstract class CallFunctionAction : WorkAction<CallFunctionAction.Parameters> {
+
+    /**
+     * Parameters for [CallFunctionAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The full HTTPS trigger URI of the function. */
+        val uri: Property<String>
+
+        /**
+         * Reference to where the OIDC identity token can be found. When present, the resolved
+         * token is sent as `Authorization: Bearer <token>`. Uses [CredentialReference] to keep
+         * the token out of the Gradle configuration cache.
+         */
+        val identityToken: Property<CredentialReference>
+
+        /** Optional request body to send as the POST payload. */
+        val payload: Property<String>
+    }
+
+    override fun execute() {
+        val requestBody = parameters.payload.orNull?.toRequestBody() ?: "".toRequestBody()
+        val requestBuilder = Request.Builder()
+            .url(parameters.uri.get())
+            .post(requestBody)
+        parameters.identityToken.orNull?.resolve()?.let {
+            requestBuilder.header("Authorization", "Bearer $it")
+        }
+        OkHttpClient().newCall(requestBuilder.build()).execute().close()
+    }
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/DeployFunctionFromZip.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/DeployFunctionFromZip.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractDeployFunctionFromZip] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val functions = gradle.sharedServices.registerIfAbsent("functions", FunctionServiceClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<DeployFunctionFromZip>("deploy") {
+ *     service.set(functions)
+ *     functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+ *     zipFile.set(layout.buildDirectory.file("dist/function.zip"))
+ * }
+ * ```
+ */
+@DisableCachingByDefault(because = "Deploying to an external service is not cacheable")
+abstract class DeployFunctionFromZip @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractDeployFunctionFromZip(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<FunctionServiceClientBuildService>
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/FunctionServiceClientBuildService.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/FunctionServiceClientBuildService.kt
@@ -1,0 +1,27 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.FunctionServiceClient
+import com.google.cloud.functions.v2.FunctionServiceSettings
+import com.kelvsyc.gradle.google.cloud.AbstractGcpClientBuildService
+import com.kelvsyc.gradle.google.cloud.GcpBuildServiceParams
+
+/**
+ * Build service managing a [FunctionServiceClient] instance for the Cloud Functions Gen 2 API.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring the credential source via the extension functions on [GcpBuildServiceParams] (e.g.
+ * [applicationDefault][com.kelvsyc.gradle.google.cloud.applicationDefault],
+ * [serviceAccount][com.kelvsyc.gradle.google.cloud.serviceAccount]). The same registration can
+ * then be shared with value sources, work actions, and tasks via a
+ * `Property<FunctionServiceClientBuildService>` parameter.
+ */
+abstract class FunctionServiceClientBuildService :
+    AbstractGcpClientBuildService<FunctionServiceClient, GcpBuildServiceParams>() {
+
+    override fun createClient(): FunctionServiceClient {
+        val settings = FunctionServiceSettings.newBuilder().apply {
+            resolveCredentialsProvider()?.let { credentialsProvider = it }
+        }.build()
+        return FunctionServiceClient.create(settings)
+    }
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/GetFunctionValueSource.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/GetFunctionValueSource.kt
@@ -1,0 +1,41 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.GetFunctionRequest
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing the HTTPS trigger URI of a Cloud Functions Gen 2 function.
+ *
+ * Returns `null` if the function has no deployed URI (e.g. still provisioning).
+ *
+ * The [Parameters.functionName] must be the full resource name in the form
+ * `projects/{project}/locations/{location}/functions/{function}`.
+ */
+abstract class GetFunctionValueSource : ValueSource<String, GetFunctionValueSource.Parameters> {
+
+    /**
+     * Parameters for [GetFunctionValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the Cloud Functions client. */
+        @get:Internal
+        val service: Property<FunctionServiceClientBuildService>
+
+        /**
+         * The full resource name of the function, e.g.
+         * `projects/my-project/locations/us-central1/functions/my-function`.
+         */
+        val functionName: Property<String>
+    }
+
+    override fun obtain(): String? {
+        val request = GetFunctionRequest.newBuilder()
+            .setName(parameters.functionName.get())
+            .build()
+        val function = parameters.service.get().getClient().getFunction(request)
+        return function.serviceConfig.uri.takeIf { it.isNotBlank() }
+    }
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/ListFunctionsValueSource.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/ListFunctionsValueSource.kt
@@ -1,0 +1,44 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.ListFunctionsRequest
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing a map of Cloud Functions Gen 2 function names to their
+ * HTTPS trigger URIs within a given project and location.
+ *
+ * Each entry maps the short function name (last path segment of the full resource name) to the
+ * function's HTTPS trigger URI. Pagination is handled internally via the high-level paged API.
+ */
+abstract class ListFunctionsValueSource :
+    ValueSource<Map<String, String>, ListFunctionsValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListFunctionsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the Cloud Functions client. */
+        @get:Internal
+        val service: Property<FunctionServiceClientBuildService>
+
+        /** GCP project ID. */
+        val projectId: Property<String>
+
+        /** GCP region, e.g. `"us-central1"`. */
+        val location: Property<String>
+    }
+
+    override fun obtain(): Map<String, String>? {
+        val parent = "projects/${parameters.projectId.get()}/locations/${parameters.location.get()}"
+        val request = ListFunctionsRequest.newBuilder()
+            .setParent(parent)
+            .build()
+        return parameters.service.get().getClient()
+            .listFunctions(request)
+            .iterateAll()
+            .associate { fn -> fn.name.substringAfterLast('/') to fn.serviceConfig.uri }
+    }
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/UpdateFunctionAction.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/UpdateFunctionAction.kt
@@ -1,0 +1,75 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.GetFunctionRequest
+import com.google.cloud.functions.v2.Source
+import com.google.cloud.functions.v2.StorageSource
+import com.google.cloud.functions.v2.UpdateFunctionRequest
+import com.google.protobuf.FieldMask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that updates the source of a Cloud Functions Gen 2 function to a
+ * zip file already staged in Google Cloud Storage.
+ *
+ * The caller is responsible for uploading the zip to GCS beforehand (e.g. using
+ * `google-cloud-storage-base`'s `UploadFileAction`). The function update is submitted as a
+ * long-running operation and this action blocks until it completes.
+ *
+ * To upload a local zip and update in a single step, use [UploadAndUpdateFunctionAction] instead.
+ */
+abstract class UpdateFunctionAction : WorkAction<UpdateFunctionAction.Parameters> {
+
+    /**
+     * Parameters for [UpdateFunctionAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the Cloud Functions client. */
+        @get:Internal
+        val service: Property<FunctionServiceClientBuildService>
+
+        /**
+         * The full resource name of the function to update, e.g.
+         * `projects/my-project/locations/us-central1/functions/my-function`.
+         */
+        val functionName: Property<String>
+
+        /** The GCS bucket containing the deployment zip. */
+        val bucket: Property<String>
+
+        /** The GCS object name of the deployment zip. */
+        val storageObject: Property<String>
+
+        /**
+         * The GCS object generation to pin. When unset, the latest object version is used.
+         */
+        val storageGeneration: Property<Long>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val storageSource = StorageSource.newBuilder()
+            .setBucket(parameters.bucket.get())
+            .setObject(parameters.storageObject.get())
+            .also { b -> parameters.storageGeneration.orNull?.let { b.setGeneration(it) } }
+            .build()
+        val function = client.getFunction(
+            GetFunctionRequest.newBuilder().setName(parameters.functionName.get()).build()
+        )
+        val updated = function.toBuilder()
+            .setBuildConfig(
+                function.buildConfig.toBuilder()
+                    .setSource(Source.newBuilder().setStorageSource(storageSource).build())
+                    .build()
+            )
+            .build()
+        client.updateFunctionAsync(
+            UpdateFunctionRequest.newBuilder()
+                .setFunction(updated)
+                .setUpdateMask(FieldMask.newBuilder().addPaths("build_config.source").build())
+                .build()
+        ).get()
+    }
+}

--- a/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/UploadAndUpdateFunctionAction.kt
+++ b/cores/google-cloud-functions-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/functions/UploadAndUpdateFunctionAction.kt
@@ -1,0 +1,85 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.GenerateUploadUrlRequest
+import com.google.cloud.functions.v2.GetFunctionRequest
+import com.google.cloud.functions.v2.Source
+import com.google.cloud.functions.v2.UpdateFunctionRequest
+import com.google.protobuf.FieldMask
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that uploads a local zip to Cloud Storage via a signed URL and then
+ * updates a Cloud Functions Gen 2 function to use it as the new deployment source.
+ *
+ * Executes three steps atomically:
+ * 1. Calls `generateUploadUrl` to obtain a signed GCS URL and a [com.google.cloud.functions.v2.StorageSource].
+ * 2. HTTP PUT the zip bytes to the signed URL.
+ * 3. Submits an `updateFunction` long-running operation with the returned source and waits for completion.
+ *
+ * For a task-level wrapper that declares the zip as a proper Gradle `@InputFile` (enabling
+ * up-to-date checking), use [AbstractDeployFunctionFromZip] / [DeployFunctionFromZip].
+ */
+abstract class UploadAndUpdateFunctionAction :
+    WorkAction<UploadAndUpdateFunctionAction.Parameters> {
+
+    /**
+     * Parameters for [UploadAndUpdateFunctionAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the Cloud Functions client. */
+        @get:Internal
+        val service: Property<FunctionServiceClientBuildService>
+
+        /**
+         * The full resource name of the function to update, e.g.
+         * `projects/my-project/locations/us-central1/functions/my-function`.
+         */
+        val functionName: Property<String>
+
+        /** The local zip file to upload and deploy. */
+        val zipFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val functionName = parameters.functionName.get()
+        val parent = functionName.substringBeforeLast("/functions/")
+
+        val uploadResponse = client.generateUploadUrl(
+            GenerateUploadUrlRequest.newBuilder().setParent(parent).build()
+        )
+
+        val zipBytes = parameters.zipFile.get().asFile.readBytes()
+        OkHttpClient().newCall(
+            Request.Builder()
+                .url(uploadResponse.uploadUrl)
+                .put(zipBytes.toRequestBody("application/zip".toMediaType()))
+                .build()
+        ).execute().close()
+
+        val function = client.getFunction(
+            GetFunctionRequest.newBuilder().setName(functionName).build()
+        )
+        val updated = function.toBuilder()
+            .setBuildConfig(
+                function.buildConfig.toBuilder()
+                    .setSource(Source.newBuilder().setStorageSource(uploadResponse.storageSource).build())
+                    .build()
+            )
+            .build()
+        client.updateFunctionAsync(
+            UpdateFunctionRequest.newBuilder()
+                .setFunction(updated)
+                .setUpdateMask(FieldMask.newBuilder().addPaths("build_config.source").build())
+                .build()
+        ).get()
+    }
+}

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/CallFunctionActionSpec.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/CallFunctionActionSpec.kt
@@ -1,0 +1,98 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.kelvsyc.gradle.clients.CredentialReference
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.slot
+import io.mockk.unmockkAll
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.testfixtures.ProjectBuilder
+
+class CallFunctionActionSpec : FunSpec() {
+    init {
+        afterTest { unmockkAll() }
+
+        test("execute - sends POST to function URI without auth header when token absent") {
+            mockkConstructor(OkHttpClient::class)
+            val project = ProjectBuilder.builder().build()
+
+            val mockCall = mockk<Call>()
+            val mockResponse = mockk<Response>()
+            justRun { mockResponse.close() }
+            every { mockCall.execute() } returns mockResponse
+
+            val requestSlot = slot<Request>()
+            every { anyConstructed<OkHttpClient>().newCall(capture(requestSlot)) } returns mockCall
+
+            val params = project.objects.newInstance<CallFunctionAction.Parameters>()
+            params.uri.set("https://us-central1-my-project.cloudfunctions.net/my-function")
+
+            val action = object : CallFunctionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.url.toString() shouldBe
+                "https://us-central1-my-project.cloudfunctions.net/my-function"
+            requestSlot.captured.method shouldBe "POST"
+            requestSlot.captured.header("Authorization") shouldBe null
+        }
+
+        test("execute - sends Authorization header when identity token is present") {
+            mockkConstructor(OkHttpClient::class)
+            val project = ProjectBuilder.builder().build()
+
+            val mockCall = mockk<Call>()
+            val mockResponse = mockk<Response>()
+            justRun { mockResponse.close() }
+            every { mockCall.execute() } returns mockResponse
+
+            val requestSlot = slot<Request>()
+            every { anyConstructed<OkHttpClient>().newCall(capture(requestSlot)) } returns mockCall
+
+            val params = project.objects.newInstance<CallFunctionAction.Parameters>()
+            params.uri.set("https://us-central1-my-project.cloudfunctions.net/my-function")
+            params.identityToken.set(CredentialReference.Literal("test-token-123"))
+
+            val action = object : CallFunctionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.header("Authorization") shouldBe "Bearer test-token-123"
+        }
+
+        test("execute - includes payload body when payload is set") {
+            mockkConstructor(OkHttpClient::class)
+            val project = ProjectBuilder.builder().build()
+
+            val mockCall = mockk<Call>()
+            val mockResponse = mockk<Response>()
+            justRun { mockResponse.close() }
+            every { mockCall.execute() } returns mockResponse
+
+            val requestSlot = slot<Request>()
+            every { anyConstructed<OkHttpClient>().newCall(capture(requestSlot)) } returns mockCall
+
+            val params = project.objects.newInstance<CallFunctionAction.Parameters>()
+            params.uri.set("https://us-central1-my-project.cloudfunctions.net/my-function")
+            params.payload.set("""{"key":"value"}""")
+
+            val action = object : CallFunctionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.body shouldNotBe null
+        }
+    }
+}

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/GetFunctionValueSourceSpec.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/GetFunctionValueSourceSpec.kt
@@ -1,0 +1,68 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.FunctionServiceClient
+import com.google.cloud.functions.v2.GetFunctionRequest
+import com.google.cloud.functions.v2.ServiceConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import com.google.cloud.functions.v2.Function as GcpFunction
+
+class GetFunctionValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns HTTPS URI when function is deployed") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<FunctionServiceClient>()
+            MockFunctionServiceClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "functions",
+                MockFunctionServiceClientBuildService::class,
+            )
+
+            val uri = "https://us-central1-my-project.cloudfunctions.net/my-function"
+            val function = GcpFunction.newBuilder()
+                .setName("projects/my-project/locations/us-central1/functions/my-function")
+                .setServiceConfig(ServiceConfig.newBuilder().setUri(uri).build())
+                .build()
+
+            val requestSlot = slot<GetFunctionRequest>()
+            every { client.getFunction(capture(requestSlot)) } returns function
+
+            val provider = project.providers.ofKt(GetFunctionValueSource::class) {
+                parameters.service.set(service)
+                parameters.functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+            }
+
+            provider.get() shouldBe uri
+            requestSlot.captured.name shouldBe "projects/my-project/locations/us-central1/functions/my-function"
+        }
+
+        test("obtain - returns null when function URI is blank") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<FunctionServiceClient>()
+            MockFunctionServiceClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "functions-blank",
+                MockFunctionServiceClientBuildService::class,
+            )
+
+            val function = GcpFunction.newBuilder()
+                .setName("projects/my-project/locations/us-central1/functions/my-function")
+                .setServiceConfig(ServiceConfig.newBuilder().setUri("").build())
+                .build()
+
+            every { client.getFunction(any<GetFunctionRequest>()) } returns function
+
+            val provider = project.providers.ofKt(GetFunctionValueSource::class) {
+                parameters.service.set(service)
+                parameters.functionName.set("projects/my-project/locations/us-central1/functions/my-function")
+            }
+
+            provider.orNull shouldBe null
+        }
+    }
+}

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/ListFunctionsValueSourceSpec.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/ListFunctionsValueSourceSpec.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.FunctionServiceClient
+import com.google.cloud.functions.v2.ListFunctionsRequest
+import com.google.cloud.functions.v2.ServiceConfig
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import com.google.cloud.functions.v2.Function as GcpFunction
+
+class ListFunctionsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns map of short name to HTTPS URI") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<FunctionServiceClient>()
+            MockFunctionServiceClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "functions",
+                MockFunctionServiceClientBuildService::class,
+            )
+
+            val functions = listOf(
+                GcpFunction.newBuilder()
+                    .setName("projects/p/locations/us-central1/functions/alpha")
+                    .setServiceConfig(ServiceConfig.newBuilder().setUri("https://alpha.example.com").build())
+                    .build(),
+                GcpFunction.newBuilder()
+                    .setName("projects/p/locations/us-central1/functions/bravo")
+                    .setServiceConfig(ServiceConfig.newBuilder().setUri("https://bravo.example.com").build())
+                    .build(),
+            )
+            val paged = mockk<FunctionServiceClient.ListFunctionsPagedResponse>()
+            every { paged.iterateAll() } returns functions
+
+            val requestSlot = slot<ListFunctionsRequest>()
+            every { client.listFunctions(capture(requestSlot)) } returns paged
+
+            val provider = project.providers.ofKt(ListFunctionsValueSource::class) {
+                parameters.service.set(service)
+                parameters.projectId.set("p")
+                parameters.location.set("us-central1")
+            }
+
+            provider.get() shouldBe mapOf(
+                "alpha" to "https://alpha.example.com",
+                "bravo" to "https://bravo.example.com",
+            )
+            requestSlot.captured.parent shouldBe "projects/p/locations/us-central1"
+        }
+    }
+}

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/MockFunctionServiceClientBuildService.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/MockFunctionServiceClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.cloud.functions.v2.FunctionServiceClient
+
+/**
+ * Test-only [FunctionServiceClientBuildService] that returns a pre-supplied mock client.
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockFunctionServiceClientBuildService : FunctionServiceClientBuildService() {
+    override fun createClient(): FunctionServiceClient =
+        checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: FunctionServiceClient? = null
+    }
+}

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/ProviderFactoryExtensions.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/ProviderFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+// Workaround: under the kotlin-gradle-library convention, Kotlin does not treat Gradle's
+// Action<in T> as T.() -> Unit, so providers.of(...) { parameters.X } fails to resolve.
+internal fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit
+) = of(valueSourceType, configuration)

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/UpdateFunctionActionSpec.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/UpdateFunctionActionSpec.kt
@@ -1,0 +1,91 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.functions.v2.FunctionServiceClient
+import com.google.cloud.functions.v2.GetFunctionRequest
+import com.google.cloud.functions.v2.OperationMetadata
+import com.google.cloud.functions.v2.UpdateFunctionRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import com.google.cloud.functions.v2.Function as GcpFunction
+
+class UpdateFunctionActionSpec : FunSpec() {
+    init {
+        test("execute - updates function source with correct GCS bucket and object") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<FunctionServiceClient>()
+            MockFunctionServiceClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "functions",
+                MockFunctionServiceClientBuildService::class,
+            )
+
+            val existingFunction = GcpFunction.newBuilder()
+                .setName("projects/p/locations/us-central1/functions/my-fn")
+                .build()
+            every { client.getFunction(any<GetFunctionRequest>()) } returns existingFunction
+
+            val updateSlot = slot<UpdateFunctionRequest>()
+            val operationFuture = mockk<OperationFuture<GcpFunction, OperationMetadata>>()
+            every { operationFuture.get() } returns existingFunction
+            every { client.updateFunctionAsync(capture(updateSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpdateFunctionAction.Parameters>()
+            params.service.set(service)
+            params.functionName.set("projects/p/locations/us-central1/functions/my-fn")
+            params.bucket.set("my-bucket")
+            params.storageObject.set("deployments/function.zip")
+
+            val action = object : UpdateFunctionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val source = updateSlot.captured.function.buildConfig.source.storageSource
+            source.bucket shouldBe "my-bucket"
+            source.getObject() shouldBe "deployments/function.zip"
+            source.generation shouldBe 0L
+            updateSlot.captured.updateMask.pathsList shouldBe listOf("build_config.source")
+        }
+
+        test("execute - pins GCS object generation when storageGeneration is set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<FunctionServiceClient>()
+            MockFunctionServiceClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "functions-gen",
+                MockFunctionServiceClientBuildService::class,
+            )
+
+            val existingFunction = GcpFunction.newBuilder()
+                .setName("projects/p/locations/us-central1/functions/my-fn")
+                .build()
+            every { client.getFunction(any<GetFunctionRequest>()) } returns existingFunction
+
+            val updateSlot = slot<UpdateFunctionRequest>()
+            val operationFuture = mockk<OperationFuture<GcpFunction, OperationMetadata>>()
+            every { operationFuture.get() } returns existingFunction
+            every { client.updateFunctionAsync(capture(updateSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpdateFunctionAction.Parameters>()
+            params.service.set(service)
+            params.functionName.set("projects/p/locations/us-central1/functions/my-fn")
+            params.bucket.set("my-bucket")
+            params.storageObject.set("deployments/function.zip")
+            params.storageGeneration.set(42L)
+
+            val action = object : UpdateFunctionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            updateSlot.captured.function.buildConfig.source.storageSource.generation shouldBe 42L
+        }
+    }
+}

--- a/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/UploadAndUpdateFunctionActionSpec.kt
+++ b/cores/google-cloud-functions-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/functions/UploadAndUpdateFunctionActionSpec.kt
@@ -1,0 +1,100 @@
+package com.kelvsyc.gradle.google.cloud.functions
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.functions.v2.FunctionServiceClient
+import com.google.cloud.functions.v2.GenerateUploadUrlRequest
+import com.google.cloud.functions.v2.GenerateUploadUrlResponse
+import com.google.cloud.functions.v2.GetFunctionRequest
+import com.google.cloud.functions.v2.OperationMetadata
+import com.google.cloud.functions.v2.StorageSource
+import com.google.cloud.functions.v2.UpdateFunctionRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.slot
+import io.mockk.unmockkAll
+import okhttp3.Call
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import java.io.File
+import com.google.cloud.functions.v2.Function as GcpFunction
+
+class UploadAndUpdateFunctionActionSpec : FunSpec() {
+    init {
+        afterTest { unmockkAll() }
+
+        test("execute - uploads zip to signed URL and updates function source") {
+            mockkConstructor(OkHttpClient::class)
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<FunctionServiceClient>()
+            MockFunctionServiceClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "functions",
+                MockFunctionServiceClientBuildService::class,
+            )
+
+            val storageSource = StorageSource.newBuilder()
+                .setBucket("gcf-sources")
+                .setObject("upload-abc123.zip")
+                .build()
+            val uploadResponse = GenerateUploadUrlResponse.newBuilder()
+                .setUploadUrl("https://storage.googleapis.com/gcf-sources/upload-abc123.zip?X-Goog-Signature=sig")
+                .setStorageSource(storageSource)
+                .build()
+
+            val uploadUrlSlot = slot<GenerateUploadUrlRequest>()
+            every { client.generateUploadUrl(capture(uploadUrlSlot)) } returns uploadResponse
+
+            val mockCall = mockk<Call>()
+            val mockResponse = mockk<Response>()
+            justRun { mockResponse.close() }
+            every { mockCall.execute() } returns mockResponse
+
+            val httpRequestSlot = slot<Request>()
+            every { anyConstructed<OkHttpClient>().newCall(capture(httpRequestSlot)) } returns mockCall
+
+            val existingFunction = GcpFunction.newBuilder()
+                .setName("projects/p/locations/us-central1/functions/my-fn")
+                .build()
+            every { client.getFunction(any<GetFunctionRequest>()) } returns existingFunction
+
+            val updateSlot = slot<UpdateFunctionRequest>()
+            val operationFuture = mockk<OperationFuture<GcpFunction, OperationMetadata>>()
+            every { operationFuture.get() } returns existingFunction
+            every { client.updateFunctionAsync(capture(updateSlot)) } returns operationFuture
+
+            val zipFile = File.createTempFile("function", ".zip")
+            zipFile.deleteOnExit()
+            zipFile.writeBytes("fake-zip-content".toByteArray())
+
+            val params = project.objects.newInstance<UploadAndUpdateFunctionAction.Parameters>()
+            params.service.set(service)
+            params.functionName.set("projects/p/locations/us-central1/functions/my-fn")
+            params.zipFile.set(zipFile)
+
+            val action = object : UploadAndUpdateFunctionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            uploadUrlSlot.captured.parent shouldBe "projects/p/locations/us-central1"
+
+            httpRequestSlot.captured.url.toString() shouldBe
+                "https://storage.googleapis.com/gcf-sources/upload-abc123.zip?X-Goog-Signature=sig"
+            httpRequestSlot.captured.method shouldBe "PUT"
+            httpRequestSlot.captured.body?.contentType()?.toString() shouldBe "application/zip"
+
+            val updatedSource = updateSlot.captured.function.buildConfig.source.storageSource
+            updatedSource.bucket shouldBe "gcf-sources"
+            updatedSource.getObject() shouldBe "upload-abc123.zip"
+            updateSlot.captured.updateMask.pathsList shouldBe listOf("build_config.source")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,8 @@ google-auth-library-oauth2-http = { module = "com.google.auth:google-auth-librar
 google-cloud-artifact-registry = { module = "com.google.cloud:google-cloud-artifact-registry" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-artifact-registry-proto = { module = "com.google.api.grpc:proto-google-cloud-artifact-registry-v1" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-core = { module = "com.google.cloud:google-cloud-core" } # version from BOM 'google-cloud-libraries-bom'
+google-cloud-functions = { module = "com.google.cloud:google-cloud-functions" } # version from BOM 'google-cloud-libraries-bom'
+google-cloud-functions-proto = { module = "com.google.api.grpc:proto-google-cloud-functions-v2" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-pubsub = { module = "com.google.cloud:google-cloud-pubsub" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-pubsub-proto = { module = "com.google.api.grpc:proto-google-cloud-pubsub-v1" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-kms = { module = "com.google.cloud:google-cloud-kms" } # version from BOM 'google-cloud-libraries-bom'


### PR DESCRIPTION
## Summary

- Adds `google-cloud-functions-base`, a new `cores/` component for GCP Cloud Functions Gen 2, following the same pattern as existing GCP bases (`google-cloud-pubsub-base`, `google-cloud-kms-base`, etc.)
- Provides `FunctionServiceClientBuildService`, two `ValueSource`s (`GetFunctionValueSource`, `ListFunctionsValueSource`), three `WorkAction`s (`CallFunctionAction`, `UpdateFunctionAction`, `UploadAndUpdateFunctionAction`), and a task wrapper (`AbstractDeployFunctionFromZip` / `DeployFunctionFromZip`) with `@InputFile` for Gradle up-to-date checking
- `CallFunctionAction` and `UploadAndUpdateFunctionAction` use OkHttp for HTTP calls; `UpdateFunctionAction` uses the gRPC admin client for GCS-staged deployments
- Adds `google-cloud-functions` and `proto-google-cloud-functions-v2` catalog entries under the existing GCP libraries BOM

## Test plan

- [ ] `./gradlew :google-cloud-functions-base:test` — all 7 specs pass
- [ ] `./gradlew :google-cloud-functions-base:detekt` — no violations
- [ ] `./gradlew :google-cloud-functions-base:build` — full component build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)