### PR TITLE
feat: add google-cloud-run-base component for Cloud Run Services and Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ since the two AWS SDKs are distinct libraries:
 |-----------|-------------|
 | `google-cloud-artifact-registry-base` | GCP Artifact Registry |
 | `google-cloud-functions-base` | GCP Cloud Functions (Gen 2) |
+| `google-cloud-run-base` | GCP Cloud Run Services and Jobs |
 | `google-cloud-storage-base` | GCP Cloud Storage |
 | `google-cloud-secret-manager-base` | GCP Secret Manager |
 | `google-cloud-pubsub-base` | GCP Pub/Sub |

--- a/cores/google-cloud-run-base/README.md
+++ b/cores/google-cloud-run-base/README.md
@@ -339,9 +339,11 @@ tasks.register<DeleteJobTask>("deleteBatchJob") {
 
 ### `RunJobTask` / `AbstractRunJobTask`
 
-Submits a Cloud Run Job Execution and waits for it to complete. Job submission is performed
-inline (not as a WorkAction); the execution name is optionally written to a file for use by
-downstream tasks:
+Submits a Cloud Run Job Execution. If `executionNameFile` is set, the execution name is written
+to disk and the task returns immediately — a downstream `WaitForJobExecutionTask` handles the
+wait, allowing other build work to run in between. If `executionNameFile` is absent, the task
+waits inline via `WaitForExecutionAction`. Job submission is always performed inline (not as a
+WorkAction):
 
 ```kotlin
 tasks.register<RunJobTask>("runBatchJob") {

--- a/cores/google-cloud-run-base/README.md
+++ b/cores/google-cloud-run-base/README.md
@@ -1,5 +1,382 @@
-# google-cloud-run-base
+# Google Cloud Run Base
 
-Gradle base component for GCP Cloud Run Services and Jobs.
+A Kotlin library providing managed Cloud Run client integration using the Google Cloud Java SDK,
+built on `clients-base` and `google-cloud-extensions`.
 
-> Documentation coming soon.
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:google-cloud-run-base")
+}
+```
+
+## Build Services
+
+| Class | Client type |
+|---|---|
+| `CloudRunServicesClientBuildService` | `ServicesClient` (Cloud Run Services v2 API) |
+| `CloudRunJobsClientBuildService` | `JobsClient` (Cloud Run Jobs v2 API) |
+| `CloudRunExecutionsClientBuildService` | `ExecutionsClient` (Cloud Run Executions v2 API) |
+
+```kotlin
+val services = gradle.sharedServices.registerIfAbsent(
+    "cloudRunServices",
+    CloudRunServicesClientBuildService::class,
+) {
+    parameters {
+        projectId.set("my-project")
+        applicationDefault()
+    }
+}
+
+val jobs = gradle.sharedServices.registerIfAbsent(
+    "cloudRunJobs",
+    CloudRunJobsClientBuildService::class,
+) {
+    parameters {
+        projectId.set("my-project")
+        applicationDefault()
+    }
+}
+
+val executions = gradle.sharedServices.registerIfAbsent(
+    "cloudRunExecutions",
+    CloudRunExecutionsClientBuildService::class,
+) {
+    parameters {
+        projectId.set("my-project")
+        applicationDefault()
+    }
+}
+```
+
+Both `projectId` and the credentials call are optional. See
+[google-cloud-extensions](../google-cloud-extensions) for the full set of credential configuration
+functions.
+
+## Value Sources
+
+### `GetServiceValueSource`
+
+Retrieves the HTTPS endpoint URL of a Cloud Run service. Returns `null` if the service does not
+exist or has no deployed URI:
+
+```kotlin
+val serviceUri: Provider<String> = providers.of(GetServiceValueSource::class) {
+    parameters {
+        service.set(services)
+        serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunServicesClientBuildService>` | Build service supplying the Services client |
+| `serviceName` | `Property<String>` | Full resource name: `projects/{p}/locations/{l}/services/{s}` |
+
+### `ListServicesValueSource`
+
+Lists all Cloud Run services in a project and location, returning a `Map<String, String>` keyed by
+short service name with the HTTPS endpoint URL as the value. Pagination is handled internally:
+
+```kotlin
+val allServices: Provider<Map<String, String>> = providers.of(ListServicesValueSource::class) {
+    parameters {
+        service.set(services)
+        projectId.set("my-project")
+        location.set("us-central1")
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunServicesClientBuildService>` | Build service supplying the Services client |
+| `projectId` | `Property<String>` | GCP project ID |
+| `location` | `Property<String>` | GCP region, e.g. `"us-central1"` |
+
+### `GetJobValueSource`
+
+Retrieves the latest execution name of a Cloud Run job. Returns `null` if the job does not exist
+or has no executions:
+
+```kotlin
+val latestExecution: Provider<String> = providers.of(GetJobValueSource::class) {
+    parameters {
+        service.set(jobs)
+        jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunJobsClientBuildService>` | Build service supplying the Jobs client |
+| `jobName` | `Property<String>` | Full resource name: `projects/{p}/locations/{l}/jobs/{j}` |
+
+### `ListJobsValueSource`
+
+Lists all Cloud Run jobs in a project and location, returning a list of short job names.
+Pagination is handled internally:
+
+```kotlin
+val allJobs: Provider<List<String>> = providers.of(ListJobsValueSource::class) {
+    parameters {
+        service.set(jobs)
+        projectId.set("my-project")
+        location.set("us-central1")
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunJobsClientBuildService>` | Build service supplying the Jobs client |
+| `projectId` | `Property<String>` | GCP project ID |
+| `location` | `Property<String>` | GCP region, e.g. `"us-central1"` |
+
+## WorkActions
+
+### `UpsertServiceAction`
+
+Creates or updates a Cloud Run Service (upsert semantics). The action fetches an existing service
+by name; if not found, creates a new one. Blocks until the long-running operation completes:
+
+```kotlin
+workerExecutor.noIsolation().submit(UpsertServiceAction::class) {
+    service.set(services)
+    serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+    imageUri.set("gcr.io/my-project/image:v1.2.3")
+    envVars.put("API_KEY", "secret-value")
+    envVars.put("LOG_LEVEL", "DEBUG")
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunServicesClientBuildService>` | Build service supplying the Services client |
+| `serviceName` | `Property<String>` | Full resource name of the service |
+| `imageUri` | `Property<String>` | Container image URI, e.g. `gcr.io/my-project/image:tag` |
+| `envVars` | `MapProperty<String, String>` | Environment variables to set on the container |
+
+### `DeleteServiceAction`
+
+Deletes a Cloud Run Service. Blocks until the long-running operation completes:
+
+```kotlin
+workerExecutor.noIsolation().submit(DeleteServiceAction::class) {
+    service.set(services)
+    serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunServicesClientBuildService>` | Build service supplying the Services client |
+| `serviceName` | `Property<String>` | Full resource name of the service |
+
+### `CreateJobAction`
+
+Creates a new Cloud Run Job definition. Blocks until the long-running operation completes:
+
+```kotlin
+workerExecutor.noIsolation().submit(CreateJobAction::class) {
+    service.set(jobs)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+    imageUri.set("gcr.io/my-project/image:v1.2.3")
+    envVars.put("DATA_PATH", "/data")
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunJobsClientBuildService>` | Build service supplying the Jobs client |
+| `jobName` | `Property<String>` | Full resource name of the job to create |
+| `imageUri` | `Property<String>` | Container image URI, e.g. `gcr.io/my-project/image:tag` |
+| `envVars` | `MapProperty<String, String>` | Environment variables to set on the container |
+
+### `UpdateJobAction`
+
+Updates an existing Cloud Run Job definition's image and environment variables. Blocks until the
+long-running operation completes:
+
+```kotlin
+workerExecutor.noIsolation().submit(UpdateJobAction::class) {
+    service.set(jobs)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+    imageUri.set("gcr.io/my-project/image:v1.2.4")
+    envVars.put("DATA_PATH", "/data")
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunJobsClientBuildService>` | Build service supplying the Jobs client |
+| `jobName` | `Property<String>` | Full resource name of the job to update |
+| `imageUri` | `Property<String>` | Container image URI, e.g. `gcr.io/my-project/image:tag` |
+| `envVars` | `MapProperty<String, String>` | Environment variables to set on the container |
+
+### `DeleteJobAction`
+
+Deletes a Cloud Run Job definition. Blocks until the long-running operation completes:
+
+```kotlin
+workerExecutor.noIsolation().submit(DeleteJobAction::class) {
+    service.set(jobs)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunJobsClientBuildService>` | Build service supplying the Jobs client |
+| `jobName` | `Property<String>` | Full resource name of the job |
+
+### `WaitForExecutionAction`
+
+Polls a Cloud Run Job Execution until it reaches a terminal state (success or failure). Raises an
+exception if the execution fails or the wait timeout is exceeded. Use with `RunJobTask` to wait
+for a separately-submitted execution:
+
+```kotlin
+workerExecutor.noIsolation().submit(WaitForExecutionAction::class) {
+    service.set(executions)
+    executionName.set("projects/my-project/locations/us-central1/jobs/my-job/executions/abc123")
+    pollIntervalMs.set(5000)      // default
+    maxWaitTimeMs.set(1800000)    // 30 minutes (default)
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `service` | `Property<CloudRunExecutionsClientBuildService>` | Build service supplying the Executions client |
+| `executionName` | `Property<String>` | Full execution resource name |
+| `pollIntervalMs` | `Property<Long>` | Poll interval in milliseconds (default: 5000) |
+| `maxWaitTimeMs` | `Property<Long>` | Maximum wait time in milliseconds (default: 30 min) |
+
+### Why There Is No `RunJobExecutionAction` WorkAction
+
+Job submission is deliberately not implemented as a `WorkAction`. The Cloud Run API's job submission
+method returns an execution name (a `String`) that must be threaded to `WaitForExecutionAction`.
+WorkAction parameters are strictly input-only — there is no mechanism for a WorkAction to write
+a return value back to the calling task.
+
+Sharing the execution name via a companion-object or static variable would be an anti-pattern
+that breaks under parallel task execution. Instead, job submission is performed inline in the
+`@TaskAction` method of `AbstractRunJobTask`, which executes in the main task thread. The submission
+API itself is fast (returns a long-running operation handle immediately); only the wait is delegated
+to a `WorkAction` via `WaitForExecutionAction`. This is idiomatic for quick, value-returning API
+calls in Gradle.
+
+## Tasks
+
+### `UpsertServiceTask` / `AbstractUpsertServiceTask`
+
+A `DefaultTask` wrapper around `UpsertServiceAction` that declares `serviceName` and `imageUri` as
+`@Input` properties, enabling Gradle dependency tracking:
+
+```kotlin
+tasks.register<UpsertServiceTask>("deployService") {
+    service.set(services)
+    serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+    imageUri.set("gcr.io/my-project/app:${project.version}")
+    envVars.put("ENVIRONMENT", "production")
+}
+```
+
+Use `AbstractUpsertServiceTask` only when you need to supply a custom `service` binding without
+`@ServiceReference` tracking.
+
+### `DeleteServiceTask` / `AbstractDeleteServiceTask`
+
+A `DefaultTask` wrapper around `DeleteServiceAction`:
+
+```kotlin
+tasks.register<DeleteServiceTask>("deleteService") {
+    service.set(services)
+    serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+}
+```
+
+### `CreateJobTask` / `AbstractCreateJobTask`
+
+A `DefaultTask` wrapper around `CreateJobAction`:
+
+```kotlin
+tasks.register<CreateJobTask>("createBatchJob") {
+    service.set(jobs)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-batch")
+    imageUri.set("gcr.io/my-project/batch-processor:v1")
+    envVars.put("BATCH_SIZE", "1000")
+}
+```
+
+### `UpdateJobTask` / `AbstractUpdateJobTask`
+
+A `DefaultTask` wrapper around `UpdateJobAction`:
+
+```kotlin
+tasks.register<UpdateJobTask>("updateBatchJob") {
+    service.set(jobs)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-batch")
+    imageUri.set("gcr.io/my-project/batch-processor:v2")
+    envVars.put("BATCH_SIZE", "2000")
+}
+```
+
+### `DeleteJobTask` / `AbstractDeleteJobTask`
+
+A `DefaultTask` wrapper around `DeleteJobAction`:
+
+```kotlin
+tasks.register<DeleteJobTask>("deleteBatchJob") {
+    service.set(jobs)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-batch")
+}
+```
+
+### `RunJobTask` / `AbstractRunJobTask`
+
+Submits a Cloud Run Job Execution and waits for it to complete. Job submission is performed
+inline (not as a WorkAction); the execution name is optionally written to a file for use by
+downstream tasks:
+
+```kotlin
+tasks.register<RunJobTask>("runBatchJob") {
+    service.set(jobs)
+    executionsService.set(executions)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-batch")
+    overrides.put("BATCH_SIZE", "5000")
+    executionNameFile.set(layout.buildDirectory.file("run/execution-name.txt"))
+}
+```
+
+`RunJobTask` declares both `service` and `executionsService` with `@ServiceReference`. Use
+`AbstractRunJobTask` only when supplying custom service bindings without automatic tracking.
+
+### `WaitForJobExecutionTask` / `AbstractWaitForJobExecutionTask`
+
+Reads an execution name from a file (typically written by `RunJobTask`) and waits for that
+execution to complete. Enables split submission-and-wait workflows for interleaving other
+build work:
+
+```kotlin
+val runJob = tasks.register<RunJobTask>("runBatchJob") {
+    service.set(jobs)
+    executionsService.set(executions)
+    jobName.set("projects/my-project/locations/us-central1/jobs/my-batch")
+    executionNameFile.set(layout.buildDirectory.file("run/execution-name.txt"))
+}
+
+val waitForJob = tasks.register<WaitForJobExecutionTask>("waitForBatchJob") {
+    service.set(executions)
+    executionNameFile.set(runJob.flatMap { it.executionNameFile })
+}
+```
+
+## See Also
+
+- [clients-base](../clients-base) — The underlying service client infrastructure
+- [google-cloud-extensions](../google-cloud-extensions) — `GcpBuildServiceParams` and credential extensions

--- a/cores/google-cloud-run-base/README.md
+++ b/cores/google-cloud-run-base/README.md
@@ -1,0 +1,5 @@
+# google-cloud-run-base
+
+Gradle base component for GCP Cloud Run Services and Jobs.
+
+> Documentation coming soon.

--- a/cores/google-cloud-run-base/build.gradle.kts
+++ b/cores/google-cloud-run-base/build.gradle.kts
@@ -1,0 +1,26 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("Google Cloud Run Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:google-cloud-extensions")
+    api(libs.google.cloud.run)
+    api(libs.google.gax)
+    implementation(libs.google.cloud.run.proto)
+    implementation(libs.google.protobuf.java)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/google-cloud-run-base/settings.gradle.kts
+++ b/cores/google-cloud-run-base/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../google-cloud-extensions")

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractCreateJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractCreateJobTask.kt
@@ -1,0 +1,62 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that creates a Cloud Run Job definition.
+ *
+ * Internally delegates to [CreateJobAction], which parses the job ID from the full resource name,
+ * then creates a new job with the specified container image and environment variables.
+ * The container is set on the job's execution template.
+ *
+ * Prefer [CreateJobTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Creating a Cloud Run job is not cacheable")
+abstract class AbstractCreateJobTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Jobs client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunJobsClientBuildService>
+
+    /**
+     * The full resource name of the job to create,
+     * e.g. `projects/my-project/locations/us-central1/jobs/my-job`.
+     */
+    @get:Input
+    abstract val jobName: Property<String>
+
+    /**
+     * The container image URI to deploy, e.g. `gcr.io/my-project/image:tag`.
+     */
+    @get:Input
+    abstract val imageUri: Property<String>
+
+    /**
+     * Environment variables to set on the container.
+     */
+    @get:Input
+    abstract val envVars: MapProperty<String, String>
+
+    @TaskAction
+    fun run() {
+        workerExecutor.noIsolation().submit(CreateJobAction::class.java) { params ->
+            params.service.set(service)
+            params.jobName.set(jobName)
+            params.imageUri.set(imageUri)
+            params.envVars.set(envVars)
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractDeleteJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractDeleteJobTask.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that deletes a Cloud Run Job definition.
+ *
+ * Internally delegates to [DeleteJobAction], which deletes the job and blocks until
+ * the long-running operation completes.
+ *
+ * Prefer [DeleteJobTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Deleting a Cloud Run job is not cacheable")
+abstract class AbstractDeleteJobTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Jobs client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunJobsClientBuildService>
+
+    /**
+     * The full resource name of the job to delete,
+     * e.g. `projects/my-project/locations/us-central1/jobs/my-job`.
+     */
+    @get:Input
+    abstract val jobName: Property<String>
+
+    @TaskAction
+    fun run() {
+        workerExecutor.noIsolation().submit(DeleteJobAction::class.java) { params ->
+            params.service.set(service)
+            params.jobName.set(jobName)
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractDeleteServiceTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractDeleteServiceTask.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that deletes a Cloud Run Service.
+ *
+ * Internally delegates to [DeleteServiceAction], which deletes the service and blocks until
+ * the long-running operation completes.
+ *
+ * Prefer [DeleteServiceTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Deleting a Cloud Run service is not cacheable")
+abstract class AbstractDeleteServiceTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Services client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunServicesClientBuildService>
+
+    /**
+     * The full resource name of the service to delete,
+     * e.g. `projects/my-project/locations/us-central1/services/my-service`.
+     */
+    @get:Input
+    abstract val serviceName: Property<String>
+
+    @TaskAction
+    fun run() {
+        workerExecutor.noIsolation().submit(DeleteServiceAction::class.java) { params ->
+            params.service.set(service)
+            params.serviceName.set(serviceName)
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractRunJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractRunJobTask.kt
@@ -1,0 +1,127 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.EnvVar
+import com.google.cloud.run.v2.RunJobRequest
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that submits a Cloud Run Job Execution and waits for it to complete.
+ *
+ * Job submission is performed inline in the [@TaskAction] method rather than delegating
+ * to a WorkAction. This is because the submission API returns an execution name (a String)
+ * that must be threaded to [WaitForExecutionAction]. WorkAction parameters are strictly
+ * input-only — there is no mechanism for a WorkAction to write a String value back to the
+ * calling task. Using a companion-object or static state to share this value would be
+ * an anti-pattern that breaks under parallel task execution.
+ *
+ * Prefer [RunJobTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply custom `service` or `executionsService` bindings without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Running a Cloud Run job is not cacheable")
+abstract class AbstractRunJobTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Jobs client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunJobsClientBuildService>
+
+    /**
+     * The build service managing the Cloud Run Executions client.
+     * Used to wait for the execution to complete.
+     */
+    @get:Internal
+    abstract val executionsService: Property<CloudRunExecutionsClientBuildService>
+
+    /**
+     * The full resource name of the job to run: `projects/{p}/locations/{l}/jobs/{j}`.
+     */
+    @get:Input
+    abstract val jobName: Property<String>
+
+    /**
+     * Per-run environment variable overrides.
+     */
+    @get:Input
+    abstract val overrides: MapProperty<String, String>
+
+    /**
+     * If set, the execution name is written to this file after submission,
+     * enabling downstream tasks to wait for this execution via [AbstractWaitForJobExecutionTask].
+     */
+    @get:Optional
+    @get:OutputFile
+    abstract val executionNameFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val client = service.get().getClient()
+
+        // Build RunJobRequest with overrides
+        val runJobRequest = RunJobRequest.newBuilder()
+            .setName(jobName.get())
+            .also { builder ->
+                if (overrides.isPresent && overrides.get().isNotEmpty()) {
+                    val envOverrides = overrides.get().map { (k, v) ->
+                        EnvVar.newBuilder().setName(k).setValue(v).build()
+                    }
+                    builder.setOverrides(
+                        RunJobRequest.Overrides.newBuilder()
+                            .addAllContainerOverrides(
+                                listOf(
+                                    RunJobRequest.Overrides.ContainerOverride.newBuilder()
+                                        .addAllEnv(envOverrides)
+                                        .build(),
+                                ),
+                            )
+                            .build(),
+                    )
+                }
+            }
+            .build()
+
+        // Submit the job and get the operation future
+        val future = client.runJobAsync(runJobRequest)
+
+        // Extract execution name without blocking on full completion
+        var metadata = future.peekMetadata().get()
+        var attempts = 0
+        while (metadata == null && attempts < MAX_PEEK_ATTEMPTS) {
+            Thread.sleep(PEEK_INTERVAL_MS)
+            metadata = future.peekMetadata().get()
+            attempts++
+        }
+        val executionName = checkNotNull(metadata) {
+            "Could not retrieve execution name for job ${jobName.get()}"
+        }.name
+
+        // Write to file if configured
+        if (executionNameFile.isPresent) {
+            executionNameFile.get().asFile.writeText(executionName)
+        }
+
+        // Wait for execution
+        workerExecutor.noIsolation().submit(WaitForExecutionAction::class.java) { params ->
+            params.service.set(executionsService)
+            params.executionName.set(executionName)
+        }
+    }
+
+    companion object {
+        private const val MAX_PEEK_ATTEMPTS = 10
+        private const val PEEK_INTERVAL_MS = 500L
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractRunJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractRunJobTask.kt
@@ -16,7 +16,7 @@ import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 
 /**
- * Abstract task that submits a Cloud Run Job Execution and waits for it to complete.
+ * Abstract task that submits a Cloud Run Job Execution, optionally waiting for it to complete.
  *
  * Job submission is performed inline in the [@TaskAction] method rather than delegating
  * to a WorkAction. This is because the submission API returns an execution name (a String)
@@ -24,6 +24,10 @@ import javax.inject.Inject
  * input-only — there is no mechanism for a WorkAction to write a String value back to the
  * calling task. Using a companion-object or static state to share this value would be
  * an anti-pattern that breaks under parallel task execution.
+ *
+ * If [executionNameFile] is set, the execution name is written to disk and the task returns
+ * immediately — waiting is deferred to a downstream [AbstractWaitForJobExecutionTask].
+ * If [executionNameFile] is absent, the task waits inline via [WaitForExecutionAction].
  *
  * Prefer [RunJobTask] for direct task registration. Subclass this abstract form only when
  * you need to supply custom `service` or `executionsService` bindings without `@ServiceReference` tracking.
@@ -59,8 +63,10 @@ abstract class AbstractRunJobTask @Inject constructor(
     abstract val overrides: MapProperty<String, String>
 
     /**
-     * If set, the execution name is written to this file after submission,
-     * enabling downstream tasks to wait for this execution via [AbstractWaitForJobExecutionTask].
+     * If set, the execution name is written to this file and the task returns immediately
+     * without waiting. A downstream [AbstractWaitForJobExecutionTask] can then wait for the
+     * execution, allowing other build work to run in between. If absent, this task waits
+     * inline via [WaitForExecutionAction].
      */
     @get:Optional
     @get:OutputFile
@@ -108,15 +114,13 @@ abstract class AbstractRunJobTask @Inject constructor(
             "Could not retrieve execution name for job ${jobName.get()}"
         }.name
 
-        // Write to file if configured
         if (executionNameFile.isPresent) {
             executionNameFile.get().asFile.writeText(executionName)
-        }
-
-        // Wait for execution
-        workerExecutor.noIsolation().submit(WaitForExecutionAction::class.java) { params ->
-            params.service.set(executionsService)
-            params.executionName.set(executionName)
+        } else {
+            workerExecutor.noIsolation().submit(WaitForExecutionAction::class.java) { params ->
+                params.service.set(executionsService)
+                params.executionName.set(executionName)
+            }
         }
     }
 

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractUpdateJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractUpdateJobTask.kt
@@ -1,0 +1,61 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that updates an existing Cloud Run Job definition.
+ *
+ * Internally delegates to [UpdateJobAction], which fetches the existing job, then updates
+ * its container image and environment variables.
+ *
+ * Prefer [UpdateJobTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Updating a Cloud Run job is not cacheable")
+abstract class AbstractUpdateJobTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Jobs client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunJobsClientBuildService>
+
+    /**
+     * The full resource name of the job to update,
+     * e.g. `projects/my-project/locations/us-central1/jobs/my-job`.
+     */
+    @get:Input
+    abstract val jobName: Property<String>
+
+    /**
+     * The container image URI to deploy, e.g. `gcr.io/my-project/image:tag`.
+     */
+    @get:Input
+    abstract val imageUri: Property<String>
+
+    /**
+     * Environment variables to set on the container.
+     */
+    @get:Input
+    abstract val envVars: MapProperty<String, String>
+
+    @TaskAction
+    fun run() {
+        workerExecutor.noIsolation().submit(UpdateJobAction::class.java) { params ->
+            params.service.set(service)
+            params.jobName.set(jobName)
+            params.imageUri.set(imageUri)
+            params.envVars.set(envVars)
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractUpsertServiceTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractUpsertServiceTask.kt
@@ -1,0 +1,63 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that creates or updates a Cloud Run Service (upsert semantics).
+ *
+ * Internally delegates to [UpsertServiceAction], which fetches the full resource name to extract
+ * the service ID and parent location, then attempts to update an existing service. If the service
+ * does not exist, it creates a new one. The container image and environment variables are set
+ * on the service's revision template.
+ *
+ * Prefer [UpsertServiceTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Deploying to Cloud Run is not cacheable")
+abstract class AbstractUpsertServiceTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Services client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunServicesClientBuildService>
+
+    /**
+     * The full resource name of the service to create or update,
+     * e.g. `projects/my-project/locations/us-central1/services/my-service`.
+     */
+    @get:Input
+    abstract val serviceName: Property<String>
+
+    /**
+     * The container image URI to deploy, e.g. `gcr.io/my-project/image:tag`.
+     */
+    @get:Input
+    abstract val imageUri: Property<String>
+
+    /**
+     * Environment variables to set on the container.
+     */
+    @get:Input
+    abstract val envVars: MapProperty<String, String>
+
+    @TaskAction
+    fun run() {
+        workerExecutor.noIsolation().submit(UpsertServiceAction::class.java) { params ->
+            params.service.set(service)
+            params.serviceName.set(serviceName)
+            params.imageUri.set(imageUri)
+            params.envVars.set(envVars)
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractWaitForJobExecutionTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/AbstractWaitForJobExecutionTask.kt
@@ -1,0 +1,52 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract task that reads an execution name from a file and waits for that
+ * Cloud Run Job Execution to complete.
+ *
+ * This task is typically used as a downstream dependency to [AbstractRunJobTask],
+ * accepting the execution name file written by that task.
+ *
+ * Internally delegates to [WaitForExecutionAction], which polls the execution
+ * status until it reaches a terminal state.
+ *
+ * Prefer [WaitForJobExecutionTask] for direct task registration. Subclass this abstract form only when
+ * you need to supply a custom `service` binding without `@ServiceReference` tracking.
+ */
+@DisableCachingByDefault(because = "Waiting for a Cloud Run execution is not cacheable")
+abstract class AbstractWaitForJobExecutionTask @Inject constructor(
+    private val workerExecutor: WorkerExecutor,
+) : DefaultTask() {
+
+    /**
+     * The build service managing the Cloud Run Executions client.
+     */
+    @get:Internal
+    abstract val service: Property<CloudRunExecutionsClientBuildService>
+
+    /**
+     * The file containing the execution resource name to wait for.
+     * Typically written by [AbstractRunJobTask.executionNameFile].
+     */
+    @get:InputFile
+    abstract val executionNameFile: RegularFileProperty
+
+    @TaskAction
+    fun run() {
+        val executionName = executionNameFile.get().asFile.readText().trim()
+        workerExecutor.noIsolation().submit(WaitForExecutionAction::class.java) { params ->
+            params.service.set(service)
+            params.executionName.set(executionName)
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CloudRunExecutionsClientBuildService.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CloudRunExecutionsClientBuildService.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.ExecutionsClient
+import com.google.cloud.run.v2.ExecutionsSettings
+import com.kelvsyc.gradle.google.cloud.AbstractGcpClientBuildService
+import com.kelvsyc.gradle.google.cloud.GcpBuildServiceParams
+
+/**
+ * Build service managing an [ExecutionsClient] instance for the Cloud Run v2 API.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring the credential source via the extension functions on [GcpBuildServiceParams] (e.g.
+ * [applicationDefault][com.kelvsyc.gradle.google.cloud.applicationDefault],
+ * [serviceAccount][com.kelvsyc.gradle.google.cloud.serviceAccount]). The same registration can
+ * then be shared with value sources, work actions, and tasks via a
+ * `Property<CloudRunExecutionsClientBuildService>` parameter.
+ */
+abstract class CloudRunExecutionsClientBuildService :
+    AbstractGcpClientBuildService<ExecutionsClient, GcpBuildServiceParams>() {
+
+    /**
+     * Creates an [ExecutionsClient] configured with the resolved credentials provider (if present).
+     *
+     * @return the initialized client
+     */
+    override fun createClient(): ExecutionsClient {
+        val settings = ExecutionsSettings.newBuilder().apply {
+            resolveCredentialsProvider()?.let { credentialsProvider = it }
+        }.build()
+        return ExecutionsClient.create(settings)
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CloudRunJobsClientBuildService.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CloudRunJobsClientBuildService.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.JobsClient
+import com.google.cloud.run.v2.JobsSettings
+import com.kelvsyc.gradle.google.cloud.AbstractGcpClientBuildService
+import com.kelvsyc.gradle.google.cloud.GcpBuildServiceParams
+
+/**
+ * Build service managing a [JobsClient] instance for the Cloud Run v2 API.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring the credential source via the extension functions on [GcpBuildServiceParams] (e.g.
+ * [applicationDefault][com.kelvsyc.gradle.google.cloud.applicationDefault],
+ * [serviceAccount][com.kelvsyc.gradle.google.cloud.serviceAccount]). The same registration can
+ * then be shared with value sources, work actions, and tasks via a
+ * `Property<CloudRunJobsClientBuildService>` parameter.
+ */
+abstract class CloudRunJobsClientBuildService :
+    AbstractGcpClientBuildService<JobsClient, GcpBuildServiceParams>() {
+
+    /**
+     * Creates a [JobsClient] configured with the resolved credentials provider (if present).
+     *
+     * @return the initialized client
+     */
+    override fun createClient(): JobsClient {
+        val settings = JobsSettings.newBuilder().apply {
+            resolveCredentialsProvider()?.let { credentialsProvider = it }
+        }.build()
+        return JobsClient.create(settings)
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CloudRunServicesClientBuildService.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CloudRunServicesClientBuildService.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.ServicesClient
+import com.google.cloud.run.v2.ServicesSettings
+import com.kelvsyc.gradle.google.cloud.AbstractGcpClientBuildService
+import com.kelvsyc.gradle.google.cloud.GcpBuildServiceParams
+
+/**
+ * Build service managing a [ServicesClient] instance for the Cloud Run v2 API.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring the credential source via the extension functions on [GcpBuildServiceParams] (e.g.
+ * [applicationDefault][com.kelvsyc.gradle.google.cloud.applicationDefault],
+ * [serviceAccount][com.kelvsyc.gradle.google.cloud.serviceAccount]). The same registration can
+ * then be shared with value sources, work actions, and tasks via a
+ * `Property<CloudRunServicesClientBuildService>` parameter.
+ */
+abstract class CloudRunServicesClientBuildService :
+    AbstractGcpClientBuildService<ServicesClient, GcpBuildServiceParams>() {
+
+    /**
+     * Creates a [ServicesClient] configured with the resolved credentials provider (if present).
+     *
+     * @return the initialized client
+     */
+    override fun createClient(): ServicesClient {
+        val settings = ServicesSettings.newBuilder().apply {
+            resolveCredentialsProvider()?.let { credentialsProvider = it }
+        }.build()
+        return ServicesClient.create(settings)
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CreateJobAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CreateJobAction.kt
@@ -1,0 +1,89 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.Container
+import com.google.cloud.run.v2.EnvVar
+import com.google.cloud.run.v2.ExecutionTemplate
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.TaskTemplate
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that creates a new Cloud Run Job definition.
+ *
+ * The action parses the job ID and parent location from the full resource name,
+ * then creates a new job with the specified container image and environment variables.
+ * The container is set on the job's execution template.
+ *
+ * This action blocks until the long-running operation completes.
+ */
+abstract class CreateJobAction : WorkAction<CreateJobAction.Parameters> {
+
+    /**
+     * Parameters for [CreateJobAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Cloud Run Jobs client.
+         */
+        @get:Internal
+        val service: Property<CloudRunJobsClientBuildService>
+
+        /**
+         * The full resource name of the job to create,
+         * e.g. `projects/my-project/locations/us-central1/jobs/my-job`.
+         */
+        val jobName: Property<String>
+
+        /**
+         * The container image URI to deploy, e.g. `gcr.io/my-project/image:tag`.
+         */
+        val imageUri: Property<String>
+
+        /**
+         * Environment variables to set on the container.
+         */
+        val envVars: MapProperty<String, String>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val jobName = parameters.jobName.get()
+        val imageUri = parameters.imageUri.get()
+        val envVarsMap = parameters.envVars.get()
+
+        // Extract job ID and parent from the full resource name
+        val jobId = jobName.substringAfterLast("/")
+        val parent = jobName.substringBeforeLast("/jobs/")
+
+        // Build the container with image and env vars
+        val containerBuilder = Container.newBuilder()
+            .setImage(imageUri)
+        for ((key, value) in envVarsMap) {
+            containerBuilder.addEnv(
+                EnvVar.newBuilder()
+                    .setName(key)
+                    .setValue(value)
+                    .build()
+            )
+        }
+
+        // Build the job with execution template -> task template -> containers
+        val job = Job.newBuilder()
+            .setTemplate(
+                ExecutionTemplate.newBuilder()
+                    .setTemplate(
+                        TaskTemplate.newBuilder()
+                            .addContainers(containerBuilder.build())
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+
+        client.createJobAsync(parent, job, jobId).get()
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CreateJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/CreateJobTask.kt
@@ -1,0 +1,33 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractCreateJobTask] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val cloudRunJobs = gradle.sharedServices.registerIfAbsent("cloudRunJobs", CloudRunJobsClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<CreateJobTask>("createJob") {
+ *     service.set(cloudRunJobs)
+ *     jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+ *     imageUri.set("gcr.io/my-project/image:tag")
+ *     envVars.put("ENV_VAR", "value")
+ * }
+ * ```
+ */
+abstract class CreateJobTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractCreateJobTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunJobsClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteJobAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteJobAction.kt
@@ -1,0 +1,38 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that deletes a Cloud Run Job definition.
+ *
+ * The action deletes the job identified by the full resource name.
+ *
+ * This action blocks until the long-running operation completes.
+ */
+abstract class DeleteJobAction : WorkAction<DeleteJobAction.Parameters> {
+
+    /**
+     * Parameters for [DeleteJobAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Cloud Run Jobs client.
+         */
+        @get:Internal
+        val service: Property<CloudRunJobsClientBuildService>
+
+        /**
+         * The full resource name of the job to delete,
+         * e.g. `projects/my-project/locations/us-central1/jobs/my-job`.
+         */
+        val jobName: Property<String>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        client.deleteJobAsync(parameters.jobName.get()).get()
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteJobTask.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractDeleteJobTask] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val cloudRunJobs = gradle.sharedServices.registerIfAbsent("cloudRunJobs", CloudRunJobsClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<DeleteJobTask>("deleteJob") {
+ *     service.set(cloudRunJobs)
+ *     jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+ * }
+ * ```
+ */
+abstract class DeleteJobTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractDeleteJobTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunJobsClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteServiceAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteServiceAction.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that deletes a Cloud Run Service.
+ *
+ * This action blocks until the long-running operation completes.
+ */
+abstract class DeleteServiceAction : WorkAction<DeleteServiceAction.Parameters> {
+
+    /**
+     * Parameters for [DeleteServiceAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Cloud Run Services client.
+         */
+        @get:Internal
+        val service: Property<CloudRunServicesClientBuildService>
+
+        /**
+         * The full resource name of the service to delete,
+         * e.g. `projects/my-project/locations/us-central1/services/my-service`.
+         */
+        val serviceName: Property<String>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        client.deleteServiceAsync(parameters.serviceName.get()).get()
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteServiceTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteServiceTask.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractDeleteServiceTask] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val cloudRun = gradle.sharedServices.registerIfAbsent("cloudRun", CloudRunServicesClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<DeleteServiceTask>("deleteService") {
+ *     service.set(cloudRun)
+ *     serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+ * }
+ * ```
+ */
+abstract class DeleteServiceTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractDeleteServiceTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunServicesClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSource.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSource.kt
@@ -1,0 +1,43 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing the latest created execution name of a Cloud Run job.
+ *
+ * Returns `null` if the job does not exist or has no latest execution.
+ *
+ * The [Parameters.jobName] must be the full resource name in the form
+ * `projects/{project}/locations/{location}/jobs/{job}`.
+ */
+abstract class GetJobValueSource : ValueSource<String, GetJobValueSource.Parameters> {
+
+    /**
+     * Parameters for [GetJobValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the Cloud Run Jobs client.
+         */
+        @get:Internal
+        val service: Property<CloudRunJobsClientBuildService>
+
+        /**
+         * The full resource name of the job, e.g.
+         * `projects/my-project/locations/us-central1/jobs/my-job`.
+         */
+        val jobName: Property<String>
+    }
+
+    override fun obtain(): String? {
+        return try {
+            val job = parameters.service.get().getClient().getJob(parameters.jobName.get())
+            job.latestCreatedExecution.name.takeIf { it.isNotBlank() }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            if (e.javaClass.name == "com.google.api.gax.rpc.NotFoundException") null else throw e
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSource.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSource.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.google.cloud.run
 
+import com.google.api.gax.rpc.NotFoundException
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -36,8 +37,8 @@ abstract class GetJobValueSource : ValueSource<String, GetJobValueSource.Paramet
         return try {
             val job = parameters.service.get().getClient().getJob(parameters.jobName.get())
             job.latestCreatedExecution.name.takeIf { it.isNotBlank() }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            if (e.javaClass.name == "com.google.api.gax.rpc.NotFoundException") null else throw e
+        } catch (@Suppress("SwallowedException") e: NotFoundException) {
+            null
         }
     }
 }

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSource.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSource.kt
@@ -1,0 +1,43 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing the HTTPS endpoint URL of a Cloud Run service.
+ *
+ * Returns `null` if the service does not exist or has no deployed URI.
+ *
+ * The [Parameters.serviceName] must be the full resource name in the form
+ * `projects/{project}/locations/{location}/services/{service}`.
+ */
+abstract class GetServiceValueSource : ValueSource<String, GetServiceValueSource.Parameters> {
+
+    /**
+     * Parameters for [GetServiceValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the Cloud Run Services client.
+         */
+        @get:Internal
+        val service: Property<CloudRunServicesClientBuildService>
+
+        /**
+         * The full resource name of the service, e.g.
+         * `projects/my-project/locations/us-central1/services/my-service`.
+         */
+        val serviceName: Property<String>
+    }
+
+    override fun obtain(): String? {
+        return try {
+            val service = parameters.service.get().getClient().getService(parameters.serviceName.get())
+            service.uri.takeIf { it.isNotBlank() }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            if (e.javaClass.name == "com.google.api.gax.rpc.NotFoundException") null else throw e
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSource.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSource.kt
@@ -1,5 +1,6 @@
 package com.kelvsyc.gradle.google.cloud.run
 
+import com.google.api.gax.rpc.NotFoundException
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -36,8 +37,8 @@ abstract class GetServiceValueSource : ValueSource<String, GetServiceValueSource
         return try {
             val service = parameters.service.get().getClient().getService(parameters.serviceName.get())
             service.uri.takeIf { it.isNotBlank() }
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            if (e.javaClass.name == "com.google.api.gax.rpc.NotFoundException") null else throw e
+        } catch (@Suppress("SwallowedException") e: NotFoundException) {
+            null
         }
     }
 }

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/ListJobsValueSource.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/ListJobsValueSource.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing a list of Cloud Run job short names within a given
+ * project and location.
+ *
+ * Each entry is the short job name (last path segment of the full resource name).
+ * Pagination is handled internally via the high-level paged API.
+ */
+abstract class ListJobsValueSource : ValueSource<List<String>, ListJobsValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListJobsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the Cloud Run Jobs client.
+         */
+        @get:Internal
+        val service: Property<CloudRunJobsClientBuildService>
+
+        /**
+         * GCP project ID.
+         */
+        val projectId: Property<String>
+
+        /**
+         * GCP region, e.g. `"us-central1"`.
+         */
+        val location: Property<String>
+    }
+
+    override fun obtain(): List<String> {
+        val parent = "projects/${parameters.projectId.get()}/locations/${parameters.location.get()}"
+        return parameters.service.get().getClient()
+            .listJobs(parent)
+            .iterateAll()
+            .map { job -> job.name.substringAfterLast('/') }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/ListServicesValueSource.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/ListServicesValueSource.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation providing a map of Cloud Run service names to their HTTPS endpoint
+ * URLs within a given project and location.
+ *
+ * Each entry maps the short service name (last path segment of the full resource name) to the
+ * service's HTTPS endpoint URL. Pagination is handled internally via the high-level paged API.
+ */
+abstract class ListServicesValueSource :
+    ValueSource<Map<String, String>, ListServicesValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListServicesValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the Cloud Run Services client.
+         */
+        @get:Internal
+        val service: Property<CloudRunServicesClientBuildService>
+
+        /**
+         * GCP project ID.
+         */
+        val projectId: Property<String>
+
+        /**
+         * GCP region, e.g. `"us-central1"`.
+         */
+        val location: Property<String>
+    }
+
+    override fun obtain(): Map<String, String> {
+        val parent = "projects/${parameters.projectId.get()}/locations/${parameters.location.get()}"
+        return parameters.service.get().getClient()
+            .listServices(parent)
+            .iterateAll()
+            .associate { svc -> svc.name.substringAfterLast('/') to svc.uri }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/RunJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/RunJobTask.kt
@@ -1,0 +1,41 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractRunJobTask] that adds `@get:ServiceReference` to both
+ * [service] and [executionsService] properties so Gradle automatically tracks the
+ * build services as task dependencies.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val cloudRunJobs = gradle.sharedServices.registerIfAbsent("cloudRunJobs", CloudRunJobsClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ * val cloudRunExecutions = gradle.sharedServices.registerIfAbsent("cloudRunExecutions", CloudRunExecutionsClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<RunJobTask>("runJob") {
+ *     service.set(cloudRunJobs)
+ *     executionsService.set(cloudRunExecutions)
+ *     jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+ *     overrides.put("ENV_VAR", "override-value")
+ *     executionNameFile.set(file("build/execution-name.txt"))
+ * }
+ * ```
+ */
+abstract class RunJobTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractRunJobTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunJobsClientBuildService>
+
+    @get:ServiceReference
+    abstract override val executionsService: Property<CloudRunExecutionsClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobAction.kt
@@ -84,7 +84,6 @@ abstract class UpdateJobAction : WorkAction<UpdateJobAction.Parameters> {
 
         val request = UpdateJobRequest.newBuilder()
             .setJob(updated)
-            .setAllowMissing(false)
             .build()
 
         client.updateJobAsync(request).get()

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobAction.kt
@@ -1,0 +1,92 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.Container
+import com.google.cloud.run.v2.EnvVar
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.UpdateJobRequest
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that updates an existing Cloud Run Job definition.
+ *
+ * The action fetches the existing job, then updates its container image and environment variables.
+ * The container is modified on the job's execution template's task template.
+ *
+ * This action blocks until the long-running operation completes.
+ */
+abstract class UpdateJobAction : WorkAction<UpdateJobAction.Parameters> {
+
+    /**
+     * Parameters for [UpdateJobAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Cloud Run Jobs client.
+         */
+        @get:Internal
+        val service: Property<CloudRunJobsClientBuildService>
+
+        /**
+         * The full resource name of the job to update,
+         * e.g. `projects/my-project/locations/us-central1/jobs/my-job`.
+         */
+        val jobName: Property<String>
+
+        /**
+         * The container image URI to deploy, e.g. `gcr.io/my-project/image:tag`.
+         */
+        val imageUri: Property<String>
+
+        /**
+         * Environment variables to set on the container.
+         */
+        val envVars: MapProperty<String, String>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val jobName = parameters.jobName.get()
+        val imageUri = parameters.imageUri.get()
+        val envVarsMap = parameters.envVars.get()
+
+        // Fetch the existing job
+        val existingJob = client.getJob(jobName)
+
+        // Build the container with image and env vars
+        val containerBuilder = Container.newBuilder()
+            .setImage(imageUri)
+        for ((key, value) in envVarsMap) {
+            containerBuilder.addEnv(
+                EnvVar.newBuilder()
+                    .setName(key)
+                    .setValue(value)
+                    .build()
+            )
+        }
+
+        // Update the job, replacing the container in the task template
+        val updated = existingJob.toBuilder()
+            .setTemplate(
+                existingJob.template.toBuilder()
+                    .setTemplate(
+                        existingJob.template.template.toBuilder()
+                            .clearContainers()
+                            .addContainers(containerBuilder.build())
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+
+        val request = UpdateJobRequest.newBuilder()
+            .setJob(updated)
+            .setAllowMissing(false)
+            .build()
+
+        client.updateJobAsync(request).get()
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobTask.kt
@@ -1,0 +1,33 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractUpdateJobTask] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val cloudRunJobs = gradle.sharedServices.registerIfAbsent("cloudRunJobs", CloudRunJobsClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<UpdateJobTask>("updateJob") {
+ *     service.set(cloudRunJobs)
+ *     jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+ *     imageUri.set("gcr.io/my-project/image:tag")
+ *     envVars.put("ENV_VAR", "value")
+ * }
+ * ```
+ */
+abstract class UpdateJobTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractUpdateJobTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunJobsClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpsertServiceAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpsertServiceAction.kt
@@ -1,0 +1,108 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.api.gax.rpc.NotFoundException
+import com.google.cloud.run.v2.Container
+import com.google.cloud.run.v2.EnvVar
+import com.google.cloud.run.v2.RevisionTemplate
+import com.google.cloud.run.v2.Service
+import com.google.protobuf.FieldMask
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that creates or updates a Cloud Run Service (upsert semantics).
+ *
+ * The action fetches the full resource name to extract the service ID and parent location,
+ * then attempts to update an existing service. If the service does not exist, it creates a new one.
+ * The container image and environment variables are set on the service's revision template.
+ *
+ * This action blocks until the long-running operation completes.
+ */
+abstract class UpsertServiceAction : WorkAction<UpsertServiceAction.Parameters> {
+
+    /**
+     * Parameters for [UpsertServiceAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service managing the Cloud Run Services client.
+         */
+        @get:Internal
+        val service: Property<CloudRunServicesClientBuildService>
+
+        /**
+         * The full resource name of the service to create or update,
+         * e.g. `projects/my-project/locations/us-central1/services/my-service`.
+         */
+        val serviceName: Property<String>
+
+        /**
+         * The container image URI to deploy, e.g. `gcr.io/my-project/image:tag`.
+         */
+        val imageUri: Property<String>
+
+        /**
+         * Environment variables to set on the container.
+         */
+        val envVars: MapProperty<String, String>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val serviceName = parameters.serviceName.get()
+        val imageUri = parameters.imageUri.get()
+        val envVarsMap = parameters.envVars.get()
+
+        // Extract service ID and parent from the full resource name
+        val serviceId = serviceName.substringAfterLast("/")
+        val parent = serviceName.substringBeforeLast("/services/")
+
+        // Build the container with image and env vars
+        val containerBuilder = Container.newBuilder()
+            .setImage(imageUri)
+        for ((key, value) in envVarsMap) {
+            containerBuilder.addEnv(
+                EnvVar.newBuilder()
+                    .setName(key)
+                    .setValue(value)
+                    .build()
+            )
+        }
+
+        try {
+            // Try to fetch the existing service
+            val existingService = client.getService(serviceName)
+
+            // Update the existing service
+            val updated = existingService.toBuilder()
+                .setTemplate(
+                    existingService.template.toBuilder()
+                        .clearContainers()
+                        .addContainers(containerBuilder.build())
+                        .build()
+                )
+                .build()
+
+            client.updateServiceAsync(
+                updated,
+                FieldMask.newBuilder()
+                    .addPaths("template.containers")
+                    .build()
+            ).get()
+        } catch (@Suppress("SwallowedException") e: NotFoundException) {
+            // Service does not exist, create it
+            val newService = Service.newBuilder()
+                .setTemplate(
+                    RevisionTemplate.newBuilder()
+                        .addContainers(containerBuilder.build())
+                        .build()
+                )
+                .build()
+
+            client.createServiceAsync(parent, newService, serviceId).get()
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpsertServiceTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/UpsertServiceTask.kt
@@ -1,0 +1,33 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractUpsertServiceTask] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly in most cases:
+ *
+ * ```kotlin
+ * val cloudRun = gradle.sharedServices.registerIfAbsent("cloudRun", CloudRunServicesClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<UpsertServiceTask>("deployService") {
+ *     service.set(cloudRun)
+ *     serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+ *     imageUri.set("gcr.io/my-project/image:tag")
+ *     envVars.put("ENV_VAR", "value")
+ * }
+ * ```
+ */
+abstract class UpsertServiceTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractUpsertServiceTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunServicesClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionAction.kt
@@ -11,7 +11,8 @@ import org.gradle.api.tasks.Internal
  * Work action that polls a Cloud Run Job Execution until it reaches a terminal state.
  *
  * This action repeatedly fetches the execution status, waiting for either successful completion
- * or failure. Polls every [pollIntervalMs] milliseconds (default 5000ms).
+ * or failure. Polls every [pollIntervalMs] milliseconds (default 5000ms). Raises an exception if
+ * the execution is not complete after [maxWaitTimeMs] (default 30 minutes).
  */
 abstract class WaitForExecutionAction : WorkAction<WaitForExecutionAction.Parameters> {
 
@@ -19,24 +20,43 @@ abstract class WaitForExecutionAction : WorkAction<WaitForExecutionAction.Parame
         val client = parameters.service.get().getClient()
         val executionName = parameters.executionName.get()
         val pollInterval = parameters.pollIntervalMs.get()
+        val maxWaitMs = parameters.maxWaitTimeMs.get()
+
+        val startTime = System.currentTimeMillis()
 
         while (true) {
             val execution = client.getExecution(executionName)
 
             // Terminal state: completionTime is set
             if (execution.hasCompletionTime()) {
-                // Check if execution failed
-                if (execution.failedCount > 0) {
-                    throw GradleException("Execution failed: ${execution.name}")
+                if (isExecutionFailed(execution)) {
+                    throw GradleException(
+                        "Execution ${execution.name} did not succeed " +
+                        "(failedCount=${execution.failedCount}, cancelledCount=${execution.cancelledCount})",
+                    )
                 }
                 // Execution succeeded
                 return
+            }
+
+            // Check for timeout
+            if (System.currentTimeMillis() - startTime >= maxWaitMs) {
+                throw GradleException(
+                    "Timed out waiting for execution $executionName " +
+                    "(waited ${System.currentTimeMillis() - startTime}ms, max ${maxWaitMs}ms)",
+                )
             }
 
             // Not yet complete, sleep and retry
             Thread.sleep(pollInterval)
         }
     }
+
+    /**
+     * Determines if an execution has failed or was cancelled.
+     */
+    private fun isExecutionFailed(execution: com.google.cloud.run.v2.Execution): Boolean =
+        execution.failedCount > 0 || execution.cancelledCount > 0
 
     /**
      * Work parameters for [WaitForExecutionAction].
@@ -58,13 +78,22 @@ abstract class WaitForExecutionAction : WorkAction<WaitForExecutionAction.Parame
          */
         @get:Internal
         val pollIntervalMs: Property<Long>
+
+        /**
+         * Maximum time to wait for execution completion in milliseconds.
+         * Defaults to 30 minutes. Raises [GradleException] if exceeded.
+         */
+        @get:Internal
+        val maxWaitTimeMs: Property<Long>
     }
 
     init {
         parameters.pollIntervalMs.convention(POLL_INTERVAL_MS)
+        parameters.maxWaitTimeMs.convention(DEFAULT_MAX_WAIT_MS)
     }
 
     companion object {
         private const val POLL_INTERVAL_MS = 5_000L
+        private const val DEFAULT_MAX_WAIT_MS = 30 * 60 * 1_000L  // 30 minutes
     }
 }

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionAction.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionAction.kt
@@ -1,0 +1,70 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.ExecutionsClient
+import org.gradle.api.GradleException
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+
+/**
+ * Work action that polls a Cloud Run Job Execution until it reaches a terminal state.
+ *
+ * This action repeatedly fetches the execution status, waiting for either successful completion
+ * or failure. Polls every [pollIntervalMs] milliseconds (default 5000ms).
+ */
+abstract class WaitForExecutionAction : WorkAction<WaitForExecutionAction.Parameters> {
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val executionName = parameters.executionName.get()
+        val pollInterval = parameters.pollIntervalMs.get()
+
+        while (true) {
+            val execution = client.getExecution(executionName)
+
+            // Terminal state: completionTime is set
+            if (execution.hasCompletionTime()) {
+                // Check if execution failed
+                if (execution.failedCount > 0) {
+                    throw GradleException("Execution failed: ${execution.name}")
+                }
+                // Execution succeeded
+                return
+            }
+
+            // Not yet complete, sleep and retry
+            Thread.sleep(pollInterval)
+        }
+    }
+
+    /**
+     * Work parameters for [WaitForExecutionAction].
+     */
+    interface Parameters : WorkParameters {
+        /**
+         * The build service providing the [ExecutionsClient].
+         */
+        @get:Internal
+        val service: Property<CloudRunExecutionsClientBuildService>
+
+        /**
+         * Full execution resource name: `projects/{projectId}/locations/{location}/jobs/{jobId}/executions/{executionId}`.
+         */
+        val executionName: Property<String>
+
+        /**
+         * Polling interval in milliseconds. Defaults to 5000ms; override to 0 in tests.
+         */
+        @get:Internal
+        val pollIntervalMs: Property<Long>
+    }
+
+    init {
+        parameters.pollIntervalMs.convention(POLL_INTERVAL_MS)
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS = 5_000L
+    }
+}

--- a/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForJobExecutionTask.kt
+++ b/cores/google-cloud-run-base/src/main/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForJobExecutionTask.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Specialization of [AbstractWaitForJobExecutionTask] that adds `@get:ServiceReference` to the
+ * [service] property so Gradle automatically tracks the build service as a task dependency.
+ *
+ * Register this task directly when you need to wait for an execution that was previously
+ * submitted by [RunJobTask]:
+ *
+ * ```kotlin
+ * val cloudRunExecutions = gradle.sharedServices.registerIfAbsent("cloudRunExecutions", CloudRunExecutionsClientBuildService::class) {
+ *     parameters { applicationDefault() }
+ * }
+ *
+ * tasks.register<WaitForJobExecutionTask>("waitForExecution") {
+ *     service.set(cloudRunExecutions)
+ *     executionNameFile.set(file("build/execution-name.txt"))
+ * }
+ * ```
+ */
+abstract class WaitForJobExecutionTask @Inject constructor(
+    workerExecutor: WorkerExecutor,
+) : AbstractWaitForJobExecutionTask(workerExecutor) {
+
+    @get:ServiceReference
+    abstract override val service: Property<CloudRunExecutionsClientBuildService>
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/CreateJobActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/CreateJobActionSpec.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.JobsClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateJobActionSpec : FunSpec() {
+    init {
+        test("execute - creates job with correct container image and env vars") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-create",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val jobName = "projects/p/locations/us-central1/jobs/my-job"
+            val createSlot = slot<Job>()
+            val parentSlot = slot<String>()
+            val jobIdSlot = slot<String>()
+            val operationFuture = mockk<OperationFuture<Job, Job>>()
+            every { operationFuture.get() } returns Job.newBuilder()
+                .setName(jobName)
+                .build()
+            every { client.createJobAsync(capture(parentSlot), capture(createSlot), capture(jobIdSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<CreateJobAction.Parameters>()
+            params.service.set(service)
+            params.jobName.set(jobName)
+            params.imageUri.set("gcr.io/p/my-image:v1")
+            params.envVars.put("FOO", "bar")
+            params.envVars.put("BAZ", "qux")
+
+            val action = object : CreateJobAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            parentSlot.captured shouldBe "projects/p/locations/us-central1"
+            jobIdSlot.captured shouldBe "my-job"
+            createSlot.captured.template.template.containersList shouldHaveSize 1
+            createSlot.captured.template.template.containersList[0].image shouldBe "gcr.io/p/my-image:v1"
+            createSlot.captured.template.template.containersList[0].envList shouldHaveSize 2
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteJobActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteJobActionSpec.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.JobsClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteJobActionSpec : FunSpec() {
+    init {
+        test("execute - calls deleteJobAsync with the correct job name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-delete",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val jobName = "projects/p/locations/us-central1/jobs/my-job"
+            val nameSlot = slot<String>()
+            val operationFuture = mockk<OperationFuture<Job, Job>>()
+            every { operationFuture.get() } returns Job.newBuilder()
+                .setName(jobName)
+                .build()
+            every { client.deleteJobAsync(capture(nameSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<DeleteJobAction.Parameters>()
+            params.service.set(service)
+            params.jobName.set(jobName)
+
+            val action = object : DeleteJobAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            nameSlot.captured shouldBe jobName
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteServiceActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/DeleteServiceActionSpec.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.run.v2.Service
+import com.google.cloud.run.v2.ServicesClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteServiceActionSpec : FunSpec() {
+    init {
+        test("execute - calls deleteServiceAsync with the correct service name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-delete",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val serviceName = "projects/p/locations/us-central1/services/my-service"
+            val nameSlot = slot<String>()
+            val operationFuture = mockk<OperationFuture<Service, Service>>()
+            every { operationFuture.get() } returns Service.newBuilder()
+                .setName(serviceName)
+                .build()
+            every { client.deleteServiceAsync(capture(nameSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<DeleteServiceAction.Parameters>()
+            params.service.set(service)
+            params.serviceName.set(serviceName)
+
+            val action = object : DeleteServiceAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            nameSlot.captured shouldBe serviceName
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSourceSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSourceSpec.kt
@@ -1,0 +1,75 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.ExecutionReference
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.JobsClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class GetJobValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns latest execution name when job exists") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val executionName = "projects/my-project/locations/us-central1/jobs/my-job/executions/abc123"
+            val latestExecution = ExecutionReference.newBuilder()
+                .setName(executionName)
+                .build()
+
+            val jobProto = Job.newBuilder()
+                .setName("projects/my-project/locations/us-central1/jobs/my-job")
+                .setLatestCreatedExecution(latestExecution)
+                .build()
+
+            val nameSlot = slot<String>()
+            every { client.getJob(capture(nameSlot)) } returns jobProto
+
+            val provider = project.providers.ofKt(GetJobValueSource::class) {
+                parameters.service.set(service)
+                parameters.jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+            }
+
+            provider.get() shouldBe executionName
+            nameSlot.captured shouldBe "projects/my-project/locations/us-central1/jobs/my-job"
+        }
+
+        test("obtain - returns null when latest execution name is blank") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-blank",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val latestExecution = ExecutionReference.newBuilder()
+                .setName("")
+                .build()
+
+            val jobProto = Job.newBuilder()
+                .setName("projects/my-project/locations/us-central1/jobs/my-job")
+                .setLatestCreatedExecution(latestExecution)
+                .build()
+
+            every { client.getJob(any<String>()) } returns jobProto
+
+            val provider = project.providers.ofKt(GetJobValueSource::class) {
+                parameters.service.set(service)
+                parameters.jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+            }
+
+            provider.orNull shouldBe null
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSourceSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetJobValueSourceSpec.kt
@@ -1,5 +1,7 @@
 package com.kelvsyc.gradle.google.cloud.run
 
+import com.google.api.gax.rpc.NotFoundException
+import com.google.api.gax.rpc.StatusCode
 import com.google.cloud.run.v2.ExecutionReference
 import com.google.cloud.run.v2.Job
 import com.google.cloud.run.v2.JobsClient
@@ -67,6 +69,30 @@ class GetJobValueSourceSpec : FunSpec() {
             val provider = project.providers.ofKt(GetJobValueSource::class) {
                 parameters.service.set(service)
                 parameters.jobName.set("projects/my-project/locations/us-central1/jobs/my-job")
+            }
+
+            provider.orNull shouldBe null
+        }
+
+        test("obtain - returns null when job is not found") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-not-found",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val statusCode = mockk<StatusCode>()
+            every { client.getJob(any<String>()) } throws NotFoundException(
+                Exception("Job not found"),
+                statusCode,
+                false
+            )
+
+            val provider = project.providers.ofKt(GetJobValueSource::class) {
+                parameters.service.set(service)
+                parameters.jobName.set("projects/my-project/locations/us-central1/jobs/nonexistent")
             }
 
             provider.orNull shouldBe null

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSourceSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSourceSpec.kt
@@ -1,0 +1,67 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.Service
+import com.google.cloud.run.v2.ServicesClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class GetServiceValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns HTTPS URI when service is deployed") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val uri = "https://my-service-abc123-us-central1.run.app"
+            val serviceProto = Service.newBuilder()
+                .setName("projects/my-project/locations/us-central1/services/my-service")
+                .setUri(uri)
+                .build()
+
+            val nameSlot = slot<String>()
+            every { client.getService(capture(nameSlot)) } returns serviceProto
+
+            val provider = project.providers.ofKt(GetServiceValueSource::class) {
+                parameters.service.set(service)
+                parameters.serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+            }
+
+            provider.get() shouldBe uri
+            nameSlot.captured shouldBe "projects/my-project/locations/us-central1/services/my-service"
+        }
+
+
+        test("obtain - returns null when service URI is blank") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-blank",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val serviceProto = Service.newBuilder()
+                .setName("projects/my-project/locations/us-central1/services/my-service")
+                .setUri("")
+                .build()
+
+            every { client.getService(any<String>()) } returns serviceProto
+
+            val provider = project.providers.ofKt(GetServiceValueSource::class) {
+                parameters.service.set(service)
+                parameters.serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+            }
+
+            provider.orNull shouldBe null
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSourceSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/GetServiceValueSourceSpec.kt
@@ -1,5 +1,7 @@
 package com.kelvsyc.gradle.google.cloud.run
 
+import com.google.api.gax.rpc.NotFoundException
+import com.google.api.gax.rpc.StatusCode
 import com.google.cloud.run.v2.Service
 import com.google.cloud.run.v2.ServicesClient
 import io.kotest.core.spec.style.FunSpec
@@ -59,6 +61,30 @@ class GetServiceValueSourceSpec : FunSpec() {
             val provider = project.providers.ofKt(GetServiceValueSource::class) {
                 parameters.service.set(service)
                 parameters.serviceName.set("projects/my-project/locations/us-central1/services/my-service")
+            }
+
+            provider.orNull shouldBe null
+        }
+
+        test("obtain - returns null when service is not found") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-not-found",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val statusCode = mockk<StatusCode>()
+            every { client.getService(any<String>()) } throws NotFoundException(
+                Exception("Service not found"),
+                statusCode,
+                false
+            )
+
+            val provider = project.providers.ofKt(GetServiceValueSource::class) {
+                parameters.service.set(service)
+                parameters.serviceName.set("projects/my-project/locations/us-central1/services/nonexistent")
             }
 
             provider.orNull shouldBe null

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/ListJobsValueSourceSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/ListJobsValueSourceSpec.kt
@@ -1,0 +1,71 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.JobsClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListJobsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns list of short job names") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val jobs = listOf(
+                Job.newBuilder()
+                    .setName("projects/p/locations/us-central1/jobs/job-alpha")
+                    .build(),
+                Job.newBuilder()
+                    .setName("projects/p/locations/us-central1/jobs/job-bravo")
+                    .build(),
+            )
+            val paged = mockk<JobsClient.ListJobsPagedResponse>()
+            every { paged.iterateAll() } returns jobs
+
+            val parentSlot = slot<String>()
+            every { client.listJobs(capture(parentSlot)) } returns paged
+
+            val provider = project.providers.ofKt(ListJobsValueSource::class) {
+                parameters.service.set(service)
+                parameters.projectId.set("p")
+                parameters.location.set("us-central1")
+            }
+
+            provider.get() shouldBe listOf("job-alpha", "job-bravo")
+            parentSlot.captured shouldBe "projects/p/locations/us-central1"
+        }
+
+        test("obtain - returns empty list when no jobs exist") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-empty",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val paged = mockk<JobsClient.ListJobsPagedResponse>()
+            every { paged.iterateAll() } returns emptyList()
+
+            every { client.listJobs(any<String>()) } returns paged
+
+            val provider = project.providers.ofKt(ListJobsValueSource::class) {
+                parameters.service.set(service)
+                parameters.projectId.set("p")
+                parameters.location.set("us-central1")
+            }
+
+            provider.get() shouldBe emptyList()
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/ListServicesValueSourceSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/ListServicesValueSourceSpec.kt
@@ -1,0 +1,76 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.Service
+import com.google.cloud.run.v2.ServicesClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListServicesValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns map of short name to HTTPS URI") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val services = listOf(
+                Service.newBuilder()
+                    .setName("projects/p/locations/us-central1/services/alpha")
+                    .setUri("https://alpha-abc123-us-central1.run.app")
+                    .build(),
+                Service.newBuilder()
+                    .setName("projects/p/locations/us-central1/services/bravo")
+                    .setUri("https://bravo-def456-us-central1.run.app")
+                    .build(),
+            )
+            val paged = mockk<ServicesClient.ListServicesPagedResponse>()
+            every { paged.iterateAll() } returns services
+
+            val parentSlot = slot<String>()
+            every { client.listServices(capture(parentSlot)) } returns paged
+
+            val provider = project.providers.ofKt(ListServicesValueSource::class) {
+                parameters.service.set(service)
+                parameters.projectId.set("p")
+                parameters.location.set("us-central1")
+            }
+
+            provider.get() shouldBe mapOf(
+                "alpha" to "https://alpha-abc123-us-central1.run.app",
+                "bravo" to "https://bravo-def456-us-central1.run.app",
+            )
+            parentSlot.captured shouldBe "projects/p/locations/us-central1"
+        }
+
+        test("obtain - returns empty map when no services exist") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-empty",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val paged = mockk<ServicesClient.ListServicesPagedResponse>()
+            every { paged.iterateAll() } returns emptyList()
+
+            every { client.listServices(any<String>()) } returns paged
+
+            val provider = project.providers.ofKt(ListServicesValueSource::class) {
+                parameters.service.set(service)
+                parameters.projectId.set("p")
+                parameters.location.set("us-central1")
+            }
+
+            provider.get() shouldBe emptyMap()
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/MockCloudRunExecutionsClientBuildService.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/MockCloudRunExecutionsClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.ExecutionsClient
+
+/**
+ * Test-only [CloudRunExecutionsClientBuildService] that returns a pre-supplied mock client.
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockCloudRunExecutionsClientBuildService : CloudRunExecutionsClientBuildService() {
+    override fun createClient(): ExecutionsClient =
+        checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: ExecutionsClient? = null
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/MockCloudRunJobsClientBuildService.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/MockCloudRunJobsClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.JobsClient
+
+/**
+ * Test-only [CloudRunJobsClientBuildService] that returns a pre-supplied mock client.
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockCloudRunJobsClientBuildService : CloudRunJobsClientBuildService() {
+    override fun createClient(): JobsClient =
+        checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: JobsClient? = null
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/MockCloudRunServicesClientBuildService.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/MockCloudRunServicesClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.ServicesClient
+
+/**
+ * Test-only [CloudRunServicesClientBuildService] that returns a pre-supplied mock client.
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockCloudRunServicesClientBuildService : CloudRunServicesClientBuildService() {
+    override fun createClient(): ServicesClient =
+        checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: ServicesClient? = null
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/ProviderFactoryExtensions.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/ProviderFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+// Workaround: under the kotlin-gradle-library convention, Kotlin does not treat Gradle's
+// Action<in T> as T.() -> Unit, so providers.of(...) { parameters.X } fails to resolve.
+internal fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit
+) = of(valueSourceType, configuration)

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobActionSpec.kt
@@ -55,12 +55,12 @@ class UpdateJobActionSpec : FunSpec() {
             capturedJob.template.template.containersList[0].envList[0].value shouldBe "production"
         }
 
-        test("execute - update passes correct request") {
+        test("execute - update request contains the updated job") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<JobsClient>()
             MockCloudRunJobsClientBuildService.mockClient = client
             val service = project.gradle.sharedServices.registerIfAbsent(
-                "jobs-mask",
+                "jobs-verify",
                 MockCloudRunJobsClientBuildService::class,
             )
 

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/UpdateJobActionSpec.kt
@@ -1,0 +1,92 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.run.v2.Job
+import com.google.cloud.run.v2.JobsClient
+import com.google.cloud.run.v2.UpdateJobRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class UpdateJobActionSpec : FunSpec() {
+    init {
+        test("execute - updates existing job with new image and env vars") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-update",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val jobName = "projects/p/locations/us-central1/jobs/my-job"
+            val existingJob = Job.newBuilder()
+                .setName(jobName)
+                .build()
+            every { client.getJob(jobName) } returns existingJob
+
+            val requestSlot = slot<UpdateJobRequest>()
+            val operationFuture = mockk<OperationFuture<Job, Job>>()
+            every { operationFuture.get() } returns existingJob
+            every { client.updateJobAsync(capture(requestSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpdateJobAction.Parameters>()
+            params.service.set(service)
+            params.jobName.set(jobName)
+            params.imageUri.set("gcr.io/p/my-image:v2")
+            params.envVars.put("ENV", "production")
+
+            val action = object : UpdateJobAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val capturedJob = requestSlot.captured.job
+            capturedJob.template.template.containersList shouldHaveSize 1
+            capturedJob.template.template.containersList[0].image shouldBe "gcr.io/p/my-image:v2"
+            capturedJob.template.template.containersList[0].envList shouldHaveSize 1
+            capturedJob.template.template.containersList[0].envList[0].name shouldBe "ENV"
+            capturedJob.template.template.containersList[0].envList[0].value shouldBe "production"
+        }
+
+        test("execute - update passes correct request") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<JobsClient>()
+            MockCloudRunJobsClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "jobs-mask",
+                MockCloudRunJobsClientBuildService::class,
+            )
+
+            val jobName = "projects/p/locations/us-central1/jobs/my-job"
+            val existingJob = Job.newBuilder()
+                .setName(jobName)
+                .build()
+            every { client.getJob(jobName) } returns existingJob
+
+            val requestSlot = slot<UpdateJobRequest>()
+            val operationFuture = mockk<OperationFuture<Job, Job>>()
+            every { operationFuture.get() } returns existingJob
+            every { client.updateJobAsync(capture(requestSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpdateJobAction.Parameters>()
+            params.service.set(service)
+            params.jobName.set(jobName)
+            params.imageUri.set("gcr.io/p/my-image:v3")
+
+            val action = object : UpdateJobAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.job.template.template.containersList shouldHaveSize 1
+            requestSlot.captured.job.template.template.containersList[0].image shouldBe "gcr.io/p/my-image:v3"
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/UpsertServiceActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/UpsertServiceActionSpec.kt
@@ -1,0 +1,138 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.api.gax.longrunning.OperationFuture
+import com.google.cloud.run.v2.Service
+import com.google.cloud.run.v2.ServicesClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import com.google.api.gax.rpc.NotFoundException
+import com.google.api.gax.rpc.StatusCode
+import com.google.protobuf.FieldMask
+
+class UpsertServiceActionSpec : FunSpec() {
+    init {
+        test("execute - creates service when it does not exist") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-create",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val serviceName = "projects/p/locations/us-central1/services/my-service"
+            val statusCode = mockk<StatusCode>()
+            every { client.getService(serviceName) } throws NotFoundException(
+                Exception("Service not found"),
+                statusCode,
+                false
+            )
+
+            val createSlot = slot<Service>()
+            val parentSlot = slot<String>()
+            val serviceIdSlot = slot<String>()
+            val operationFuture = mockk<OperationFuture<Service, Service>>()
+            every { operationFuture.get() } returns Service.newBuilder()
+                .setName(serviceName)
+                .build()
+            every { client.createServiceAsync(capture(parentSlot), capture(createSlot), capture(serviceIdSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpsertServiceAction.Parameters>()
+            params.service.set(service)
+            params.serviceName.set(serviceName)
+            params.imageUri.set("gcr.io/p/my-image:v1")
+            params.envVars.put("FOO", "bar")
+            params.envVars.put("BAZ", "qux")
+
+            val action = object : UpsertServiceAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            parentSlot.captured shouldBe "projects/p/locations/us-central1"
+            serviceIdSlot.captured shouldBe "my-service"
+            createSlot.captured.template.containersList shouldHaveSize 1
+            createSlot.captured.template.containersList[0].image shouldBe "gcr.io/p/my-image:v1"
+            createSlot.captured.template.containersList[0].envList shouldHaveSize 2
+        }
+
+        test("execute - updates service when it exists") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-update",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val serviceName = "projects/p/locations/us-central1/services/my-service"
+            val existingService = Service.newBuilder()
+                .setName(serviceName)
+                .build()
+            every { client.getService(serviceName) } returns existingService
+
+            val updateSlot = slot<Service>()
+            val maskSlot = slot<FieldMask>()
+            val operationFuture = mockk<OperationFuture<Service, Service>>()
+            every { operationFuture.get() } returns existingService
+            every { client.updateServiceAsync(capture(updateSlot), capture(maskSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpsertServiceAction.Parameters>()
+            params.service.set(service)
+            params.serviceName.set(serviceName)
+            params.imageUri.set("gcr.io/p/my-image:v2")
+            params.envVars.put("ENV", "production")
+
+            val action = object : UpsertServiceAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            updateSlot.captured.template.containersList shouldHaveSize 1
+            updateSlot.captured.template.containersList[0].image shouldBe "gcr.io/p/my-image:v2"
+            updateSlot.captured.template.containersList[0].envList shouldHaveSize 1
+            updateSlot.captured.template.containersList[0].envList[0].name shouldBe "ENV"
+            updateSlot.captured.template.containersList[0].envList[0].value shouldBe "production"
+        }
+
+        test("execute - update uses correct field mask") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ServicesClient>()
+            MockCloudRunServicesClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "services-mask",
+                MockCloudRunServicesClientBuildService::class,
+            )
+
+            val serviceName = "projects/p/locations/us-central1/services/my-service"
+            val existingService = Service.newBuilder()
+                .setName(serviceName)
+                .build()
+            every { client.getService(serviceName) } returns existingService
+
+            val maskSlot = slot<FieldMask>()
+            val operationFuture = mockk<OperationFuture<Service, Service>>()
+            every { operationFuture.get() } returns existingService
+            every { client.updateServiceAsync(any<Service>(), capture(maskSlot)) } returns operationFuture
+
+            val params = project.objects.newInstance<UpsertServiceAction.Parameters>()
+            params.service.set(service)
+            params.serviceName.set(serviceName)
+            params.imageUri.set("gcr.io/p/my-image:v3")
+
+            val action = object : UpsertServiceAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            maskSlot.captured.pathsList shouldBe listOf("template.containers")
+        }
+    }
+}

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionActionSpec.kt
@@ -88,7 +88,7 @@ class WaitForExecutionActionSpec : FunSpec() {
             val exception = shouldThrow<GradleException> {
                 action.execute()
             }
-            exception.message shouldBe "Execution failed: $executionName"
+            exception.message shouldBe "Execution $executionName did not succeed (failedCount=1, cancelledCount=0)"
         }
 
         test("execute - polls until completion") {
@@ -135,6 +135,80 @@ class WaitForExecutionActionSpec : FunSpec() {
             action.execute()
 
             verify(exactly = 2) { client.getExecution(executionName) }
+        }
+
+        test("execute - throws GradleException when execution is cancelled") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ExecutionsClient>()
+            MockCloudRunExecutionsClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "executions-cancel",
+                MockCloudRunExecutionsClientBuildService::class,
+            )
+
+            val executionName = "projects/p/locations/us-central1/jobs/my-job/executions/exec-4"
+            val completionTime = Timestamp.newBuilder()
+                .setSeconds(1000000000L)
+                .build()
+            val execution = Execution.newBuilder()
+                .setName(executionName)
+                .setCompletionTime(completionTime)
+                .setFailedCount(0)
+                .setCancelledCount(1)
+                .build()
+
+            every { client.getExecution(executionName) } returns execution
+
+            val params = project.objects.newInstance<WaitForExecutionAction.Parameters>()
+            params.service.set(service)
+            params.executionName.set(executionName)
+            params.pollIntervalMs.set(0L)
+
+            val action = object : WaitForExecutionAction() {
+                override fun getParameters() = params
+            }
+
+            val exception = shouldThrow<GradleException> {
+                action.execute()
+            }
+            exception.message shouldBe "Execution $executionName did not succeed (failedCount=0, cancelledCount=1)"
+        }
+
+        test("execute - throws GradleException when timeout is exceeded") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ExecutionsClient>()
+            MockCloudRunExecutionsClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "executions-timeout",
+                MockCloudRunExecutionsClientBuildService::class,
+            )
+
+            val executionName = "projects/p/locations/us-central1/jobs/my-job/executions/exec-5"
+
+            // Return incomplete execution every time
+            val incompleteExecution = Execution.newBuilder()
+                .setName(executionName)
+                .setReconciling(true)
+                .build()
+
+            every { client.getExecution(executionName) } returns incompleteExecution
+
+            val params = project.objects.newInstance<WaitForExecutionAction.Parameters>()
+            params.service.set(service)
+            params.executionName.set(executionName)
+            params.pollIntervalMs.set(0L)
+            params.maxWaitTimeMs.set(0L)  // Set timeout to 0 to trigger immediately
+
+            val action = object : WaitForExecutionAction() {
+                override fun getParameters() = params
+            }
+
+            val exception = shouldThrow<GradleException> {
+                action.execute()
+            }
+            exception.message?.startsWith("Timed out waiting for execution $executionName") shouldBe true
         }
     }
 }

--- a/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionActionSpec.kt
+++ b/cores/google-cloud-run-base/src/test/kotlin/com/kelvsyc/gradle/google/cloud/run/WaitForExecutionActionSpec.kt
@@ -1,0 +1,140 @@
+package com.kelvsyc.gradle.google.cloud.run
+
+import com.google.cloud.run.v2.Execution
+import com.google.cloud.run.v2.ExecutionsClient
+import com.google.protobuf.Timestamp
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.GradleException
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class WaitForExecutionActionSpec : FunSpec() {
+    init {
+        test("execute - returns when execution succeeds") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ExecutionsClient>()
+            MockCloudRunExecutionsClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "executions-success",
+                MockCloudRunExecutionsClientBuildService::class,
+            )
+
+            val executionName = "projects/p/locations/us-central1/jobs/my-job/executions/exec-1"
+            val completionTime = Timestamp.newBuilder()
+                .setSeconds(1000000000L)
+                .build()
+            val execution = Execution.newBuilder()
+                .setName(executionName)
+                .setCompletionTime(completionTime)
+                .setFailedCount(0)
+                .setSucceededCount(1)
+                .build()
+
+            every { client.getExecution(executionName) } returns execution
+
+            val params = project.objects.newInstance<WaitForExecutionAction.Parameters>()
+            params.service.set(service)
+            params.executionName.set(executionName)
+            params.pollIntervalMs.set(0L)
+
+            val action = object : WaitForExecutionAction() {
+                override fun getParameters() = params
+            }
+
+            action.execute()
+
+            verify(exactly = 1) { client.getExecution(executionName) }
+        }
+
+        test("execute - throws GradleException when execution fails") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ExecutionsClient>()
+            MockCloudRunExecutionsClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "executions-failure",
+                MockCloudRunExecutionsClientBuildService::class,
+            )
+
+            val executionName = "projects/p/locations/us-central1/jobs/my-job/executions/exec-2"
+            val completionTime = Timestamp.newBuilder()
+                .setSeconds(1000000000L)
+                .build()
+            val execution = Execution.newBuilder()
+                .setName(executionName)
+                .setCompletionTime(completionTime)
+                .setFailedCount(1)
+                .setSucceededCount(0)
+                .build()
+
+            every { client.getExecution(executionName) } returns execution
+
+            val params = project.objects.newInstance<WaitForExecutionAction.Parameters>()
+            params.service.set(service)
+            params.executionName.set(executionName)
+            params.pollIntervalMs.set(0L)
+
+            val action = object : WaitForExecutionAction() {
+                override fun getParameters() = params
+            }
+
+            val exception = shouldThrow<GradleException> {
+                action.execute()
+            }
+            exception.message shouldBe "Execution failed: $executionName"
+        }
+
+        test("execute - polls until completion") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ExecutionsClient>()
+            MockCloudRunExecutionsClientBuildService.mockClient = client
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "executions-poll",
+                MockCloudRunExecutionsClientBuildService::class,
+            )
+
+            val executionName = "projects/p/locations/us-central1/jobs/my-job/executions/exec-3"
+
+            // First call: incomplete (no completionTime)
+            val incompleteExecution = Execution.newBuilder()
+                .setName(executionName)
+                .setReconciling(true)
+                .build()
+
+            // Second call: complete and successful
+            val completionTime = Timestamp.newBuilder()
+                .setSeconds(1000000000L)
+                .build()
+            val completeExecution = Execution.newBuilder()
+                .setName(executionName)
+                .setCompletionTime(completionTime)
+                .setFailedCount(0)
+                .setSucceededCount(1)
+                .build()
+
+            every { client.getExecution(executionName) }
+                .returnsMany(incompleteExecution, completeExecution)
+
+            val params = project.objects.newInstance<WaitForExecutionAction.Parameters>()
+            params.service.set(service)
+            params.executionName.set(executionName)
+            params.pollIntervalMs.set(0L)
+
+            val action = object : WaitForExecutionAction() {
+                override fun getParameters() = params
+            }
+
+            action.execute()
+
+            verify(exactly = 2) { client.getExecution(executionName) }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -94,6 +94,8 @@ google-cloud-kms = { module = "com.google.cloud:google-cloud-kms" } # version fr
 google-cloud-secret-manager = { module = "com.google.cloud:google-cloud-secretmanager" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-secret-manager-proto = { module = "com.google.api.grpc:proto-google-cloud-secretmanager-v1" } # version from BOM 'google-cloud-libraries-bom'
 google-cloud-storage = { module = "com.google.cloud:google-cloud-storage" } # version from BOM 'google-cloud-libraries-bom'
+google-cloud-run = { module = "com.google.cloud:google-cloud-run" } # version from BOM 'google-cloud-libraries-bom'
+google-cloud-run-proto = { module = "com.google.api.grpc:proto-google-cloud-run-v2" } # version from BOM 'google-cloud-libraries-bom'
 google-gax = { module = "com.google.api:gax" } # version from BOM 'google-cloud-libraries-bom'
 google-protobuf-java = { module = "com.google.protobuf:protobuf-java" } # version from BOM 'google-cloud-libraries-bom'
 gson = "com.google.code.gson:gson:2.14.0"


### PR DESCRIPTION
## Summary

- Adds `google-cloud-run-base` to `cores/` — a Gradle base component exposing Cloud Run Admin API v2 primitives as composable building blocks
- Provides three `BuildService` wrappers (`ServicesClient`, `JobsClient`, `ExecutionsClient`), four `ValueSource` implementations, six `WorkAction` implementations, and seven abstract/concrete task pairs covering Cloud Run Service upsert/delete and Job definition create/update/delete/run/wait
- Job submission is performed inline in `@TaskAction` (not as a `WorkAction`) because the execution name returned by the API cannot be passed back from a WorkAction to the calling task; when `executionNameFile` is set the task writes the name and returns immediately, deferring the wait to a downstream `WaitForJobExecutionTask`
- Adds two new version catalog entries (`google-cloud-run`, `google-cloud-run-proto`) resolved from the existing `google-cloud-libraries-bom`

## Test plan

- [ ] `./gradlew :google-cloud-run-base:test` — all 10 WorkAction/ValueSource specs pass
- [ ] `./gradlew :google-cloud-run-base:detekt` — no lint violations
- [ ] `./gradlew :google-cloud-run-base:build` — full component build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)