### PR TITLE
feat: add aws-appconfig-java-base component for AppConfig integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ since the two AWS SDKs are distinct libraries:
 
 | AWS Service | Java | Kotlin |
 |-------------|------|--------|
+| AppConfig | `aws-appconfig-java-base` | — |
 | S3 | `aws-s3-java-base` | `aws-s3-kotlin-base` |
 | SQS | `aws-sqs-java-base` | `aws-sqs-kotlin-base` |
 | SNS | `aws-sns-java-base` | `aws-sns-kotlin-base` |

--- a/cores/aws-appconfig-java-base/README.md
+++ b/cores/aws-appconfig-java-base/README.md
@@ -1,0 +1,70 @@
+# aws-appconfig-java-base
+
+Gradle plugin providing AWS AppConfig integration via the AWS Java SDK v2.
+
+## Overview
+
+Offers two independent halves:
+
+- **Pull** — retrieve the currently deployed configuration at build time, as a string `ValueSource` or a materialized file.
+- **Push** — primitive `WorkAction` building blocks for lifecycle plugins to manage AppConfig resources and trigger deployments.
+
+## BuildServices
+
+| Service | Purpose |
+|---|---|
+| `AppConfigClientBuildService` | Wraps `AppConfigClient` for management operations |
+| `AppConfigDataClientBuildService` | Wraps `AppConfigDataClient`; manages session tokens; exposes `fetchConfiguration()` |
+
+Register both via `gradle.sharedServices.registerIfAbsent(...)`, configured with `AwsBuildServiceParams` (region + credentials).
+
+## Pull
+
+### GetConfigurationValueSource
+
+Returns the current deployed configuration as a `String`:
+
+```kotlin
+val config = providers.of(GetConfigurationValueSource::class) {
+    parameters.service.set(appConfigDataService)
+    parameters.applicationIdentifier.set("my-app")
+    parameters.environmentIdentifier.set("production")
+    parameters.configurationProfileIdentifier.set("my-profile")
+}
+```
+
+Extend `AbstractGetConfigurationValueSource<T, P>` and override `convert(ByteArray): T?` for custom return types.
+
+### DownloadConfigurationAction
+
+Writes the configuration to a file via `WorkerExecutor.noIsolation()`:
+
+```kotlin
+workerExecutor.noIsolation().submit(DownloadConfigurationAction::class.java) {
+    service.set(appConfigDataService)
+    applicationIdentifier.set("my-app")
+    environmentIdentifier.set("production")
+    configurationProfileIdentifier.set("my-profile")
+    outputFile.set(layout.buildDirectory.file("config/app.json"))
+}
+```
+
+## Push
+
+### Resource Setup WorkActions
+
+One `WorkAction` each for Create/Update/Delete of: **Application**, **Environment**, **ConfigurationProfile**.
+
+### Deployment Lifecycle
+
+| WorkAction | Purpose |
+|---|---|
+| `CreateHostedConfigurationVersionAction` | Creates a new hosted configuration version; writes version number to `versionNumberFile` |
+| `StartDeploymentAction` | Starts a deployment; writes deployment number to `deploymentNumberFile` |
+| `WaitForDeploymentAction` | Polls until `COMPLETE` or `ROLLED_BACK`; throws `GradleException` on failure/timeout |
+| `StopDeploymentAction` | Triggers rollback of an in-progress deployment |
+
+A lifecycle plugin wires these together:
+1. Submit `CreateHostedConfigurationVersionAction` → read `versionNumberFile`
+2. Submit `StartDeploymentAction` with version → read `deploymentNumberFile`
+3. Submit `WaitForDeploymentAction` with deployment number

--- a/cores/aws-appconfig-java-base/build.gradle.kts
+++ b/cores/aws-appconfig-java-base/build.gradle.kts
@@ -1,0 +1,29 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("AppConfig Java Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-java-extensions")
+    implementation("com.kelvsyc.gradle:gradle-extensions")
+
+    api(libs.aws.appconfig.java)
+    api(libs.aws.appconfigdata.java)
+    api(libs.aws.sdk.core.java)
+
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    // FIXME https://github.com/gradle/gradle/issues/18647
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/aws-appconfig-java-base/settings.gradle.kts
+++ b/cores/aws-appconfig-java-base/settings.gradle.kts
@@ -1,0 +1,11 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../gradle-extensions")
+includeBuild("../aws-java-extensions")

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AbstractGetConfigurationValueSource.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AbstractGetConfigurationValueSource.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * Abstract [ValueSource] template base for retrieving a deployed AppConfig configuration
+ * and converting it to a custom value type.
+ *
+ * Extend this class and implement [convert] to transform the raw configuration bytes
+ * into your desired type. Returns `null` when the configuration is unavailable or empty.
+ *
+ * Most users should use [GetConfigurationValueSource] for UTF-8 string retrieval.
+ * Extend this class only if you need a different conversion (e.g., JSON, binary format).
+ *
+ * @param T the non-null value type returned by [obtain].
+ */
+abstract class AbstractGetConfigurationValueSource<T : Any> : ValueSource<T, AbstractGetConfigurationValueSource.Parameters> {
+    /**
+     * Common parameters for all [AbstractGetConfigurationValueSource] implementations.
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the AppConfig Data client. */
+        @get:Internal
+        val service: Property<AppConfigDataClientBuildService>
+
+        /** Application name or ID. */
+        val applicationIdentifier: Property<String>
+
+        /** Environment name or ID. */
+        val environmentIdentifier: Property<String>
+
+        /** Configuration profile name or ID. */
+        val configurationProfileIdentifier: Property<String>
+    }
+
+    /**
+     * Converts raw configuration bytes to [T].
+     *
+     * @return the converted value, or `null` if conversion is not possible.
+     */
+    protected abstract fun convert(bytes: ByteArray): T?
+
+    override fun obtain(): T? {
+        val bytes = parameters.service.get().fetchConfiguration(
+            parameters.applicationIdentifier.get(),
+            parameters.environmentIdentifier.get(),
+            parameters.configurationProfileIdentifier.get(),
+        )
+        if (bytes == null || bytes.isEmpty()) return null
+        return convert(bytes)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AbstractGetConfigurationValueSource.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AbstractGetConfigurationValueSource.kt
@@ -6,18 +6,17 @@ import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
- * Abstract [ValueSource] template base for retrieving a deployed AppConfig configuration
- * and converting it to a custom value type.
+ * Abstract [ValueSource] base for retrieving a deployed AppConfig configuration and converting it
+ * to a value of type [T].
  *
- * Extend this class and implement [convert] to transform the raw configuration bytes
- * into your desired type. Returns `null` when the configuration is unavailable or empty.
- *
- * Most users should use [GetConfigurationValueSource] for UTF-8 string retrieval.
- * Extend this class only if you need a different conversion (e.g., JSON, binary format).
+ * Subclasses implement [convert] to map the raw configuration bytes to the desired type.
+ * Returns `null` when the configuration is unavailable or the byte array is empty.
  *
  * @param T the non-null value type returned by [obtain].
+ * @param P the parameters type, which must extend [Parameters].
  */
-abstract class AbstractGetConfigurationValueSource<T : Any> : ValueSource<T, AbstractGetConfigurationValueSource.Parameters> {
+abstract class AbstractGetConfigurationValueSource<T : Any, P : AbstractGetConfigurationValueSource.Parameters> :
+    ValueSource<T, P> {
     /**
      * Common parameters for all [AbstractGetConfigurationValueSource] implementations.
      */
@@ -48,8 +47,7 @@ abstract class AbstractGetConfigurationValueSource<T : Any> : ValueSource<T, Abs
             parameters.applicationIdentifier.get(),
             parameters.environmentIdentifier.get(),
             parameters.configurationProfileIdentifier.get(),
-        )
-        if (bytes == null || bytes.isEmpty()) return null
-        return convert(bytes)
+        ) ?: return null
+        return if (bytes.isEmpty()) null else convert(bytes)
     }
 }

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AppConfigClientBuildService.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AppConfigClientBuildService.kt
@@ -1,0 +1,16 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+
+/**
+ * Build service managing an [AppConfigClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring [AwsBuildServiceParams] with the desired AWS region and credentials.
+ */
+abstract class AppConfigClientBuildService :
+    AbstractAwsJavaClientBuildService<AppConfigClient, AwsBuildServiceParams>() {
+    override fun createClient(): AppConfigClient = configureBuilder(AppConfigClient.builder()).build()
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AppConfigDataClientBuildService.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/AppConfigDataClientBuildService.kt
@@ -1,0 +1,74 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
+import com.kelvsyc.gradle.logging.GradleLoggerDelegate
+import com.kelvsyc.gradle.logging.warn
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient
+import software.amazon.awssdk.services.appconfigdata.model.AppConfigDataException
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Build service managing an [AppConfigDataClient] instance with session-token caching.
+ *
+ * Wraps the AppConfig Data API's two-step session protocol. Call [fetchConfiguration] to retrieve
+ * the current deployed configuration for a given application, environment, and configuration profile.
+ * Session tokens are cached per (application, environment, profile) triple for the build lifetime,
+ * so repeated calls within the same build reuse the existing session.
+ */
+abstract class AppConfigDataClientBuildService :
+    AbstractAwsJavaClientBuildService<AppConfigDataClient, AwsBuildServiceParams>() {
+
+    companion object {
+        val logger by GradleLoggerDelegate
+    }
+
+    private data class SessionKey(
+        val applicationIdentifier: String,
+        val environmentIdentifier: String,
+        val configurationProfileIdentifier: String,
+    )
+
+    private val sessionTokens = ConcurrentHashMap<SessionKey, String>()
+
+    override fun createClient(): AppConfigDataClient =
+        configureBuilder(AppConfigDataClient.builder()).build()
+
+    /**
+     * Retrieves the current deployed configuration for the given identifiers.
+     *
+     * Manages the AppConfig Data session-token protocol internally. Starts a new session on the first
+     * call for a given [applicationIdentifier]/[environmentIdentifier]/[configurationProfileIdentifier]
+     * combination, then reuses the cached token on subsequent calls within the same build.
+     *
+     * @return the configuration content as a [ByteArray], or `null` if the request fails.
+     */
+    fun fetchConfiguration(
+        applicationIdentifier: String,
+        environmentIdentifier: String,
+        configurationProfileIdentifier: String,
+    ): ByteArray? {
+        return try {
+            val key = SessionKey(applicationIdentifier, environmentIdentifier, configurationProfileIdentifier)
+            val token = sessionTokens.getOrPut(key) {
+                val sessionRequest = StartConfigurationSessionRequest.builder()
+                    .applicationIdentifier(applicationIdentifier)
+                    .environmentIdentifier(environmentIdentifier)
+                    .configurationProfileIdentifier(configurationProfileIdentifier)
+                    .build()
+                getClient().startConfigurationSession(sessionRequest).initialConfigurationToken()
+            }
+            val configRequest = GetLatestConfigurationRequest.builder()
+                .configurationToken(token)
+                .build()
+            val response = getClient().getLatestConfiguration(configRequest)
+            sessionTokens[key] = response.nextPollConfigurationToken()
+            response.configuration().asByteArray()
+        } catch (e: AppConfigDataException) {
+            logger.warn(e) { "Unable to fetch AppConfig configuration for $applicationIdentifier/$environmentIdentifier/$configurationProfileIdentifier" }
+            null
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateApplicationAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateApplicationAction.kt
@@ -1,0 +1,38 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.CreateApplicationRequest
+
+/**
+ * [WorkAction] that creates an AppConfig application.
+ */
+abstract class CreateApplicationAction : WorkAction<CreateApplicationAction.Parameters> {
+
+    /**
+     * Parameters for [CreateApplicationAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** Name of the application to create. */
+        val name: Property<String>
+
+        /** Optional description of the application. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val request = CreateApplicationRequest.builder().apply {
+            name(parameters.name.get())
+            if (parameters.description.isPresent) {
+                description(parameters.description.get())
+            }
+        }.build()
+        parameters.service.get().getClient().createApplication(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateConfigurationProfileAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateConfigurationProfileAction.kt
@@ -1,0 +1,53 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.CreateConfigurationProfileRequest
+
+/**
+ * [WorkAction] that creates an AppConfig configuration profile within an application.
+ *
+ * Use `"hosted"` as [Parameters.locationUri] for AppConfig-hosted configurations. Set
+ * [Parameters.type] to `"AWS.Freeform"` or `"AWS.AppConfig.FeatureFlags"`.
+ */
+abstract class CreateConfigurationProfileAction : WorkAction<CreateConfigurationProfileAction.Parameters> {
+
+    /**
+     * Parameters for [CreateConfigurationProfileAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID that will contain this profile. */
+        val applicationId: Property<String>
+
+        /** Name of the configuration profile to create. */
+        val name: Property<String>
+
+        /** URI of the configuration source. Use `"hosted"` for AppConfig-hosted configurations. */
+        val locationUri: Property<String>
+
+        /** Profile type: `"AWS.Freeform"` or `"AWS.AppConfig.FeatureFlags"`. */
+        val type: Property<String>
+
+        /** Optional description of the configuration profile. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val request = CreateConfigurationProfileRequest.builder().apply {
+            applicationId(parameters.applicationId.get())
+            name(parameters.name.get())
+            locationUri(parameters.locationUri.get())
+            type(parameters.type.get())
+            if (parameters.description.isPresent) {
+                description(parameters.description.get())
+            }
+        }.build()
+        parameters.service.get().getClient().createConfigurationProfile(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateEnvironmentAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateEnvironmentAction.kt
@@ -1,0 +1,42 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.CreateEnvironmentRequest
+
+/**
+ * [WorkAction] that creates an AppConfig environment within an application.
+ */
+abstract class CreateEnvironmentAction : WorkAction<CreateEnvironmentAction.Parameters> {
+
+    /**
+     * Parameters for [CreateEnvironmentAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID that will contain this environment. */
+        val applicationId: Property<String>
+
+        /** Name of the environment to create. */
+        val name: Property<String>
+
+        /** Optional description of the environment. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val request = CreateEnvironmentRequest.builder().apply {
+            applicationId(parameters.applicationId.get())
+            name(parameters.name.get())
+            if (parameters.description.isPresent) {
+                description(parameters.description.get())
+            }
+        }.build()
+        parameters.service.get().getClient().createEnvironment(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateHostedConfigurationVersionAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateHostedConfigurationVersionAction.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.appconfig.model.CreateHostedConfigurationVersionRequest
+
+/**
+ * [WorkAction] that creates a new hosted configuration version in AppConfig.
+ *
+ * Writes the resulting version number (as a plain integer string) to [Parameters.versionNumberFile].
+ * Lifecycle plugin tasks read this file to obtain the version number for [StartDeploymentAction].
+ */
+abstract class CreateHostedConfigurationVersionAction :
+    WorkAction<CreateHostedConfigurationVersionAction.Parameters> {
+
+    /**
+     * Parameters for [CreateHostedConfigurationVersionAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID. */
+        val applicationId: Property<String>
+
+        /** The configuration profile ID. */
+        val configurationProfileId: Property<String>
+
+        /** Configuration content as a string (e.g. JSON or YAML). */
+        val content: Property<String>
+
+        /** MIME type of the configuration content (e.g. `"application/json"`). */
+        val contentType: Property<String>
+
+        /** File to which the created version number is written. */
+        val versionNumberFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val request = CreateHostedConfigurationVersionRequest.builder()
+            .applicationId(parameters.applicationId.get())
+            .configurationProfileId(parameters.configurationProfileId.get())
+            .contentType(parameters.contentType.get())
+            .content(SdkBytes.fromByteArray(parameters.content.get().toByteArray()))
+            .build()
+        val response = parameters.service.get().getClient()
+            .createHostedConfigurationVersion(request)
+        parameters.versionNumberFile.get().asFile.writeText(response.versionNumber().toString())
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteApplicationAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteApplicationAction.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.DeleteApplicationRequest
+
+/**
+ * [WorkAction] that deletes an AppConfig application.
+ */
+abstract class DeleteApplicationAction : WorkAction<DeleteApplicationAction.Parameters> {
+
+    /**
+     * Parameters for [DeleteApplicationAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application name or ID. */
+        val applicationId: Property<String>
+    }
+
+    override fun execute() {
+        val request = DeleteApplicationRequest.builder()
+            .applicationId(parameters.applicationId.get())
+            .build()
+        parameters.service.get().getClient().deleteApplication(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteConfigurationProfileAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteConfigurationProfileAction.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.DeleteConfigurationProfileRequest
+
+/**
+ * [WorkAction] that deletes an AppConfig configuration profile.
+ */
+abstract class DeleteConfigurationProfileAction : WorkAction<DeleteConfigurationProfileAction.Parameters> {
+
+    /**
+     * Parameters for [DeleteConfigurationProfileAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID. */
+        val applicationId: Property<String>
+
+        /** The configuration profile ID. */
+        val configurationProfileId: Property<String>
+    }
+
+    override fun execute() {
+        val request = DeleteConfigurationProfileRequest.builder()
+            .applicationId(parameters.applicationId.get())
+            .configurationProfileId(parameters.configurationProfileId.get())
+            .build()
+        parameters.service.get().getClient().deleteConfigurationProfile(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteEnvironmentAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteEnvironmentAction.kt
@@ -1,0 +1,36 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.DeleteEnvironmentRequest
+
+/**
+ * [WorkAction] that deletes an AppConfig environment.
+ */
+abstract class DeleteEnvironmentAction : WorkAction<DeleteEnvironmentAction.Parameters> {
+
+    /**
+     * Parameters for [DeleteEnvironmentAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID. */
+        val applicationId: Property<String>
+
+        /** The environment ID. */
+        val environmentId: Property<String>
+    }
+
+    override fun execute() {
+        val request = DeleteEnvironmentRequest.builder()
+            .applicationId(parameters.applicationId.get())
+            .environmentId(parameters.environmentId.get())
+            .build()
+        parameters.service.get().getClient().deleteEnvironment(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DownloadConfigurationAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DownloadConfigurationAction.kt
@@ -1,0 +1,51 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] that downloads the current deployed AppConfig configuration to a local file.
+ *
+ * Submit through `WorkerExecutor.noIsolation()`. Throws [GradleException] if the configuration
+ * cannot be retrieved.
+ */
+abstract class DownloadConfigurationAction : WorkAction<DownloadConfigurationAction.Parameters> {
+
+    /**
+     * Parameters for [DownloadConfigurationAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig Data client. */
+        @get:Internal
+        val service: Property<AppConfigDataClientBuildService>
+
+        /** Application name or ID. */
+        val applicationIdentifier: Property<String>
+
+        /** Environment name or ID. */
+        val environmentIdentifier: Property<String>
+
+        /** Configuration profile name or ID. */
+        val configurationProfileIdentifier: Property<String>
+
+        /** Destination file the configuration is written to. */
+        val outputFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val bytes = parameters.service.get().fetchConfiguration(
+            parameters.applicationIdentifier.get(),
+            parameters.environmentIdentifier.get(),
+            parameters.configurationProfileIdentifier.get(),
+        ) ?: throw GradleException(
+            "Unable to fetch AppConfig configuration for " +
+            "${parameters.applicationIdentifier.get()}/${parameters.environmentIdentifier.get()}/" +
+            parameters.configurationProfileIdentifier.get(),
+        )
+        parameters.outputFile.get().asFile.writeBytes(bytes)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/GetConfigurationValueSource.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/GetConfigurationValueSource.kt
@@ -1,43 +1,19 @@
 package com.kelvsyc.gradle.aws.java.appconfig
 
-import org.gradle.api.provider.Property
-import org.gradle.api.provider.ValueSource
-import org.gradle.api.provider.ValueSourceParameters
-import org.gradle.api.tasks.Internal
-
 /**
- * [ValueSource] implementation that retrieves the current deployed AppConfig configuration
- * as a UTF-8 decoded [String].
+ * [org.gradle.api.provider.ValueSource] implementation that retrieves the current deployed
+ * AppConfig configuration as a UTF-8 decoded [String].
  *
  * Returns `null` when the configuration is unavailable or empty. Errors are logged as warnings
  * and result in a `null` return rather than a thrown exception.
  */
-abstract class GetConfigurationValueSource : ValueSource<String, GetConfigurationValueSource.Parameters> {
+abstract class GetConfigurationValueSource :
+    AbstractGetConfigurationValueSource<String, GetConfigurationValueSource.Parameters>() {
+
     /**
      * Parameters for [GetConfigurationValueSource].
      */
-    interface Parameters : ValueSourceParameters {
-        /** The build service managing the AppConfig Data client. */
-        @get:Internal
-        val service: Property<AppConfigDataClientBuildService>
+    interface Parameters : AbstractGetConfigurationValueSource.Parameters
 
-        /** Application name or ID. */
-        val applicationIdentifier: Property<String>
-
-        /** Environment name or ID. */
-        val environmentIdentifier: Property<String>
-
-        /** Configuration profile name or ID. */
-        val configurationProfileIdentifier: Property<String>
-    }
-
-    override fun obtain(): String? {
-        val bytes = parameters.service.get().fetchConfiguration(
-            parameters.applicationIdentifier.get(),
-            parameters.environmentIdentifier.get(),
-            parameters.configurationProfileIdentifier.get(),
-        )
-        if (bytes == null || bytes.isEmpty()) return null
-        return bytes.toString(Charsets.UTF_8)
-    }
+    override fun convert(bytes: ByteArray): String = bytes.toString(Charsets.UTF_8)
 }

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/GetConfigurationValueSource.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/GetConfigurationValueSource.kt
@@ -1,0 +1,43 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] implementation that retrieves the current deployed AppConfig configuration
+ * as a UTF-8 decoded [String].
+ *
+ * Returns `null` when the configuration is unavailable or empty. Errors are logged as warnings
+ * and result in a `null` return rather than a thrown exception.
+ */
+abstract class GetConfigurationValueSource : ValueSource<String, GetConfigurationValueSource.Parameters> {
+    /**
+     * Parameters for [GetConfigurationValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the AppConfig Data client. */
+        @get:Internal
+        val service: Property<AppConfigDataClientBuildService>
+
+        /** Application name or ID. */
+        val applicationIdentifier: Property<String>
+
+        /** Environment name or ID. */
+        val environmentIdentifier: Property<String>
+
+        /** Configuration profile name or ID. */
+        val configurationProfileIdentifier: Property<String>
+    }
+
+    override fun obtain(): String? {
+        val bytes = parameters.service.get().fetchConfiguration(
+            parameters.applicationIdentifier.get(),
+            parameters.environmentIdentifier.get(),
+            parameters.configurationProfileIdentifier.get(),
+        )
+        if (bytes == null || bytes.isEmpty()) return null
+        return bytes.toString(Charsets.UTF_8)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StartDeploymentAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StartDeploymentAction.kt
@@ -1,0 +1,57 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.StartDeploymentRequest
+
+/**
+ * [WorkAction] that starts an AppConfig deployment.
+ *
+ * Writes the resulting deployment number (as a plain integer string) to [Parameters.deploymentNumberFile].
+ * Lifecycle plugin tasks read this file to obtain the deployment number for [WaitForDeploymentAction]
+ * or [StopDeploymentAction].
+ */
+abstract class StartDeploymentAction : WorkAction<StartDeploymentAction.Parameters> {
+
+    /**
+     * Parameters for [StartDeploymentAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID. */
+        val applicationId: Property<String>
+
+        /** The environment ID. */
+        val environmentId: Property<String>
+
+        /** The configuration profile ID. */
+        val configurationProfileId: Property<String>
+
+        /** The deployment strategy ID. */
+        val deploymentStrategyId: Property<String>
+
+        /** The configuration version number to deploy (as a string, e.g. `"3"`). */
+        val configurationVersion: Property<String>
+
+        /** File to which the deployment number is written. */
+        val deploymentNumberFile: RegularFileProperty
+    }
+
+    override fun execute() {
+        val request = StartDeploymentRequest.builder()
+            .applicationId(parameters.applicationId.get())
+            .environmentId(parameters.environmentId.get())
+            .configurationProfileId(parameters.configurationProfileId.get())
+            .deploymentStrategyId(parameters.deploymentStrategyId.get())
+            .configurationVersion(parameters.configurationVersion.get())
+            .build()
+        val response = parameters.service.get().getClient().startDeployment(request)
+        parameters.deploymentNumberFile.get().asFile.writeText(response.deploymentNumber().toString())
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StopDeploymentAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StopDeploymentAction.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.StopDeploymentRequest
+
+/**
+ * [WorkAction] that stops an in-progress AppConfig deployment, triggering a rollback.
+ */
+abstract class StopDeploymentAction : WorkAction<StopDeploymentAction.Parameters> {
+
+    /**
+     * Parameters for [StopDeploymentAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application name or ID. */
+        val applicationId: Property<String>
+
+        /** The environment name or ID. */
+        val environmentId: Property<String>
+
+        /** The deployment number to stop. */
+        val deploymentNumber: Property<Int>
+    }
+
+    override fun execute() {
+        val request = StopDeploymentRequest.builder()
+            .applicationId(parameters.applicationId.get())
+            .environmentId(parameters.environmentId.get())
+            .deploymentNumber(parameters.deploymentNumber.get())
+            .build()
+        parameters.service.get().getClient().stopDeployment(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateApplicationAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateApplicationAction.kt
@@ -1,0 +1,44 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.UpdateApplicationRequest
+
+/**
+ * [WorkAction] that updates an existing AppConfig application.
+ */
+abstract class UpdateApplicationAction : WorkAction<UpdateApplicationAction.Parameters> {
+
+    /**
+     * Parameters for [UpdateApplicationAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application name or ID. */
+        val applicationId: Property<String>
+
+        /** Updated application name. */
+        val name: Property<String>
+
+        /** Updated application description. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val request = UpdateApplicationRequest.builder().apply {
+            applicationId(parameters.applicationId.get())
+            if (parameters.name.isPresent) {
+                name(parameters.name.get())
+            }
+            if (parameters.description.isPresent) {
+                description(parameters.description.get())
+            }
+        }.build()
+        parameters.service.get().getClient().updateApplication(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateConfigurationProfileAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateConfigurationProfileAction.kt
@@ -1,0 +1,48 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.UpdateConfigurationProfileRequest
+
+/**
+ * [WorkAction] that updates an existing AppConfig configuration profile.
+ */
+abstract class UpdateConfigurationProfileAction : WorkAction<UpdateConfigurationProfileAction.Parameters> {
+
+    /**
+     * Parameters for [UpdateConfigurationProfileAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID. */
+        val applicationId: Property<String>
+
+        /** The configuration profile ID. */
+        val configurationProfileId: Property<String>
+
+        /** Updated profile name. */
+        val name: Property<String>
+
+        /** Updated profile description. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val request = UpdateConfigurationProfileRequest.builder().apply {
+            applicationId(parameters.applicationId.get())
+            configurationProfileId(parameters.configurationProfileId.get())
+            if (parameters.name.isPresent) {
+                name(parameters.name.get())
+            }
+            if (parameters.description.isPresent) {
+                description(parameters.description.get())
+            }
+        }.build()
+        parameters.service.get().getClient().updateConfigurationProfile(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateEnvironmentAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateEnvironmentAction.kt
@@ -1,0 +1,48 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.UpdateEnvironmentRequest
+
+/**
+ * [WorkAction] that updates an existing AppConfig environment.
+ */
+abstract class UpdateEnvironmentAction : WorkAction<UpdateEnvironmentAction.Parameters> {
+
+    /**
+     * Parameters for [UpdateEnvironmentAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application ID. */
+        val applicationId: Property<String>
+
+        /** The environment ID. */
+        val environmentId: Property<String>
+
+        /** Updated environment name. */
+        val name: Property<String>
+
+        /** Updated environment description. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val request = UpdateEnvironmentRequest.builder().apply {
+            applicationId(parameters.applicationId.get())
+            environmentId(parameters.environmentId.get())
+            if (parameters.name.isPresent) {
+                name(parameters.name.get())
+            }
+            if (parameters.description.isPresent) {
+                description(parameters.description.get())
+            }
+        }.build()
+        parameters.service.get().getClient().updateEnvironment(request)
+    }
+}

--- a/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/WaitForDeploymentAction.kt
+++ b/cores/aws-appconfig-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/appconfig/WaitForDeploymentAction.kt
@@ -1,0 +1,83 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import software.amazon.awssdk.services.appconfig.model.DeploymentState
+import software.amazon.awssdk.services.appconfig.model.GetDeploymentRequest
+
+/**
+ * [WorkAction] that polls an AppConfig deployment until it reaches a terminal state.
+ *
+ * Polls every [Parameters.pollIntervalMs] milliseconds (default 5 000 ms). Throws [GradleException]
+ * if the deployment is rolled back or if [Parameters.maxWaitTimeMs] (default 30 min) is exceeded.
+ * Terminal success state: [DeploymentState.COMPLETE].
+ * Terminal failure state: [DeploymentState.ROLLED_BACK].
+ */
+abstract class WaitForDeploymentAction : WorkAction<WaitForDeploymentAction.Parameters> {
+
+    /**
+     * Parameters for [WaitForDeploymentAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the AppConfig client. */
+        @get:Internal
+        val service: Property<AppConfigClientBuildService>
+
+        /** The application name or ID. */
+        val applicationId: Property<String>
+
+        /** The environment name or ID. */
+        val environmentId: Property<String>
+
+        /** The deployment number to poll. */
+        val deploymentNumber: Property<Int>
+
+        /** Polling interval in milliseconds. Override to `0` in tests. */
+        @get:Internal
+        val pollIntervalMs: Property<Long>
+
+        /** Maximum time to wait in milliseconds before throwing [GradleException]. */
+        @get:Internal
+        val maxWaitTimeMs: Property<Long>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        val pollInterval = parameters.pollIntervalMs.orElse(POLL_INTERVAL_MS).get()
+        val maxWaitMs = parameters.maxWaitTimeMs.orElse(DEFAULT_MAX_WAIT_MS).get()
+        val startTime = System.currentTimeMillis()
+
+        while (true) {
+            val request = GetDeploymentRequest.builder()
+                .applicationId(parameters.applicationId.get())
+                .environmentId(parameters.environmentId.get())
+                .deploymentNumber(parameters.deploymentNumber.get())
+                .build()
+            val state = client.getDeployment(request).state()
+
+            when (state) {
+                DeploymentState.COMPLETE -> return
+                DeploymentState.ROLLED_BACK -> throw GradleException(
+                    "Deployment ${parameters.deploymentNumber.get()} was rolled back",
+                )
+                else -> {
+                    if (System.currentTimeMillis() - startTime >= maxWaitMs) {
+                        throw GradleException(
+                            "Timed out waiting for deployment ${parameters.deploymentNumber.get()} " +
+                            "(waited ${System.currentTimeMillis() - startTime}ms, max ${maxWaitMs}ms)",
+                        )
+                    }
+                    Thread.sleep(pollInterval)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS = 5_000L
+        private const val DEFAULT_MAX_WAIT_MS = 30L * 60L * 1_000L
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateApplicationActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateApplicationActionSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.CreateApplicationRequest
+import software.amazon.awssdk.services.appconfig.model.CreateApplicationResponse
+
+class CreateApplicationActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application name and description") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<CreateApplicationRequest>()
+            every { client.createApplication(capture(requestSlot)) } returns mockk<CreateApplicationResponse>()
+
+            val params = project.objects.newInstance<CreateApplicationAction.Parameters>()
+            params.service.set(service)
+            params.name.set("my-application")
+            params.description.set("My application description")
+
+            val action = object : CreateApplicationAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.name() shouldBe "my-application"
+            requestSlot.captured.description() shouldBe "My application description"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateConfigurationProfileActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateConfigurationProfileActionSpec.kt
@@ -1,0 +1,44 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.CreateConfigurationProfileRequest
+import software.amazon.awssdk.services.appconfig.model.CreateConfigurationProfileResponse
+
+class CreateConfigurationProfileActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID, name, locationUri, and type") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<CreateConfigurationProfileRequest>()
+            every { client.createConfigurationProfile(capture(requestSlot)) } returns mockk<CreateConfigurationProfileResponse>()
+
+            val params = project.objects.newInstance<CreateConfigurationProfileAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.name.set("my-profile")
+            params.locationUri.set("hosted")
+            params.type.set("AWS.Freeform")
+
+            val action = object : CreateConfigurationProfileAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.name() shouldBe "my-profile"
+            requestSlot.captured.locationUri() shouldBe "hosted"
+            requestSlot.captured.type() shouldBe "AWS.Freeform"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateEnvironmentActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateEnvironmentActionSpec.kt
@@ -1,0 +1,42 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.CreateEnvironmentRequest
+import software.amazon.awssdk.services.appconfig.model.CreateEnvironmentResponse
+
+class CreateEnvironmentActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID, environment name, and description") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<CreateEnvironmentRequest>()
+            every { client.createEnvironment(capture(requestSlot)) } returns mockk<CreateEnvironmentResponse>()
+
+            val params = project.objects.newInstance<CreateEnvironmentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.name.set("production")
+            params.description.set("Production environment")
+
+            val action = object : CreateEnvironmentAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.name() shouldBe "production"
+            requestSlot.captured.description() shouldBe "Production environment"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateHostedConfigurationVersionActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/CreateHostedConfigurationVersionActionSpec.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.CreateHostedConfigurationVersionRequest
+import software.amazon.awssdk.services.appconfig.model.CreateHostedConfigurationVersionResponse
+import java.io.File
+
+class CreateHostedConfigurationVersionActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct request and writes version number to file") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<CreateHostedConfigurationVersionRequest>()
+            val response = mockk<CreateHostedConfigurationVersionResponse>()
+            every { response.versionNumber() } returns 3
+            every { client.createHostedConfigurationVersion(capture(requestSlot)) } returns response
+
+            val outputFile = File.createTempFile("version", ".txt").also { it.deleteOnExit() }
+
+            val params = project.objects.newInstance<CreateHostedConfigurationVersionAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.configurationProfileId.set("prof789")
+            params.content.set("""{"enabled":true}""")
+            params.contentType.set("application/json")
+            params.versionNumberFile.set(outputFile)
+
+            val action = object : CreateHostedConfigurationVersionAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.configurationProfileId() shouldBe "prof789"
+            requestSlot.captured.contentType() shouldBe "application/json"
+            outputFile.readText() shouldBe "3"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteApplicationActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteApplicationActionSpec.kt
@@ -1,0 +1,38 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.DeleteApplicationRequest
+import software.amazon.awssdk.services.appconfig.model.DeleteApplicationResponse
+
+class DeleteApplicationActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<DeleteApplicationRequest>()
+            every { client.deleteApplication(capture(requestSlot)) } returns mockk<DeleteApplicationResponse>()
+
+            val params = project.objects.newInstance<DeleteApplicationAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+
+            val action = object : DeleteApplicationAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteConfigurationProfileActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteConfigurationProfileActionSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.DeleteConfigurationProfileRequest
+import software.amazon.awssdk.services.appconfig.model.DeleteConfigurationProfileResponse
+
+class DeleteConfigurationProfileActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID and configuration profile ID") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<DeleteConfigurationProfileRequest>()
+            every { client.deleteConfigurationProfile(capture(requestSlot)) } returns mockk<DeleteConfigurationProfileResponse>()
+
+            val params = project.objects.newInstance<DeleteConfigurationProfileAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.configurationProfileId.set("prof789")
+
+            val action = object : DeleteConfigurationProfileAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.configurationProfileId() shouldBe "prof789"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteEnvironmentActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DeleteEnvironmentActionSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.DeleteEnvironmentRequest
+import software.amazon.awssdk.services.appconfig.model.DeleteEnvironmentResponse
+
+class DeleteEnvironmentActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID and environment ID") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<DeleteEnvironmentRequest>()
+            every { client.deleteEnvironment(capture(requestSlot)) } returns mockk<DeleteEnvironmentResponse>()
+
+            val params = project.objects.newInstance<DeleteEnvironmentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+
+            val action = object : DeleteEnvironmentAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.environmentId() shouldBe "env456"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DownloadConfigurationActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/DownloadConfigurationActionSpec.kt
@@ -1,0 +1,54 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionResponse
+import java.io.File
+
+class DownloadConfigurationActionSpec : FunSpec() {
+    init {
+        test("execute - writes configuration bytes to output file") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigDataClient>()
+            MockAppConfigDataClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig-data", MockAppConfigDataClientBuildService::class)
+
+            val sessionResponse = mockk<StartConfigurationSessionResponse>()
+            every { sessionResponse.initialConfigurationToken() } returns "token"
+            every { client.startConfigurationSession(any<StartConfigurationSessionRequest>()) } returns sessionResponse
+
+            val configContent = """{"feature":"enabled"}"""
+            val configResponse = mockk<GetLatestConfigurationResponse>()
+            every { configResponse.configuration() } returns SdkBytes.fromUtf8String(configContent)
+            every { configResponse.nextPollConfigurationToken() } returns "next-token"
+            every { client.getLatestConfiguration(any<GetLatestConfigurationRequest>()) } returns configResponse
+
+            val outputFile = File.createTempFile("appconfig", ".json").also { it.deleteOnExit() }
+
+            val params = project.objects.newInstance<DownloadConfigurationAction.Parameters>()
+            params.service.set(service)
+            params.applicationIdentifier.set("my-app")
+            params.environmentIdentifier.set("production")
+            params.configurationProfileIdentifier.set("my-profile")
+            params.outputFile.set(outputFile)
+
+            val action = object : DownloadConfigurationAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            outputFile.readText() shouldBe configContent
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/GetConfigurationValueSourceSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/GetConfigurationValueSourceSpec.kt
@@ -1,0 +1,67 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient
+import software.amazon.awssdk.services.appconfigdata.model.AppConfigDataException
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationRequest
+import software.amazon.awssdk.services.appconfigdata.model.GetLatestConfigurationResponse
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionRequest
+import software.amazon.awssdk.services.appconfigdata.model.StartConfigurationSessionResponse
+
+class GetConfigurationValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns configuration as UTF-8 string on success") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigDataClient>()
+            MockAppConfigDataClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig-data", MockAppConfigDataClientBuildService::class)
+
+            val sessionResponse = mockk<StartConfigurationSessionResponse>()
+            every { sessionResponse.initialConfigurationToken() } returns "initial-token"
+            every { client.startConfigurationSession(any<StartConfigurationSessionRequest>()) } returns sessionResponse
+
+            val configResponse = mockk<GetLatestConfigurationResponse>()
+            every { configResponse.configuration() } returns SdkBytes.fromUtf8String("""{"enabled":true}""")
+            every { configResponse.nextPollConfigurationToken() } returns "next-token"
+            every { client.getLatestConfiguration(any<GetLatestConfigurationRequest>()) } returns configResponse
+
+            val provider = project.providers.ofKt(GetConfigurationValueSource::class) {
+                parameters.service.set(service)
+                parameters.applicationIdentifier.set("my-app")
+                parameters.environmentIdentifier.set("production")
+                parameters.configurationProfileIdentifier.set("my-profile")
+            }
+
+            provider.get() shouldBe """{"enabled":true}"""
+        }
+
+        test("obtain - returns null when AppConfigDataException is thrown") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigDataClient>()
+            MockAppConfigDataClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig-data", MockAppConfigDataClientBuildService::class)
+
+            every {
+                client.startConfigurationSession(any<StartConfigurationSessionRequest>())
+            } throws AppConfigDataException.builder().message("not found").build()
+
+            val provider = project.providers.ofKt(GetConfigurationValueSource::class) {
+                parameters.service.set(service)
+                parameters.applicationIdentifier.set("missing-app")
+                parameters.environmentIdentifier.set("production")
+                parameters.configurationProfileIdentifier.set("missing-profile")
+            }
+
+            provider.orNull.shouldBeNull()
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/MockAppConfigClientBuildService.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/MockAppConfigClientBuildService.kt
@@ -1,0 +1,14 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+
+/**
+ * Test-only [AppConfigClientBuildService] that returns a pre-supplied mock [AppConfigClient].
+ */
+abstract class MockAppConfigClientBuildService : AppConfigClientBuildService() {
+    override fun createClient(): AppConfigClient = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: AppConfigClient? = null
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/MockAppConfigDataClientBuildService.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/MockAppConfigDataClientBuildService.kt
@@ -1,0 +1,14 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import software.amazon.awssdk.services.appconfigdata.AppConfigDataClient
+
+/**
+ * Test-only [AppConfigDataClientBuildService] that returns a pre-supplied mock [AppConfigDataClient].
+ */
+abstract class MockAppConfigDataClientBuildService : AppConfigDataClientBuildService() {
+    override fun createClient(): AppConfigDataClient = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: AppConfigDataClient? = null
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/ProviderFactoryExtensions.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/ProviderFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+// Workaround: under the kotlin-gradle-library convention, Kotlin does not treat Gradle's
+// Action<in T> as T.() -> Unit, so providers.of(...) { parameters.X } fails to resolve.
+internal fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit,
+) = of(valueSourceType, configuration)

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StartDeploymentActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StartDeploymentActionSpec.kt
@@ -1,0 +1,53 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.StartDeploymentRequest
+import software.amazon.awssdk.services.appconfig.model.StartDeploymentResponse
+import java.io.File
+
+class StartDeploymentActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct request and writes deployment number to file") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<StartDeploymentRequest>()
+            val response = mockk<StartDeploymentResponse>()
+            every { response.deploymentNumber() } returns 7
+            every { client.startDeployment(capture(requestSlot)) } returns response
+
+            val outputFile = File.createTempFile("deployment", ".txt").also { it.deleteOnExit() }
+
+            val params = project.objects.newInstance<StartDeploymentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+            params.configurationProfileId.set("prof789")
+            params.deploymentStrategyId.set("strategy-id")
+            params.configurationVersion.set("3")
+            params.deploymentNumberFile.set(outputFile)
+
+            val action = object : StartDeploymentAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.environmentId() shouldBe "env456"
+            requestSlot.captured.configurationProfileId() shouldBe "prof789"
+            requestSlot.captured.deploymentStrategyId() shouldBe "strategy-id"
+            requestSlot.captured.configurationVersion() shouldBe "3"
+            outputFile.readText() shouldBe "7"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StopDeploymentActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/StopDeploymentActionSpec.kt
@@ -1,0 +1,42 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.StopDeploymentRequest
+import software.amazon.awssdk.services.appconfig.model.StopDeploymentResponse
+
+class StopDeploymentActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID, environment ID, and deployment number") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<StopDeploymentRequest>()
+            every { client.stopDeployment(capture(requestSlot)) } returns mockk<StopDeploymentResponse>()
+
+            val params = project.objects.newInstance<StopDeploymentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+            params.deploymentNumber.set(7)
+
+            val action = object : StopDeploymentAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.environmentId() shouldBe "env456"
+            requestSlot.captured.deploymentNumber() shouldBe 7
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateApplicationActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateApplicationActionSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.UpdateApplicationRequest
+import software.amazon.awssdk.services.appconfig.model.UpdateApplicationResponse
+
+class UpdateApplicationActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID and updated name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<UpdateApplicationRequest>()
+            every { client.updateApplication(capture(requestSlot)) } returns mockk<UpdateApplicationResponse>()
+
+            val params = project.objects.newInstance<UpdateApplicationAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.name.set("renamed-application")
+
+            val action = object : UpdateApplicationAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.name() shouldBe "renamed-application"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateConfigurationProfileActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateConfigurationProfileActionSpec.kt
@@ -1,0 +1,42 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.UpdateConfigurationProfileRequest
+import software.amazon.awssdk.services.appconfig.model.UpdateConfigurationProfileResponse
+
+class UpdateConfigurationProfileActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID, profile ID, and updated name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<UpdateConfigurationProfileRequest>()
+            every { client.updateConfigurationProfile(capture(requestSlot)) } returns mockk<UpdateConfigurationProfileResponse>()
+
+            val params = project.objects.newInstance<UpdateConfigurationProfileAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.configurationProfileId.set("prof789")
+            params.name.set("renamed-profile")
+
+            val action = object : UpdateConfigurationProfileAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.configurationProfileId() shouldBe "prof789"
+            requestSlot.captured.name() shouldBe "renamed-profile"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateEnvironmentActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/UpdateEnvironmentActionSpec.kt
@@ -1,0 +1,42 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.UpdateEnvironmentRequest
+import software.amazon.awssdk.services.appconfig.model.UpdateEnvironmentResponse
+
+class UpdateEnvironmentActionSpec : FunSpec() {
+    init {
+        test("execute - sends correct application ID, environment ID, and updated name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+            val requestSlot = slot<UpdateEnvironmentRequest>()
+            every { client.updateEnvironment(capture(requestSlot)) } returns mockk<UpdateEnvironmentResponse>()
+
+            val params = project.objects.newInstance<UpdateEnvironmentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+            params.name.set("staging")
+
+            val action = object : UpdateEnvironmentAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            requestSlot.captured.applicationId() shouldBe "abc123"
+            requestSlot.captured.environmentId() shouldBe "env456"
+            requestSlot.captured.name() shouldBe "staging"
+        }
+    }
+}

--- a/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/WaitForDeploymentActionSpec.kt
+++ b/cores/aws-appconfig-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/appconfig/WaitForDeploymentActionSpec.kt
@@ -1,0 +1,93 @@
+package com.kelvsyc.gradle.aws.java.appconfig
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.api.GradleException
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.appconfig.AppConfigClient
+import software.amazon.awssdk.services.appconfig.model.DeploymentState
+import software.amazon.awssdk.services.appconfig.model.GetDeploymentRequest
+import software.amazon.awssdk.services.appconfig.model.GetDeploymentResponse
+
+class WaitForDeploymentActionSpec : FunSpec() {
+    init {
+        test("execute - returns normally when deployment reaches COMPLETE state") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+
+            val response = mockk<GetDeploymentResponse>()
+            every { response.state() } returns DeploymentState.COMPLETE
+            every { client.getDeployment(any<GetDeploymentRequest>()) } returns response
+
+            val params = project.objects.newInstance<WaitForDeploymentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+            params.deploymentNumber.set(7)
+            params.pollIntervalMs.set(0L)
+            params.maxWaitTimeMs.set(30_000L)
+
+            val action = object : WaitForDeploymentAction() {
+                override fun getParameters() = params
+            }
+            action.execute() // should not throw
+        }
+
+        test("execute - throws GradleException when deployment is ROLLED_BACK") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+
+            val response = mockk<GetDeploymentResponse>()
+            every { response.state() } returns DeploymentState.ROLLED_BACK
+            every { client.getDeployment(any<GetDeploymentRequest>()) } returns response
+
+            val params = project.objects.newInstance<WaitForDeploymentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+            params.deploymentNumber.set(7)
+            params.pollIntervalMs.set(0L)
+            params.maxWaitTimeMs.set(30_000L)
+
+            val action = object : WaitForDeploymentAction() {
+                override fun getParameters() = params
+            }
+            shouldThrow<GradleException> { action.execute() }
+        }
+
+        test("execute - throws GradleException when timeout is exceeded") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<AppConfigClient>()
+            MockAppConfigClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices
+                .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+
+            val response = mockk<GetDeploymentResponse>()
+            every { response.state() } returns DeploymentState.DEPLOYING
+            every { client.getDeployment(any<GetDeploymentRequest>()) } returns response
+
+            val params = project.objects.newInstance<WaitForDeploymentAction.Parameters>()
+            params.service.set(service)
+            params.applicationId.set("abc123")
+            params.environmentId.set("env456")
+            params.deploymentNumber.set(7)
+            params.pollIntervalMs.set(0L)
+            params.maxWaitTimeMs.set(0L)
+
+            val action = object : WaitForDeploymentAction() {
+                override fun getParameters() = params
+            }
+            shouldThrow<GradleException> { action.execute() }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ azure-messaging-servicebus = { module = "com.azure:azure-messaging-servicebus" }
 azure-storage-common = { module = "com.azure:azure-storage-common" } # version from BOM 'azure-sdk-bom'
 azure-containers-containerregistry = { module = "com.azure:azure-containers-containerregistry" } # version from BOM 'azure-sdk-bom'
 azure-resourcemanager-appservice = { module = "com.azure.resourcemanager:azure-resourcemanager-appservice" } # version from BOM 'azure-sdk-bom'
+aws-appconfig-java = { module = "software.amazon.awssdk:appconfig" } # version from BOM 'aws-java-sdk-bom'
+aws-appconfigdata-java = { module = "software.amazon.awssdk:appconfigdata" } # version from BOM 'aws-java-sdk-bom'
 aws-auth-java = { module = "software.amazon.awssdk:auth" } # version from BOM 'aws-java-sdk-bom'
 aws-config-kotlin = { module = "aws.sdk.kotlin:aws-config" } # version from BOM 'aws-kotlin-sdk-bom'
 aws-core-java = { module = "software.amazon.awssdk:aws-core" } # version from BOM 'aws-java-sdk-bom'


### PR DESCRIPTION
## Summary

- Adds a new `aws-appconfig-java-base` Gradle component providing AWS AppConfig integration via the AWS Java SDK v2
- **Pull side**: `AppConfigDataClientBuildService` wraps the AppConfig Data session-token protocol; `GetConfigurationValueSource` retrieves deployed configuration as a `String`; `DownloadConfigurationAction` materializes it to a file
- **Push side**: CRUD `WorkAction`s for Applications, Environments, and Configuration Profiles; deployment lifecycle primitives (`CreateHostedConfigurationVersionAction`, `StartDeploymentAction`, `WaitForDeploymentAction`, `StopDeploymentAction`)
- Adds two new catalog entries (`aws-appconfig-java`, `aws-appconfigdata-java`) and full unit test coverage across all 14 WorkActions and ValueSources

## Test plan

- [ ] `./gradlew :aws-appconfig-java-base:test` — all unit tests pass
- [ ] `./gradlew :aws-appconfig-java-base:detekt` — no lint violations
- [ ] `./gradlew :aws-appconfig-java-base:build` — full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)