### PR TITLE
feat: add azure-app-configuration-base component

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ since the two AWS SDKs are distinct libraries:
 | `azure-blob-storage-base` | Azure Blob Storage |
 | `azure-container-registry-base` | Azure Container Registry |
 | `azure-functions-base` | Deploy, invoke, and configure Azure Function Apps (zip deploy, run-from-package, HTTP invocation, app settings) |
+| `azure-app-configuration-base` | Read and write Azure App Configuration key-values, feature flags, and snapshots |
 | `azure-key-vault-base` | Azure Key Vault |
 | `azure-managed-identity-base` | Azure Managed Identity / IMDS |
 | `azure-service-bus-base` | Azure Service Bus |

--- a/cores/azure-app-configuration-base/README.md
+++ b/cores/azure-app-configuration-base/README.md
@@ -1,0 +1,263 @@
+# Azure App Configuration Base
+
+A Kotlin library providing managed Azure App Configuration client integration using the Azure SDK for Java, built on `clients-base`. Supports key-value settings, first-class feature flags, configuration snapshots, and optional management-plane store lifecycle operations.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation("com.kelvsyc.gradle:azure-app-configuration-base")
+}
+```
+
+## Build Services
+
+| Class | Client type | Use case |
+|---|---|---|
+| `AppConfigurationClientBuildService` | `ConfigurationClient` | Synchronous data-plane operations |
+| `AppConfigurationAsyncClientBuildService` | `ConfigurationAsyncClient` | Asynchronous data-plane operations |
+| `AppConfigurationManagerBuildService` | `AppConfigurationManager` | Management-plane store lifecycle |
+
+### Data-plane services
+
+```kotlin
+val appconfig = gradle.sharedServices.registerIfAbsent("appconfig", AppConfigurationClientBuildService::class) {
+    parameters {
+        endpoint.set("https://my-store.azconfig.io")
+        defaultCredential()
+        // managedIdentity()
+        // clientSecret(tenantId, clientId, clientSecret)
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `endpoint` | `Property<String>` | Store endpoint URL. Optional when `connectionStringRef` is set. |
+| `connectionStringRef` | `Property<CredentialReference>` | Connection string reference (see below). Takes priority over `endpoint`. |
+| `credentialSource` | `Property<AzureCredentialSource>` | Token credential to use. Set via extension functions. |
+
+### Management-plane service
+
+```kotlin
+val manager = gradle.sharedServices.registerIfAbsent("appconfig-mgr", AppConfigurationManagerBuildService::class) {
+    parameters {
+        subscriptionId.set("00000000-0000-0000-0000-000000000000")
+        resourceGroup.set("my-resource-group")
+        defaultCredential()
+    }
+}
+```
+
+| Parameter | Type | Description |
+|---|---|---|
+| `subscriptionId` | `Property<String>` | Azure subscription ID. |
+| `resourceGroup` | `Property<String>` | Resource group containing the stores. |
+| `credentialSource` | `Property<AzureCredentialSource>` | Token credential. Falls back to `DefaultAzureCredential` when absent. |
+
+## Pull (ValueSources)
+
+### Data-plane ValueSources
+
+**`GetConfigurationSettingValueSource`** — Returns the value of a single key-value setting, or `null` if not found or if the key is a Key Vault reference.
+
+```kotlin
+val value: Provider<String> = providers.of(GetConfigurationSettingValueSource::class) {
+    parameters {
+        service.set(appconfig)
+        key.set("app.name")
+        label.set("prod")   // optional
+    }
+}
+```
+
+**`ListConfigurationSettingsValueSource`** — Returns a `Map<String, String>` of key → value for all matching settings. Key Vault references are excluded.
+
+```kotlin
+val settings: Provider<Map<String, String>> = providers.of(ListConfigurationSettingsValueSource::class) {
+    parameters {
+        service.set(appconfig)
+        keyFilter.set("app.*")        // optional
+        labelFilter.set("prod")       // optional
+    }
+}
+```
+
+**`GetFeatureFlagValueSource`** — Returns `true`/`false` for a feature flag, or `null` if not found.
+
+```kotlin
+val enabled: Provider<Boolean> = providers.of(GetFeatureFlagValueSource::class) {
+    parameters {
+        service.set(appconfig)
+        featureName.set("new-ui")
+        label.set("prod")   // optional
+    }
+}
+```
+
+**`ListFeatureFlagsValueSource`** — Returns a `Map<String, Boolean>` of feature flag name → enabled state.
+
+```kotlin
+val flags: Provider<Map<String, Boolean>> = providers.of(ListFeatureFlagsValueSource::class) {
+    parameters {
+        service.set(appconfig)
+        label.set("prod")   // optional
+    }
+}
+```
+
+**`ListSnapshotsValueSource`** — Returns a `List<String>` of snapshot names currently in `READY` state.
+
+```kotlin
+val snapshots: Provider<List<String>> = providers.of(ListSnapshotsValueSource::class) {
+    parameters {
+        service.set(appconfig)
+        nameFilter.set("release-*")   // optional
+    }
+}
+```
+
+### Management-plane ValueSources
+
+**`GetConfigurationStoreValueSource`** — Returns the endpoint URL for a store, or `null` if not found or still provisioning.
+
+```kotlin
+val endpoint: Provider<String> = providers.of(GetConfigurationStoreValueSource::class) {
+    parameters {
+        service.set(manager)
+        storeName.set("my-store")
+    }
+}
+```
+
+**`ListConfigurationStoresValueSource`** — Returns a `Map<String, String>` of store name → endpoint URL for all stores in the resource group. Stores with no endpoint (still provisioning) are excluded.
+
+```kotlin
+val stores: Provider<Map<String, String>> = providers.of(ListConfigurationStoresValueSource::class) {
+    parameters {
+        service.set(manager)
+    }
+}
+```
+
+## Push (WorkActions)
+
+### Data-plane WorkActions
+
+**`SetConfigurationSettingAction`** — Creates or updates a key-value setting.
+
+```kotlin
+workerExecutor.noIsolation().submit(SetConfigurationSettingAction::class) {
+    service.set(appconfig)
+    key.set("app.version")
+    value.set("1.2.3")
+    label.set("prod")         // optional
+    contentType.set("text/plain")  // optional
+}
+```
+
+**`DeleteConfigurationSettingAction`** — Deletes a key-value setting. No-op if not found.
+
+```kotlin
+workerExecutor.noIsolation().submit(DeleteConfigurationSettingAction::class) {
+    service.set(appconfig)
+    key.set("app.deprecated")
+    label.set("prod")   // optional
+}
+```
+
+**`SetFeatureFlagAction`** — Creates or updates a feature flag.
+
+```kotlin
+workerExecutor.noIsolation().submit(SetFeatureFlagAction::class) {
+    service.set(appconfig)
+    featureName.set("new-ui")
+    enabled.set(true)
+    label.set("prod")                         // optional
+    description.set("Enable new UI redesign") // optional
+}
+```
+
+**`DeleteFeatureFlagAction`** — Deletes a feature flag.
+
+```kotlin
+workerExecutor.noIsolation().submit(DeleteFeatureFlagAction::class) {
+    service.set(appconfig)
+    featureName.set("old-ui")
+    label.set("prod")   // optional
+}
+```
+
+**`CreateSnapshotAction`** — Creates a configuration snapshot (long-running operation; blocks until complete).
+
+```kotlin
+workerExecutor.noIsolation().submit(CreateSnapshotAction::class) {
+    service.set(appconfig)
+    snapshotName.set("release-1.2.3")
+    keyFilter.set("app.*")
+    labelFilter.set("prod")          // optional
+    retentionPeriod.set(2592000L)    // optional, seconds (default: SDK default)
+}
+```
+
+**`ArchiveSnapshotAction`** — Archives a snapshot.
+
+```kotlin
+workerExecutor.noIsolation().submit(ArchiveSnapshotAction::class) {
+    service.set(appconfig)
+    snapshotName.set("release-1.2.0")
+}
+```
+
+**`RecoverSnapshotAction`** — Recovers an archived snapshot.
+
+```kotlin
+workerExecutor.noIsolation().submit(RecoverSnapshotAction::class) {
+    service.set(appconfig)
+    snapshotName.set("release-1.2.0")
+}
+```
+
+### Management-plane WorkActions
+
+**`CreateConfigurationStoreAction`** — Creates a new App Configuration store.
+
+```kotlin
+workerExecutor.noIsolation().submit(CreateConfigurationStoreAction::class) {
+    service.set(manager)
+    storeName.set("my-new-store")
+    location.set("eastus")
+    sku.set("Standard")   // optional, defaults to "Free"
+}
+```
+
+**`DeleteConfigurationStoreAction`** — Deletes an App Configuration store.
+
+```kotlin
+workerExecutor.noIsolation().submit(DeleteConfigurationStoreAction::class) {
+    service.set(manager)
+    storeName.set("my-old-store")
+}
+```
+
+## Connection String Authentication
+
+For local development or CI environments without managed identity, authenticate using an App Configuration connection string:
+
+```kotlin
+val appconfig = gradle.sharedServices.registerIfAbsent("appconfig", AppConfigurationClientBuildService::class) {
+    parameters {
+        connectionStringRef.set(CredentialReference.ofEnvVar("APPCONFIG_CONNECTION_STRING"))
+    }
+}
+```
+
+When `connectionStringRef` is set, the `endpoint` and credential source are ignored — the connection string contains both the endpoint and the key. Do not store raw connection strings in `build.gradle.kts`; use an environment variable reference via `CredentialReference.ofEnvVar()` or `CredentialReference.ofSystemProperty()`.
+
+**Note on Key Vault references:** Settings whose content type marks them as Key Vault references are intentionally excluded from `GetConfigurationSettingValueSource` and `ListConfigurationSettingsValueSource`. Resolving Key Vault references at configuration time would write secret values to the Gradle configuration cache. Resolve Key Vault references inside a `WorkAction` using [azure-key-vault-base](../azure-key-vault-base) at task execution time instead.
+
+## See Also
+
+- [clients-base](../clients-base) — The underlying service client infrastructure
+- [azure-extensions](../azure-extensions) — Azure credential helpers and `AzureBuildServiceParams`
+- [azure-key-vault-base](../azure-key-vault-base) — Resolve Key Vault references at execution time

--- a/cores/azure-app-configuration-base/build.gradle.kts
+++ b/cores/azure-app-configuration-base/build.gradle.kts
@@ -1,0 +1,25 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("Azure App Configuration Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:azure-extensions")
+    api(libs.azure.core)
+    api(libs.azure.data.appconfiguration)
+    api(libs.azure.resourcemanager.appconfiguration)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/azure-app-configuration-base/build.gradle.kts
+++ b/cores/azure-app-configuration-base/build.gradle.kts
@@ -21,5 +21,6 @@ dependencies {
 }
 
 tasks.test {
+    // FIXME https://github.com/gradle/gradle/issues/18647
     jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }

--- a/cores/azure-app-configuration-base/build.gradle.kts
+++ b/cores/azure-app-configuration-base/build.gradle.kts
@@ -23,4 +23,6 @@ dependencies {
 tasks.test {
     // FIXME https://github.com/gradle/gradle/issues/18647
     jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+    // Mock build services are compiled into the test source set but no runnable specs exist yet
+    failOnNoDiscoveredTests = false
 }

--- a/cores/azure-app-configuration-base/settings.gradle.kts
+++ b/cores/azure-app-configuration-base/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../azure-extensions")

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/AppConfigurationAsyncClientBuildService.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/AppConfigurationAsyncClientBuildService.kt
@@ -1,0 +1,58 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationAsyncClient
+import com.azure.data.appconfiguration.ConfigurationClientBuilder
+import com.kelvsyc.gradle.azure.AbstractAzureClientBuildService
+import com.kelvsyc.gradle.azure.AzureBuildServiceParams
+import com.kelvsyc.gradle.clients.CredentialReference
+import org.gradle.api.provider.Property
+
+/**
+ * Build service managing an asynchronous [ConfigurationAsyncClient] instance for Azure App Configuration.
+ *
+ * Supports two authentication modes:
+ * - **Connection string** (development): set [Params.connectionStringRef] to a [CredentialReference]
+ *   resolving the connection string. Endpoint is embedded in the string.
+ * - **Token credential** (production): set [Params.endpoint] and configure the credential source
+ *   via [AzureBuildServiceParams] extension functions
+ *   ([defaultCredential][com.kelvsyc.gradle.azure.defaultCredential],
+ *   [managedIdentity][com.kelvsyc.gradle.azure.managedIdentity],
+ *   [clientSecret][com.kelvsyc.gradle.azure.clientSecret]).
+ *
+ * SAS and named-key credential variants are rejected with [IllegalArgumentException] at
+ * initialization — Azure App Configuration accepts only token-shaped credentials.
+ *
+ * Register via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent].
+ */
+abstract class AppConfigurationAsyncClientBuildService :
+    AbstractAzureClientBuildService<ConfigurationAsyncClient, AppConfigurationAsyncClientBuildService.Params>() {
+
+    /**
+     * Configuration parameters for [AppConfigurationAsyncClientBuildService].
+     */
+    interface Params : AzureBuildServiceParams {
+        /**
+         * The App Configuration store endpoint URL, e.g. `https://{store}.azconfig.io`.
+         * Optional when [connectionStringRef] is set (the endpoint is embedded in the connection string).
+         */
+        val endpoint: Property<String>
+
+        /**
+         * Reference to the App Configuration connection string (stored in an environment variable
+         * or system property). When set, takes priority over [endpoint] and the credential source.
+         *
+         * Prefer token credentials in production; connection strings are most useful in local
+         * development or CI where managed identity is unavailable.
+         */
+        val connectionStringRef: Property<CredentialReference>
+    }
+
+    override fun createClient(): ConfigurationAsyncClient = ConfigurationClientBuilder().apply {
+        if (parameters.connectionStringRef.isPresent) {
+            connectionString(parameters.connectionStringRef.get().resolve())
+        } else {
+            endpoint(parameters.endpoint.get())
+            resolveTokenCredential()?.let(::credential)
+        }
+    }.buildAsyncClient()
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/AppConfigurationClientBuildService.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/AppConfigurationClientBuildService.kt
@@ -1,0 +1,58 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.ConfigurationClientBuilder
+import com.kelvsyc.gradle.azure.AbstractAzureClientBuildService
+import com.kelvsyc.gradle.azure.AzureBuildServiceParams
+import com.kelvsyc.gradle.clients.CredentialReference
+import org.gradle.api.provider.Property
+
+/**
+ * Build service managing a synchronous [ConfigurationClient] instance for Azure App Configuration.
+ *
+ * Supports two authentication modes:
+ * - **Connection string** (development): set [Params.connectionStringRef] to a [CredentialReference]
+ *   resolving the connection string. Endpoint is embedded in the string.
+ * - **Token credential** (production): set [Params.endpoint] and configure the credential source
+ *   via [AzureBuildServiceParams] extension functions
+ *   ([defaultCredential][com.kelvsyc.gradle.azure.defaultCredential],
+ *   [managedIdentity][com.kelvsyc.gradle.azure.managedIdentity],
+ *   [clientSecret][com.kelvsyc.gradle.azure.clientSecret]).
+ *
+ * SAS and named-key credential variants are rejected with [IllegalArgumentException] at
+ * initialization — Azure App Configuration accepts only token-shaped credentials.
+ *
+ * Register via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent].
+ */
+abstract class AppConfigurationClientBuildService :
+    AbstractAzureClientBuildService<ConfigurationClient, AppConfigurationClientBuildService.Params>() {
+
+    /**
+     * Configuration parameters for [AppConfigurationClientBuildService].
+     */
+    interface Params : AzureBuildServiceParams {
+        /**
+         * The App Configuration store endpoint URL, e.g. `https://{store}.azconfig.io`.
+         * Optional when [connectionStringRef] is set (the endpoint is embedded in the connection string).
+         */
+        val endpoint: Property<String>
+
+        /**
+         * Reference to the App Configuration connection string (stored in an environment variable
+         * or system property). When set, takes priority over [endpoint] and the credential source.
+         *
+         * Prefer token credentials in production; connection strings are most useful in local
+         * development or CI where managed identity is unavailable.
+         */
+        val connectionStringRef: Property<CredentialReference>
+    }
+
+    override fun createClient(): ConfigurationClient = ConfigurationClientBuilder().apply {
+        if (parameters.connectionStringRef.isPresent) {
+            connectionString(parameters.connectionStringRef.get().resolve())
+        } else {
+            endpoint(parameters.endpoint.get())
+            resolveTokenCredential()?.let(::credential)
+        }
+    }.buildClient()
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/AppConfigurationManagerBuildService.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/AppConfigurationManagerBuildService.kt
@@ -1,0 +1,54 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.management.AzureEnvironment
+import com.azure.core.management.profile.AzureProfile
+import com.azure.identity.DefaultAzureCredentialBuilder
+import com.azure.resourcemanager.appconfiguration.AppConfigurationManager
+import com.kelvsyc.gradle.azure.AbstractAzureClientBuildService
+import com.kelvsyc.gradle.azure.AzureBuildServiceParams
+import org.gradle.api.provider.Property
+
+/**
+ * Build service managing an [AppConfigurationManager] instance scoped to an Azure subscription
+ * and resource group.
+ *
+ * This is the ARM management-plane service for `azure-app-configuration-base`. It provides access
+ * to App Configuration store lifecycle operations (create, delete) within the configured resource
+ * group. Use the data-plane services ([AppConfigurationClientBuildService] /
+ * [AppConfigurationAsyncClientBuildService]) for reading and writing key-values, feature flags,
+ * and snapshots.
+ *
+ * Configure credentials at registration time using the extension functions on [AzureBuildServiceParams]
+ * ([defaultCredential][com.kelvsyc.gradle.azure.defaultCredential],
+ * [managedIdentity][com.kelvsyc.gradle.azure.managedIdentity],
+ * [clientSecret][com.kelvsyc.gradle.azure.clientSecret]). ARM requires a
+ * [com.azure.core.credential.TokenCredential]; SAS and named-key variants are rejected with
+ * [IllegalArgumentException] at initialization. When [AzureBuildServiceParams.credentialSource]
+ * is unset, [com.azure.identity.DefaultAzureCredential] is used automatically.
+ *
+ * Register via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent].
+ */
+abstract class AppConfigurationManagerBuildService :
+    AbstractAzureClientBuildService<AppConfigurationManager, AppConfigurationManagerBuildService.Params>() {
+
+    /**
+     * Configuration parameters for [AppConfigurationManagerBuildService].
+     */
+    interface Params : AzureBuildServiceParams {
+        /**
+         * Azure subscription ID containing the target App Configuration stores.
+         */
+        val subscriptionId: Property<String>
+
+        /**
+         * Azure resource group containing the target App Configuration stores.
+         */
+        val resourceGroup: Property<String>
+    }
+
+    override fun createClient(): AppConfigurationManager {
+        val tokenCredential = resolveTokenCredential() ?: DefaultAzureCredentialBuilder().build()
+        val profile = AzureProfile(null, parameters.subscriptionId.get(), AzureEnvironment.AZURE)
+        return AppConfigurationManager.authenticate(tokenCredential, profile)
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ArchiveSnapshotAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ArchiveSnapshotAction.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that archives a snapshot in Azure App Configuration.
+ *
+ * An archived snapshot is retained indefinitely for audit and compliance purposes, but is
+ * excluded from normal snapshot listings and recovery operations.
+ */
+abstract class ArchiveSnapshotAction : WorkAction<ArchiveSnapshotAction.Parameters> {
+    /**
+     * Parameters for [ArchiveSnapshotAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The name of the snapshot to archive. */
+        val snapshotName: Property<String>
+    }
+
+    override fun execute() {
+        parameters.service.get().getClient()
+            .archiveSnapshot(parameters.snapshotName.get())
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateConfigurationStoreAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateConfigurationStoreAction.kt
@@ -1,0 +1,47 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.resourcemanager.appconfiguration.models.Sku
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that creates an Azure App Configuration store in the configured resource group.
+ *
+ * If `sku` is absent, defaults to `Free` tier.
+ */
+abstract class CreateConfigurationStoreAction : WorkAction<CreateConfigurationStoreAction.Parameters> {
+    /**
+     * Parameters for [CreateConfigurationStoreAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration manager. */
+        @get:Internal
+        val service: Property<AppConfigurationManagerBuildService>
+
+        /** The name of the App Configuration store to create. */
+        val storeName: Property<String>
+
+        /** The Azure region (location) where the store will be created. */
+        val location: Property<String>
+
+        /** The SKU tier for the store (e.g., "Free", "Standard"). Defaults to "Free" if absent. */
+        val sku: Property<String>
+    }
+
+    override fun execute() {
+        val svc = parameters.service.get()
+        val rg = svc.parameters.resourceGroup.get()
+        val skuName = if (parameters.sku.isPresent) parameters.sku.get() else "Free"
+        val skuObject = Sku().withName(skuName)
+
+        svc.getClient().configurationStores()
+            .define(parameters.storeName.get())
+            .withRegion(parameters.location.get())
+            .withExistingResourceGroup(rg)
+            .withSku(skuObject)
+            .create()
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateSnapshotAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateSnapshotAction.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.util.Context
+import com.azure.data.appconfiguration.models.ConfigurationSettingsFilter
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import java.time.Duration
+
+/**
+ * [WorkAction] implementation that creates a snapshot in Azure App Configuration.
+ *
+ * A snapshot captures a consistent view of configuration settings at a point in time, filtered
+ * by key and optional label. The snapshot is retained for the specified duration (if provided).
+ * This operation blocks until snapshot creation completes.
+ */
+abstract class CreateSnapshotAction : WorkAction<CreateSnapshotAction.Parameters> {
+    /**
+     * Parameters for [CreateSnapshotAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The name of the snapshot to create. */
+        val snapshotName: Property<String>
+
+        /** The key filter pattern for settings to include in the snapshot (e.g., "app.*"). */
+        val keyFilter: Property<String>
+
+        /** Optional label filter to include only settings with a matching label. */
+        val labelFilter: Property<String>
+
+        /** Optional retention period in seconds. If specified, the snapshot expires after this duration. */
+        val retentionPeriod: Property<Long>
+    }
+
+    override fun execute() {
+        val filter = ConfigurationSettingsFilter(parameters.keyFilter.get())
+        if (parameters.labelFilter.isPresent) {
+            filter.setLabel(parameters.labelFilter.get())
+        }
+
+        val snapshot = ConfigurationSnapshot(listOf(filter))
+        if (parameters.retentionPeriod.isPresent) {
+            snapshot.setRetentionPeriod(Duration.ofSeconds(parameters.retentionPeriod.get()))
+        }
+
+        parameters.service.get().getClient()
+            .beginCreateSnapshot(parameters.snapshotName.get(), snapshot, Context.NONE)
+            .waitForCompletion()
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationSettingAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationSettingAction.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that deletes a configuration setting from Azure App Configuration.
+ *
+ * The setting is identified by its key and optional label. If the setting does not exist,
+ * no error is raised.
+ */
+abstract class DeleteConfigurationSettingAction : WorkAction<DeleteConfigurationSettingAction.Parameters> {
+    /**
+     * Parameters for [DeleteConfigurationSettingAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The key of the configuration setting to delete. */
+        val key: Property<String>
+
+        /** Optional label to identify the configuration setting variant to delete. */
+        val label: Property<String>
+    }
+
+    override fun execute() {
+        val client = parameters.service.get().getClient()
+        client.deleteConfigurationSetting(parameters.key.get(), parameters.label.orNull)
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationStoreAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationStoreAction.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that deletes an Azure App Configuration store from the configured resource group.
+ */
+abstract class DeleteConfigurationStoreAction : WorkAction<DeleteConfigurationStoreAction.Parameters> {
+    /**
+     * Parameters for [DeleteConfigurationStoreAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration manager. */
+        @get:Internal
+        val service: Property<AppConfigurationManagerBuildService>
+
+        /** The name of the App Configuration store to delete. */
+        val storeName: Property<String>
+    }
+
+    override fun execute() {
+        val svc = parameters.service.get()
+        val rg = svc.parameters.resourceGroup.get()
+        svc.getClient().configurationStores()
+            .deleteByResourceGroup(rg, parameters.storeName.get())
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteFeatureFlagAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteFeatureFlagAction.kt
@@ -1,0 +1,37 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that deletes a feature flag from Azure App Configuration.
+ *
+ * The feature flag is identified by its name and optional label. The internal key is constructed
+ * using the [FeatureFlagConfigurationSetting.KEY_PREFIX]. If the feature flag does not exist,
+ * no error is raised.
+ */
+abstract class DeleteFeatureFlagAction : WorkAction<DeleteFeatureFlagAction.Parameters> {
+    /**
+     * Parameters for [DeleteFeatureFlagAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The name of the feature flag to delete. */
+        val featureName: Property<String>
+
+        /** Optional label to identify the feature flag variant to delete. */
+        val label: Property<String>
+    }
+
+    override fun execute() {
+        val key = FeatureFlagConfigurationSetting.KEY_PREFIX + parameters.featureName.get()
+        parameters.service.get().getClient()
+            .deleteConfigurationSetting(key, parameters.label.orNull)
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSource.kt
@@ -1,0 +1,65 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.exception.ResourceNotFoundException
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that retrieves a single configuration setting from Azure App Configuration.
+ *
+ * Returns the setting's value as a string. When the setting is a Key Vault reference
+ * (identified by content type `application/vnd.microsoft.appconfig.keyvaultref+json`),
+ * returns empty string instead. Callers should use `azure-key-vault-base` to resolve Key Vault
+ * references separately.
+ *
+ * Returns empty string if the configuration setting is not found.
+ */
+abstract class GetConfigurationSettingValueSource :
+    ValueSource<String, GetConfigurationSettingValueSource.Parameters> {
+
+    /**
+     * Parameters for [GetConfigurationSettingValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /**
+         * The configuration setting key to retrieve.
+         */
+        val key: Property<String>
+
+        /**
+         * Optional label filter. When absent, settings without a label are queried.
+         */
+        val label: Property<String>
+    }
+
+    override fun obtain(): String {
+        return try {
+            val client = parameters.service.get().getClient()
+            val setting = client.getConfigurationSetting(
+                parameters.key.get(),
+                parameters.label.orNull
+            )
+            // Skip Key Vault references by checking content type.
+            val contentType = setting.contentType ?: ""
+            if (contentType.contains("keyvaultref", ignoreCase = true)) "" else setting.value
+        } catch (e: ResourceNotFoundException) {
+            logger.debug("Configuration setting not found: ${parameters.key.get()}", e)
+            ""
+        }
+    }
+
+    private companion object {
+        private val logger = Logging.getLogger(GetConfigurationSettingValueSource::class.java)
+    }
+}
+
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSource.kt
@@ -12,7 +12,7 @@ import org.gradle.api.tasks.Internal
  *
  * Returns the setting's value as a string. When the setting is a Key Vault reference
  * (identified by content type `application/vnd.microsoft.appconfig.keyvaultref+json`),
- * returns empty string instead. Callers should use `azure-key-vault-base` to resolve Key Vault
+ * returns an empty string. Callers should use `azure-key-vault-base` to resolve Key Vault
  * references separately.
  *
  * Returns empty string if the configuration setting is not found.
@@ -48,7 +48,6 @@ abstract class GetConfigurationSettingValueSource :
                 parameters.key.get(),
                 parameters.label.orNull
             )
-            // Skip Key Vault references by checking content type.
             val contentType = setting.contentType ?: ""
             if (contentType.contains("keyvaultref", ignoreCase = true)) "" else setting.value
         } catch (e: ResourceNotFoundException) {
@@ -61,5 +60,7 @@ abstract class GetConfigurationSettingValueSource :
         private val logger = Logging.getLogger(GetConfigurationSettingValueSource::class.java)
     }
 }
+
+
 
 

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSource.kt
@@ -10,12 +10,11 @@ import org.gradle.api.tasks.Internal
 /**
  * [ValueSource] that retrieves a single configuration setting from Azure App Configuration.
  *
- * Returns the setting's value as a string. When the setting is a Key Vault reference
- * (identified by content type `application/vnd.microsoft.appconfig.keyvaultref+json`),
- * returns an empty string. Callers should use `azure-key-vault-base` to resolve Key Vault
- * references separately.
- *
- * Returns empty string if the configuration setting is not found.
+ * Returns the setting's string value, or `null` if:
+ * - the setting does not exist, or
+ * - the setting is a Key Vault reference (content type contains `keyvaultref`). Key Vault
+ *   references are intentionally not resolved here to prevent secrets from entering the
+ *   configuration cache; use `azure-key-vault-base` and resolve at task execution time instead.
  */
 abstract class GetConfigurationSettingValueSource :
     ValueSource<String, GetConfigurationSettingValueSource.Parameters> {
@@ -41,18 +40,15 @@ abstract class GetConfigurationSettingValueSource :
         val label: Property<String>
     }
 
-    override fun obtain(): String {
+    override fun obtain(): String? {
         return try {
             val client = parameters.service.get().getClient()
-            val setting = client.getConfigurationSetting(
-                parameters.key.get(),
-                parameters.label.orNull
-            )
+            val setting = client.getConfigurationSetting(parameters.key.get(), parameters.label.orNull)
             val contentType = setting.contentType ?: ""
-            if (contentType.contains("keyvaultref", ignoreCase = true)) "" else setting.value
+            if (contentType.contains("keyvaultref", ignoreCase = true)) null else setting.value
         } catch (e: ResourceNotFoundException) {
             logger.debug("Configuration setting not found: ${parameters.key.get()}", e)
-            ""
+            null
         }
     }
 

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationStoreValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationStoreValueSource.kt
@@ -1,0 +1,54 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.management.exception.ManagementException
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that retrieves the endpoint URL for a single Azure App Configuration store.
+ *
+ * Returns the store's endpoint URL (e.g., `https://my-store.azconfig.io`), or `null` if:
+ * - the store does not exist, or
+ * - the store endpoint is not available (e.g., still provisioning).
+ *
+ * Uses the management-plane [AppConfigurationManagerBuildService] to enumerate stores within
+ * the configured resource group.
+ */
+abstract class GetConfigurationStoreValueSource :
+    ValueSource<String, GetConfigurationStoreValueSource.Parameters> {
+
+    /**
+     * Parameters for [GetConfigurationStoreValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration manager client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationManagerBuildService>
+
+        /**
+         * The App Configuration store name.
+         */
+        val storeName: Property<String>
+    }
+
+    override fun obtain(): String? {
+        return try {
+            val svc = parameters.service.get()
+            val store = svc.getClient().configurationStores()
+                .getByResourceGroup(svc.parameters.resourceGroup.get(), parameters.storeName.get())
+            store.endpoint()
+        } catch (e: ManagementException) {
+            logger.debug("Configuration store not found: ${parameters.storeName.get()}", e)
+            null
+        }
+    }
+
+    private companion object {
+        private val logger = Logging.getLogger(GetConfigurationStoreValueSource::class.java)
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSource.kt
@@ -1,0 +1,71 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.exception.ResourceNotFoundException
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that retrieves the enabled state of a feature flag from Azure App Configuration.
+ *
+ * Feature flag keys in Azure App Configuration are stored with the prefix `.appconfig.featureflag/`.
+ * Callers provide only the feature name; this class constructs the full key internally.
+ *
+ * Returns `true` if the feature flag exists and is enabled, `false` if it exists and is disabled,
+ * and `false` if the feature flag is not found.
+ *
+ * The enabled state is determined by parsing the setting's JSON value for the `enabled` field.
+ */
+abstract class GetFeatureFlagValueSource :
+    ValueSource<Boolean, GetFeatureFlagValueSource.Parameters> {
+
+    /**
+     * Parameters for [GetFeatureFlagValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /**
+         * The feature flag name (without the `.appconfig.featureflag/` prefix).
+         */
+        val featureName: Property<String>
+
+        /**
+         * Optional label filter. When absent, the flag without a label is queried.
+         */
+        val label: Property<String>
+    }
+
+    override fun obtain(): Boolean {
+        return try {
+            val client = parameters.service.get().getClient()
+            val key = ".appconfig.featureflag/" + parameters.featureName.get()
+            val setting = client.getConfigurationSetting(key, parameters.label.orNull)
+            // Feature flag value is a JSON containing { "enabled": true|false }
+            // For now, check content type to identify if this is a feature flag setting
+            val contentType = setting.contentType ?: ""
+            if (contentType.contains("featureflag", ignoreCase = true)) {
+                // Would need to parse JSON to extract enabled field; for now return false
+                // This is a placeholder pending actual JSON parsing implementation
+                false
+            } else {
+                false
+            }
+        } catch (e: ResourceNotFoundException) {
+            logger.debug("Feature flag not found: ${parameters.featureName.get()}", e)
+            false
+        }
+    }
+
+    private companion object {
+        private val logger = Logging.getLogger(GetFeatureFlagValueSource::class.java)
+    }
+}
+
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSource.kt
@@ -1,8 +1,7 @@
 package com.kelvsyc.gradle.azure.appconfiguration
 
 import com.azure.core.exception.ResourceNotFoundException
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
@@ -12,12 +11,12 @@ import org.gradle.api.tasks.Internal
 /**
  * [ValueSource] that retrieves the enabled state of a feature flag from Azure App Configuration.
  *
- * Feature flag keys in Azure App Configuration are stored with the prefix `.appconfig.featureflag/`.
- * Callers provide only the feature name; this class constructs the full key internally.
+ * Feature flag keys in Azure App Configuration are stored with the prefix
+ * [FeatureFlagConfigurationSetting.KEY_PREFIX] (`.appconfig.featureflag/`). Callers provide
+ * only the feature name; this class constructs the full key internally.
  *
- * Returns `true` if the feature flag exists and is enabled, and `false` if it is disabled or not found.
- *
- * The enabled state is extracted from the setting's JSON value by reading the `enabled` field.
+ * Returns `true` if the feature flag exists and is enabled, `false` if it exists and is disabled,
+ * or `null` if the feature flag is not found.
  */
 abstract class GetFeatureFlagValueSource :
     ValueSource<Boolean, GetFeatureFlagValueSource.Parameters> {
@@ -33,7 +32,7 @@ abstract class GetFeatureFlagValueSource :
         val service: Property<AppConfigurationClientBuildService>
 
         /**
-         * The feature flag name (without the `.appconfig.featureflag/` prefix).
+         * The feature flag name (without the [FeatureFlagConfigurationSetting.KEY_PREFIX]).
          */
         val featureName: Property<String>
 
@@ -43,28 +42,15 @@ abstract class GetFeatureFlagValueSource :
         val label: Property<String>
     }
 
-    override fun obtain(): Boolean {
+    override fun obtain(): Boolean? {
         return try {
             val client = parameters.service.get().getClient()
-            val key = ".appconfig.featureflag/" + parameters.featureName.get()
+            val key = FeatureFlagConfigurationSetting.KEY_PREFIX + parameters.featureName.get()
             val setting = client.getConfigurationSetting(key, parameters.label.orNull)
-            val contentType = setting.contentType ?: ""
-            if (contentType.contains("featureflag", ignoreCase = true)) {
-                // Feature flag value is a JSON containing { "enabled": true|false }
-                try {
-                    val mapper = ObjectMapper()
-                    val json = mapper.readTree(setting.value)
-                    json.get("enabled")?.asBoolean() ?: false
-                } catch (e: JsonProcessingException) {
-                    logger.debug("Failed to parse feature flag JSON for ${parameters.featureName.get()}", e)
-                    false
-                }
-            } else {
-                false
-            }
+            if (setting is FeatureFlagConfigurationSetting) setting.isEnabled else null
         } catch (e: ResourceNotFoundException) {
             logger.debug("Feature flag not found: ${parameters.featureName.get()}", e)
-            false
+            null
         }
     }
 
@@ -72,7 +58,3 @@ abstract class GetFeatureFlagValueSource :
         private val logger = Logging.getLogger(GetFeatureFlagValueSource::class.java)
     }
 }
-
-
-
-

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSource.kt
@@ -1,6 +1,8 @@
 package com.kelvsyc.gradle.azure.appconfiguration
 
 import com.azure.core.exception.ResourceNotFoundException
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
@@ -13,10 +15,9 @@ import org.gradle.api.tasks.Internal
  * Feature flag keys in Azure App Configuration are stored with the prefix `.appconfig.featureflag/`.
  * Callers provide only the feature name; this class constructs the full key internally.
  *
- * Returns `true` if the feature flag exists and is enabled, `false` if it exists and is disabled,
- * and `false` if the feature flag is not found.
+ * Returns `true` if the feature flag exists and is enabled, and `false` if it is disabled or not found.
  *
- * The enabled state is determined by parsing the setting's JSON value for the `enabled` field.
+ * The enabled state is extracted from the setting's JSON value by reading the `enabled` field.
  */
 abstract class GetFeatureFlagValueSource :
     ValueSource<Boolean, GetFeatureFlagValueSource.Parameters> {
@@ -47,13 +48,17 @@ abstract class GetFeatureFlagValueSource :
             val client = parameters.service.get().getClient()
             val key = ".appconfig.featureflag/" + parameters.featureName.get()
             val setting = client.getConfigurationSetting(key, parameters.label.orNull)
-            // Feature flag value is a JSON containing { "enabled": true|false }
-            // For now, check content type to identify if this is a feature flag setting
             val contentType = setting.contentType ?: ""
             if (contentType.contains("featureflag", ignoreCase = true)) {
-                // Would need to parse JSON to extract enabled field; for now return false
-                // This is a placeholder pending actual JSON parsing implementation
-                false
+                // Feature flag value is a JSON containing { "enabled": true|false }
+                try {
+                    val mapper = ObjectMapper()
+                    val json = mapper.readTree(setting.value)
+                    json.get("enabled")?.asBoolean() ?: false
+                } catch (e: JsonProcessingException) {
+                    logger.debug("Failed to parse feature flag JSON for ${parameters.featureName.get()}", e)
+                    false
+                }
             } else {
                 false
             }
@@ -67,5 +72,7 @@ abstract class GetFeatureFlagValueSource :
         private val logger = Logging.getLogger(GetFeatureFlagValueSource::class.java)
     }
 }
+
+
 
 

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationSettingsValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationSettingsValueSource.kt
@@ -1,0 +1,62 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.models.SettingSelector
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that lists all configuration settings from Azure App Configuration,
+ * optionally filtered by key prefix and label.
+ *
+ * Returns a [Map] of configuration key → value. Key Vault reference entries
+ * (identified by content type `application/vnd.microsoft.appconfig.keyvaultref+json`)
+ * are excluded from the result. To resolve Key Vault references, use `azure-key-vault-base` separately.
+ *
+ * Returns an empty map if no settings match the filters.
+ */
+abstract class ListConfigurationSettingsValueSource :
+    ValueSource<Map<String, String>, ListConfigurationSettingsValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListConfigurationSettingsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /**
+         * Optional key filter (prefix or pattern). When absent, all keys are included.
+         */
+        val keyFilter: Property<String>
+
+        /**
+         * Optional label filter. When absent, settings across all labels are included.
+         */
+        val labelFilter: Property<String>
+    }
+
+    override fun obtain(): Map<String, String> {
+        val client = parameters.service.get().getClient()
+        val selector = SettingSelector()
+        if (parameters.keyFilter.isPresent) {
+            selector.setKeyFilter(parameters.keyFilter.get())
+        }
+        if (parameters.labelFilter.isPresent) {
+            selector.setLabelFilter(parameters.labelFilter.get())
+        }
+
+        return client.listConfigurationSettings(selector)
+            .toList()
+            .filterNot { setting ->
+                val contentType = setting.contentType ?: ""
+                contentType.contains("keyvaultref", ignoreCase = true)
+            }
+            .associate { it.key to it.value }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationStoresValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationStoresValueSource.kt
@@ -1,0 +1,38 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that lists all Azure App Configuration stores within a resource group.
+ *
+ * Returns a [Map] of store name → endpoint URL. Stores with null endpoints (e.g., still
+ * provisioning) are excluded from the result.
+ *
+ * Returns an empty map if no stores exist in the resource group.
+ */
+abstract class ListConfigurationStoresValueSource :
+    ValueSource<Map<String, String>, ListConfigurationStoresValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListConfigurationStoresValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration manager client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationManagerBuildService>
+
+    }
+
+    override fun obtain(): Map<String, String> {
+        val svc = parameters.service.get()
+        return svc.getClient().configurationStores()
+            .listByResourceGroup(svc.parameters.resourceGroup.get())
+            .mapNotNull { store -> store.endpoint()?.let { store.name() to it } }
+            .toMap()
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSource.kt
@@ -1,19 +1,19 @@
 package com.kelvsyc.gradle.azure.appconfiguration
 
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
 import com.azure.data.appconfiguration.models.SettingSelector
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
-import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
 import org.gradle.api.tasks.Internal
 
 /**
- * [ValueSource] that lists all feature flags from Azure App Configuration, optionally filtered by label.
+ * [ValueSource] that lists all feature flags from Azure App Configuration, optionally filtered
+ * by label.
  *
- * Returns a [Map] of feature flag name → enabled state. Feature names have the `.appconfig.featureflag/`
- * prefix automatically stripped, so the returned keys are bare feature names.
+ * Returns a [Map] of feature flag name → enabled state. The [FeatureFlagConfigurationSetting.KEY_PREFIX]
+ * (`.appconfig.featureflag/`) is automatically stripped from each returned key so that callers
+ * receive bare feature names.
  *
  * Returns an empty map if no feature flags match the filter.
  */
@@ -38,35 +38,13 @@ abstract class ListFeatureFlagsValueSource :
 
     override fun obtain(): Map<String, Boolean> {
         val client = parameters.service.get().getClient()
-        val selector = SettingSelector().setKeyFilter(".appconfig.featureflag/*")
+        val selector = SettingSelector().setKeyFilter(FeatureFlagConfigurationSetting.KEY_PREFIX + "*")
         if (parameters.label.isPresent) {
             selector.setLabelFilter(parameters.label.get())
         }
-
-        val mapper = ObjectMapper()
         return client.listConfigurationSettings(selector)
             .toList()
-            .filter { setting ->
-                val contentType = setting.contentType ?: ""
-                contentType.contains("featureflag", ignoreCase = true)
-            }
-            .associate { setting ->
-                val flagName = setting.key.removePrefix(".appconfig.featureflag/")
-                try {
-                    val json = mapper.readTree(setting.value)
-                    val enabled = json.get("enabled")?.asBoolean() ?: false
-                    flagName to enabled
-                } catch (e: JsonProcessingException) {
-                    logger.debug("Failed to parse feature flag JSON for $flagName", e)
-                    flagName to false
-                }
-            }
-    }
-
-    private companion object {
-        private val logger = Logging.getLogger(ListFeatureFlagsValueSource::class.java)
+            .filterIsInstance<FeatureFlagConfigurationSetting>()
+            .associate { it.key.removePrefix(FeatureFlagConfigurationSetting.KEY_PREFIX) to it.isEnabled }
     }
 }
-
-
-

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSource.kt
@@ -1,6 +1,9 @@
 package com.kelvsyc.gradle.azure.appconfiguration
 
 import com.azure.data.appconfiguration.models.SettingSelector
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ValueSource
 import org.gradle.api.provider.ValueSourceParameters
@@ -13,9 +16,6 @@ import org.gradle.api.tasks.Internal
  * prefix automatically stripped, so the returned keys are bare feature names.
  *
  * Returns an empty map if no feature flags match the filter.
- *
- * Note: The enabled state is determined by parsing the setting's JSON value for the `enabled` field.
- * Pending JSON parsing implementation, this currently returns `false` for all flags.
  */
 abstract class ListFeatureFlagsValueSource :
     ValueSource<Map<String, Boolean>, ListFeatureFlagsValueSource.Parameters> {
@@ -38,12 +38,12 @@ abstract class ListFeatureFlagsValueSource :
 
     override fun obtain(): Map<String, Boolean> {
         val client = parameters.service.get().getClient()
-        val selector = SettingSelector()
-        selector.setKeyFilter(".appconfig.featureflag/*")
+        val selector = SettingSelector().setKeyFilter(".appconfig.featureflag/*")
         if (parameters.label.isPresent) {
             selector.setLabelFilter(parameters.label.get())
         }
 
+        val mapper = ObjectMapper()
         return client.listConfigurationSettings(selector)
             .toList()
             .filter { setting ->
@@ -52,9 +52,21 @@ abstract class ListFeatureFlagsValueSource :
             }
             .associate { setting ->
                 val flagName = setting.key.removePrefix(".appconfig.featureflag/")
-                // Would parse JSON to extract enabled field; for now return false
-                flagName to false
+                try {
+                    val json = mapper.readTree(setting.value)
+                    val enabled = json.get("enabled")?.asBoolean() ?: false
+                    flagName to enabled
+                } catch (e: JsonProcessingException) {
+                    logger.debug("Failed to parse feature flag JSON for $flagName", e)
+                    flagName to false
+                }
             }
     }
+
+    private companion object {
+        private val logger = Logging.getLogger(ListFeatureFlagsValueSource::class.java)
+    }
 }
+
+
 

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSource.kt
@@ -1,0 +1,60 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.models.SettingSelector
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that lists all feature flags from Azure App Configuration, optionally filtered by label.
+ *
+ * Returns a [Map] of feature flag name → enabled state. Feature names have the `.appconfig.featureflag/`
+ * prefix automatically stripped, so the returned keys are bare feature names.
+ *
+ * Returns an empty map if no feature flags match the filter.
+ *
+ * Note: The enabled state is determined by parsing the setting's JSON value for the `enabled` field.
+ * Pending JSON parsing implementation, this currently returns `false` for all flags.
+ */
+abstract class ListFeatureFlagsValueSource :
+    ValueSource<Map<String, Boolean>, ListFeatureFlagsValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListFeatureFlagsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /**
+         * Optional label filter. When absent, flags across all labels are included.
+         */
+        val label: Property<String>
+    }
+
+    override fun obtain(): Map<String, Boolean> {
+        val client = parameters.service.get().getClient()
+        val selector = SettingSelector()
+        selector.setKeyFilter(".appconfig.featureflag/*")
+        if (parameters.label.isPresent) {
+            selector.setLabelFilter(parameters.label.get())
+        }
+
+        return client.listConfigurationSettings(selector)
+            .toList()
+            .filter { setting ->
+                val contentType = setting.contentType ?: ""
+                contentType.contains("featureflag", ignoreCase = true)
+            }
+            .associate { setting ->
+                val flagName = setting.key.removePrefix(".appconfig.featureflag/")
+                // Would parse JSON to extract enabled field; for now return false
+                flagName to false
+            }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListSnapshotsValueSource.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListSnapshotsValueSource.kt
@@ -1,0 +1,53 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.models.ConfigurationSnapshotStatus
+import com.azure.data.appconfiguration.models.SnapshotSelector
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * [ValueSource] that lists configuration snapshots from Azure App Configuration,
+ * optionally filtered by name pattern.
+ *
+ * Only snapshots with [ConfigurationSnapshotStatus.READY] status are included in the result.
+ * Snapshots in other states (e.g., ARCHIVED) are filtered out.
+ *
+ * Returns a [List] of snapshot names. Returns an empty list if no snapshots match the criteria.
+ */
+abstract class ListSnapshotsValueSource :
+    ValueSource<List<String>, ListSnapshotsValueSource.Parameters> {
+
+    /**
+     * Parameters for [ListSnapshotsValueSource].
+     */
+    interface Parameters : ValueSourceParameters {
+        /**
+         * The build service managing the App Configuration client.
+         */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /**
+         * Optional snapshot name pattern filter. When absent, all snapshots are included
+         * (subject to the status filter).
+         */
+        val nameFilter: Property<String>
+    }
+
+    override fun obtain(): List<String> {
+        val client = parameters.service.get().getClient()
+        val selector = SnapshotSelector()
+        if (parameters.nameFilter.isPresent) {
+            selector.setNameFilter(parameters.nameFilter.get())
+        }
+
+        return client.listSnapshots(selector)
+            .toList()
+            .filter { it.status == ConfigurationSnapshotStatus.READY }
+            .map { it.name }
+    }
+}
+
+

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/RecoverSnapshotAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/RecoverSnapshotAction.kt
@@ -1,0 +1,31 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that recovers a snapshot in Azure App Configuration.
+ *
+ * Recovering a snapshot restores all of its configuration settings as the latest version
+ * in the store, overwriting any current values with the snapshot's values.
+ */
+abstract class RecoverSnapshotAction : WorkAction<RecoverSnapshotAction.Parameters> {
+    /**
+     * Parameters for [RecoverSnapshotAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The name of the snapshot to recover. */
+        val snapshotName: Property<String>
+    }
+
+    override fun execute() {
+        parameters.service.get().getClient()
+            .recoverSnapshot(parameters.snapshotName.get())
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetConfigurationSettingAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetConfigurationSettingAction.kt
@@ -1,0 +1,49 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that sets a configuration setting in Azure App Configuration.
+ *
+ * If the setting already exists, it is updated. Optional properties (label and content type)
+ * are only applied if present.
+ */
+abstract class SetConfigurationSettingAction : WorkAction<SetConfigurationSettingAction.Parameters> {
+    /**
+     * Parameters for [SetConfigurationSettingAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The key of the configuration setting. */
+        val key: Property<String>
+
+        /** The value of the configuration setting. */
+        val value: Property<String>
+
+        /** Optional label to identify the configuration setting (e.g., environment name). */
+        val label: Property<String>
+
+        /** Optional content type of the configuration setting (e.g., "application/json"). */
+        val contentType: Property<String>
+    }
+
+    override fun execute() {
+        val setting = ConfigurationSetting()
+            .setKey(parameters.key.get())
+            .setValue(parameters.value.get())
+        if (parameters.label.isPresent) {
+            setting.setLabel(parameters.label.get())
+        }
+        if (parameters.contentType.isPresent) {
+            setting.setContentType(parameters.contentType.get())
+        }
+        parameters.service.get().getClient().setConfigurationSetting(setting)
+    }
+}

--- a/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetFeatureFlagAction.kt
+++ b/cores/azure-app-configuration-base/src/main/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetFeatureFlagAction.kt
@@ -1,0 +1,51 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+
+/**
+ * [WorkAction] implementation that sets a feature flag in Azure App Configuration.
+ *
+ * Feature flags are created as configuration settings with the `.appconfig.featureflag/` key prefix.
+ * If the feature flag already exists, it is updated. Optional properties (label and description)
+ * are only applied if present.
+ */
+abstract class SetFeatureFlagAction : WorkAction<SetFeatureFlagAction.Parameters> {
+    /**
+     * Parameters for [SetFeatureFlagAction].
+     */
+    interface Parameters : WorkParameters {
+        /** The build service managing the App Configuration client. */
+        @get:Internal
+        val service: Property<AppConfigurationClientBuildService>
+
+        /** The name of the feature flag. */
+        val featureName: Property<String>
+
+        /** Whether the feature flag is enabled or disabled. */
+        val enabled: Property<Boolean>
+
+        /** Optional label to identify the feature flag variant (e.g., environment name). */
+        val label: Property<String>
+
+        /** Optional description of the feature flag's purpose. */
+        val description: Property<String>
+    }
+
+    override fun execute() {
+        val setting = FeatureFlagConfigurationSetting(
+            parameters.featureName.get(),
+            parameters.enabled.get()
+        )
+        if (parameters.label.isPresent) {
+            setting.setLabel(parameters.label.get())
+        }
+        if (parameters.description.isPresent) {
+            setting.setDescription(parameters.description.get())
+        }
+        parameters.service.get().getClient().setConfigurationSetting(setting)
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ArchiveSnapshotActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ArchiveSnapshotActionSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ArchiveSnapshotActionSpec : FunSpec() {
+    init {
+        test("execute - archives snapshot by name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val snapshotNameSlot = slot<String>()
+            every { client.archiveSnapshot(capture(snapshotNameSlot)) } returns mockk<ConfigurationSnapshot>()
+
+            val params = project.objects.newInstance<ArchiveSnapshotAction.Parameters>()
+            params.service.set(service)
+            params.snapshotName.set("snapshot-archive")
+
+            val action = object : ArchiveSnapshotAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            snapshotNameSlot.captured shouldBe "snapshot-archive"
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateConfigurationStoreActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateConfigurationStoreActionSpec.kt
@@ -1,0 +1,147 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.resourcemanager.appconfiguration.AppConfigurationManager
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStore
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStores
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateConfigurationStoreActionSpec : FunSpec() {
+    init {
+        test("execute - creates store with default Free sku when sku not set") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            // Mock the fluent builder chain
+            val blank = mockk<ConfigurationStore.DefinitionStages.Blank>()
+            val withLocation = mockk<ConfigurationStore.DefinitionStages.WithResourceGroup>()
+            val withResourceGroup = mockk<ConfigurationStore.DefinitionStages.WithSku>()
+            val withSku = mockk<ConfigurationStore.DefinitionStages.WithCreate>()
+            val store = mockk<ConfigurationStore>()
+
+            every { stores.define(any()) } returns blank
+            every { blank.withRegion(any<String>()) } returns withLocation
+            every { withLocation.withExistingResourceGroup(any()) } returns withResourceGroup
+            every { withResourceGroup.withSku(any()) } returns withSku
+            every { withSku.create() } returns store
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("my-rg")
+            }
+
+            val params = project.objects.newInstance<CreateConfigurationStoreAction.Parameters>()
+            params.service.set(service)
+            params.storeName.set("test-store")
+            params.location.set("eastus")
+
+            val action = object : CreateConfigurationStoreAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            verify { blank.withRegion("eastus") }
+            verify { withLocation.withExistingResourceGroup("my-rg") }
+            verify { withSku.create() }
+        }
+
+        test("execute - creates store with specified sku") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val blank = mockk<ConfigurationStore.DefinitionStages.Blank>()
+            val withLocation = mockk<ConfigurationStore.DefinitionStages.WithResourceGroup>()
+            val withResourceGroup = mockk<ConfigurationStore.DefinitionStages.WithSku>()
+            val withSku = mockk<ConfigurationStore.DefinitionStages.WithCreate>()
+            val store = mockk<ConfigurationStore>()
+
+            val skuSlot = slot<com.azure.resourcemanager.appconfiguration.models.Sku>()
+
+            every { stores.define(any()) } returns blank
+            every { blank.withRegion(any<String>()) } returns withLocation
+            every { withLocation.withExistingResourceGroup(any()) } returns withResourceGroup
+            every { withResourceGroup.withSku(capture(skuSlot)) } returns withSku
+            every { withSku.create() } returns store
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("my-rg")
+            }
+
+            val params = project.objects.newInstance<CreateConfigurationStoreAction.Parameters>()
+            params.service.set(service)
+            params.storeName.set("standard-store")
+            params.location.set("westus")
+            params.sku.set("Standard")
+
+            val action = object : CreateConfigurationStoreAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            skuSlot.captured.name() shouldBe "Standard"
+        }
+
+        test("execute - uses resource group from service") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val blank = mockk<ConfigurationStore.DefinitionStages.Blank>()
+            val withLocation = mockk<ConfigurationStore.DefinitionStages.WithResourceGroup>()
+            val withResourceGroup = mockk<ConfigurationStore.DefinitionStages.WithSku>()
+            val withSku = mockk<ConfigurationStore.DefinitionStages.WithCreate>()
+            val store = mockk<ConfigurationStore>()
+
+            val rgSlot = slot<String>()
+
+            every { stores.define(any()) } returns blank
+            every { blank.withRegion(any<String>()) } returns withLocation
+            every { withLocation.withExistingResourceGroup(capture(rgSlot)) } returns withResourceGroup
+            every { withResourceGroup.withSku(any()) } returns withSku
+            every { withSku.create() } returns store
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("service-rg")
+            }
+
+            val params = project.objects.newInstance<CreateConfigurationStoreAction.Parameters>()
+            params.service.set(service)
+            params.storeName.set("app-store")
+            params.location.set("northeurope")
+
+            val action = object : CreateConfigurationStoreAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            rgSlot.captured shouldBe "service-rg"
+        }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateSnapshotActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/CreateSnapshotActionSpec.kt
@@ -1,0 +1,97 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.util.polling.PollOperationDetails
+import com.azure.core.util.Context
+import com.azure.core.util.polling.SyncPoller
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateSnapshotActionSpec : FunSpec() {
+    init {
+        test("execute - creates snapshot with key filter") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val poller = mockk<SyncPoller<PollOperationDetails, ConfigurationSnapshot>>(relaxed = true)
+            every {
+                client.beginCreateSnapshot(any(), any(), any())
+            } returns poller
+            every { poller.waitForCompletion() } returns mockk()
+
+            val params = project.objects.newInstance<CreateSnapshotAction.Parameters>()
+            params.service.set(service)
+            params.snapshotName.set("snapshot-1")
+            params.keyFilter.set("app.*")
+
+            val action = object : CreateSnapshotAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+        }
+
+        test("execute - sets label filter when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val poller = mockk<SyncPoller<PollOperationDetails, ConfigurationSnapshot>>(relaxed = true)
+            every {
+                client.beginCreateSnapshot(any(), any(), any())
+            } returns poller
+            every { poller.waitForCompletion() } returns mockk()
+
+            val params = project.objects.newInstance<CreateSnapshotAction.Parameters>()
+            params.service.set(service)
+            params.snapshotName.set("snapshot-prod")
+            params.keyFilter.set("config.*")
+            params.labelFilter.set("production")
+
+            val action = object : CreateSnapshotAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+        }
+
+        test("execute - sets retention period when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val poller = mockk<SyncPoller<PollOperationDetails, ConfigurationSnapshot>>(relaxed = true)
+            every {
+                client.beginCreateSnapshot(any(), any(), any())
+            } returns poller
+            every { poller.waitForCompletion() } returns mockk()
+
+            val params = project.objects.newInstance<CreateSnapshotAction.Parameters>()
+            params.service.set(service)
+            params.snapshotName.set("snapshot-temp")
+            params.keyFilter.set("temp.*")
+            params.retentionPeriod.set(3600)
+
+            val action = object : CreateSnapshotAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationSettingActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationSettingActionSpec.kt
@@ -1,0 +1,67 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteConfigurationSettingActionSpec : FunSpec() {
+    init {
+        test("execute - deletes by key and null label") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val keySlot = slot<String>()
+            every { client.deleteConfigurationSetting(capture(keySlot), isNull()) } returns mockk<ConfigurationSetting>()
+
+            val params = project.objects.newInstance<DeleteConfigurationSettingAction.Parameters>()
+            params.service.set(service)
+            params.key.set("app.old")
+
+            val action = object : DeleteConfigurationSettingAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            keySlot.captured shouldBe "app.old"
+        }
+
+        test("execute - passes label when set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val keySlot = slot<String>()
+            val labelSlot = slot<String>()
+            every { client.deleteConfigurationSetting(capture(keySlot), capture(labelSlot)) } returns mockk<ConfigurationSetting>()
+
+            val params = project.objects.newInstance<DeleteConfigurationSettingAction.Parameters>()
+            params.service.set(service)
+            params.key.set("app.config")
+            params.label.set("staging")
+
+            val action = object : DeleteConfigurationSettingAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            keySlot.captured shouldBe "app.config"
+            labelSlot.captured shouldBe "staging"
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationStoreActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteConfigurationStoreActionSpec.kt
@@ -1,0 +1,78 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.resourcemanager.appconfiguration.AppConfigurationManager
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStores
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteConfigurationStoreActionSpec : FunSpec() {
+    init {
+        test("execute - deletes store by name") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+            every { stores.deleteByResourceGroup(any(), any()) } returns Unit
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("my-rg")
+            }
+
+            val params = project.objects.newInstance<DeleteConfigurationStoreAction.Parameters>()
+            params.service.set(service)
+            params.storeName.set("test-store")
+
+            val action = object : DeleteConfigurationStoreAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            verify { stores.deleteByResourceGroup("my-rg", "test-store") }
+        }
+
+        test("execute - uses resource group from service") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val rgSlot = slot<String>()
+            val nameSlot = slot<String>()
+            every { stores.deleteByResourceGroup(capture(rgSlot), capture(nameSlot)) } returns Unit
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("custom-rg")
+            }
+
+            val params = project.objects.newInstance<DeleteConfigurationStoreAction.Parameters>()
+            params.service.set(service)
+            params.storeName.set("store-to-delete")
+
+            val action = object : DeleteConfigurationStoreAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            rgSlot.captured shouldBe "custom-rg"
+            nameSlot.captured shouldBe "store-to-delete"
+        }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteFeatureFlagActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/DeleteFeatureFlagActionSpec.kt
@@ -1,0 +1,71 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteFeatureFlagActionSpec : FunSpec() {
+    init {
+        test("execute - deletes flag with correct key prefix") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val keySlot = slot<String>()
+            val labelSlot = slot<String>()
+            every { client.deleteConfigurationSetting(capture(keySlot), capture(labelSlot)) } returns mockk<ConfigurationSetting>()
+
+            val params = project.objects.newInstance<DeleteFeatureFlagAction.Parameters>()
+            params.service.set(service)
+            params.featureName.set("my-flag")
+
+            val action = object : DeleteFeatureFlagAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val expectedKey = FeatureFlagConfigurationSetting.KEY_PREFIX + "my-flag"
+            keySlot.captured shouldBe expectedKey
+        }
+
+        test("execute - passes label when set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val keySlot = slot<String>()
+            val labelSlot = slot<String>()
+            every { client.deleteConfigurationSetting(capture(keySlot), capture(labelSlot)) } returns mockk<ConfigurationSetting>()
+
+            val params = project.objects.newInstance<DeleteFeatureFlagAction.Parameters>()
+            params.service.set(service)
+            params.featureName.set("experimental-ui")
+            params.label.set("prod")
+
+            val action = object : DeleteFeatureFlagAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val expectedKey = FeatureFlagConfigurationSetting.KEY_PREFIX + "experimental-ui"
+            keySlot.captured shouldBe expectedKey
+            labelSlot.captured shouldBe "prod"
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSourceSpec.kt
@@ -23,22 +23,19 @@ class GetConfigurationSettingValueSourceSpec : FunSpec() {
                 MockAppConfigurationClientBuildService::class
             )
             val keySlot = slot<String>()
-            val setting = mockk<ConfigurationSetting>()
-            every { setting.value } returns "hello"
-            every { setting.contentType } returns null
-            every { client.getConfigurationSetting(capture(keySlot), any()) } returns setting
+            val setting = ConfigurationSetting().setKey("app.name").setValue("hello")
+            every { client.getConfigurationSetting(capture(keySlot), null) } returns setting
 
             val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
                 parameters.service.set(service)
                 parameters.key.set("app.name")
             }
-            val result = provider.get()
 
-            result shouldBe "hello"
+            provider.orNull shouldBe "hello"
             keySlot.captured shouldBe "app.name"
         }
 
-        test("obtain - returns empty string for Key Vault reference") {
+        test("obtain - returns null for Key Vault reference") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<ConfigurationClient>()
             MockAppConfigurationClientBuildService.mockClient = client
@@ -46,20 +43,20 @@ class GetConfigurationSettingValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-            val kvSetting = mockk<ConfigurationSetting>()
-            every { kvSetting.contentType } returns "application/vnd.microsoft.appconfig.keyvaultref+json"
-            every { client.getConfigurationSetting(any(), any()) } returns kvSetting
+            val kvSetting = ConfigurationSetting()
+                .setKey("kv-ref")
+                .setContentType("application/vnd.microsoft.appconfig.keyvaultref+json;charset=utf-8")
+            every { client.getConfigurationSetting(any(), null) } returns kvSetting
 
             val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
                 parameters.service.set(service)
                 parameters.key.set("kv-ref")
             }
-            val result = provider.get()
 
-            result shouldBe ""
+            provider.orNull.shouldBeNull()
         }
 
-        test("obtain - returns empty string when setting not found") {
+        test("obtain - returns null when setting not found") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<ConfigurationClient>()
             MockAppConfigurationClientBuildService.mockClient = client
@@ -67,16 +64,15 @@ class GetConfigurationSettingValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-            every { client.getConfigurationSetting(any(), any()) } throws
+            every { client.getConfigurationSetting(any(), null) } throws
                 ResourceNotFoundException("not found", null)
 
             val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
                 parameters.service.set(service)
                 parameters.key.set("missing-key")
             }
-            val result = provider.get()
 
-            result shouldBe ""
+            provider.orNull.shouldBeNull()
         }
 
         test("obtain - passes label when set") {
@@ -89,9 +85,7 @@ class GetConfigurationSettingValueSourceSpec : FunSpec() {
             )
             val keySlot = slot<String>()
             val labelSlot = slot<String>()
-            val setting = mockk<ConfigurationSetting>()
-            every { setting.value } returns "prod-value"
-            every { setting.contentType } returns null
+            val setting = ConfigurationSetting().setKey("app.config").setValue("prod-value")
             every { client.getConfigurationSetting(capture(keySlot), capture(labelSlot)) } returns setting
 
             val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
@@ -99,14 +93,10 @@ class GetConfigurationSettingValueSourceSpec : FunSpec() {
                 parameters.key.set("app.config")
                 parameters.label.set("prod")
             }
-            val result = provider.get()
 
-            result shouldBe "prod-value"
+            provider.orNull shouldBe "prod-value"
             keySlot.captured shouldBe "app.config"
             labelSlot.captured shouldBe "prod"
         }
     }
 }
-
-
-

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSourceSpec.kt
@@ -4,6 +4,7 @@ import com.azure.core.exception.ResourceNotFoundException
 import com.azure.data.appconfiguration.ConfigurationClient
 import com.azure.data.appconfiguration.models.ConfigurationSetting
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -106,5 +107,6 @@ class GetConfigurationSettingValueSourceSpec : FunSpec() {
         }
     }
 }
+
 
 

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationSettingValueSourceSpec.kt
@@ -1,0 +1,110 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.exception.ResourceNotFoundException
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class GetConfigurationSettingValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns value for plain setting") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val keySlot = slot<String>()
+            val setting = mockk<ConfigurationSetting>()
+            every { setting.value } returns "hello"
+            every { setting.contentType } returns null
+            every { client.getConfigurationSetting(capture(keySlot), any()) } returns setting
+
+            val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
+                parameters.service.set(service)
+                parameters.key.set("app.name")
+            }
+            val result = provider.get()
+
+            result shouldBe "hello"
+            keySlot.captured shouldBe "app.name"
+        }
+
+        test("obtain - returns empty string for Key Vault reference") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val kvSetting = mockk<ConfigurationSetting>()
+            every { kvSetting.contentType } returns "application/vnd.microsoft.appconfig.keyvaultref+json"
+            every { client.getConfigurationSetting(any(), any()) } returns kvSetting
+
+            val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
+                parameters.service.set(service)
+                parameters.key.set("kv-ref")
+            }
+            val result = provider.get()
+
+            result shouldBe ""
+        }
+
+        test("obtain - returns empty string when setting not found") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            every { client.getConfigurationSetting(any(), any()) } throws
+                ResourceNotFoundException("not found", null)
+
+            val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
+                parameters.service.set(service)
+                parameters.key.set("missing-key")
+            }
+            val result = provider.get()
+
+            result shouldBe ""
+        }
+
+        test("obtain - passes label when set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val keySlot = slot<String>()
+            val labelSlot = slot<String>()
+            val setting = mockk<ConfigurationSetting>()
+            every { setting.value } returns "prod-value"
+            every { setting.contentType } returns null
+            every { client.getConfigurationSetting(capture(keySlot), capture(labelSlot)) } returns setting
+
+            val provider = project.providers.ofKt(GetConfigurationSettingValueSource::class) {
+                parameters.service.set(service)
+                parameters.key.set("app.config")
+                parameters.label.set("prod")
+            }
+            val result = provider.get()
+
+            result shouldBe "prod-value"
+            keySlot.captured shouldBe "app.config"
+            labelSlot.captured shouldBe "prod"
+        }
+    }
+}
+
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationStoreValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetConfigurationStoreValueSourceSpec.kt
@@ -1,0 +1,122 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.appconfiguration.AppConfigurationManager
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStore
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStores
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class GetConfigurationStoreValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns endpoint URL for existing store") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val store = mockk<ConfigurationStore>()
+            every { store.endpoint() } returns "https://my-store.azconfig.io"
+            every { stores.getByResourceGroup("rg", "my-store") } returns store
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("rg")
+            }
+
+            val provider = project.providers.ofKt(GetConfigurationStoreValueSource::class) {
+                parameters.service.set(service)
+                parameters.storeName.set("my-store")
+            }
+
+            provider.orNull shouldBe "https://my-store.azconfig.io"
+        }
+
+        test("obtain - returns null when store not found") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+            every { stores.getByResourceGroup(any(), any()) } throws
+                ManagementException("not found", null)
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("rg")
+            }
+
+            val provider = project.providers.ofKt(GetConfigurationStoreValueSource::class) {
+                parameters.service.set(service)
+                parameters.storeName.set("missing-store")
+            }
+
+            provider.orNull.shouldBeNull()
+        }
+
+        test("obtain - returns null when endpoint is not available") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val store = mockk<ConfigurationStore>()
+            every { store.endpoint() } returns null
+            every { stores.getByResourceGroup("rg", "provisioning-store") } returns store
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("rg")
+            }
+
+            val provider = project.providers.ofKt(GetConfigurationStoreValueSource::class) {
+                parameters.service.set(service)
+                parameters.storeName.set("provisioning-store")
+            }
+
+            provider.orNull.shouldBeNull()
+        }
+
+        test("obtain - uses resource group from service parameters") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val rgSlot = slot<String>()
+            val store = mockk<ConfigurationStore>()
+            every { store.endpoint() } returns "https://test-store.azconfig.io"
+            every { stores.getByResourceGroup(capture(rgSlot), any()) } returns store
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("my-resource-group")
+            }
+
+            val provider = project.providers.ofKt(GetConfigurationStoreValueSource::class) {
+                parameters.service.set(service)
+                parameters.storeName.set("test-store")
+            }
+            provider.orNull
+
+            rgSlot.captured shouldBe "my-resource-group"
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
@@ -2,7 +2,7 @@ package com.kelvsyc.gradle.azure.appconfiguration
 
 import com.azure.core.exception.ResourceNotFoundException
 import com.azure.data.appconfiguration.ConfigurationClient
-import com.azure.data.appconfiguration.models.ConfigurationSetting
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -22,19 +22,15 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
-            val flag = mockk<ConfigurationSetting>()
-            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
-            every { flag.value } returns """{"enabled":true}"""
-            every { client.getConfigurationSetting(any(), any()) } returns flag
+            val flag = FeatureFlagConfigurationSetting("new-ui", true)
+            every { client.getConfigurationSetting(any(), null) } returns flag
 
             val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
                 parameters.service.set(service)
                 parameters.featureName.set("new-ui")
             }
-            val result = provider.get()
 
-            result shouldBe true
+            provider.orNull shouldBe true
         }
 
         test("obtain - returns false for disabled flag") {
@@ -45,22 +41,18 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
-            val flag = mockk<ConfigurationSetting>()
-            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
-            every { flag.value } returns """{"enabled":false}"""
-            every { client.getConfigurationSetting(any(), any()) } returns flag
+            val flag = FeatureFlagConfigurationSetting("old-ui", false)
+            every { client.getConfigurationSetting(any(), null) } returns flag
 
             val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
                 parameters.service.set(service)
                 parameters.featureName.set("old-ui")
             }
-            val result = provider.get()
 
-            result shouldBe false
+            provider.orNull shouldBe false
         }
 
-        test("obtain - returns false when not found") {
+        test("obtain - returns null when not found") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<ConfigurationClient>()
             MockAppConfigurationClientBuildService.mockClient = client
@@ -68,17 +60,15 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
-            every { client.getConfigurationSetting(any(), any()) } throws
+            every { client.getConfigurationSetting(any(), null) } throws
                 ResourceNotFoundException("not found", null)
 
             val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
                 parameters.service.set(service)
                 parameters.featureName.set("missing-flag")
             }
-            val result = provider.get()
 
-            result shouldBe false
+            provider.orNull.shouldBeNull()
         }
 
         test("obtain - uses correct key prefix") {
@@ -89,23 +79,17 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
             val keySlot = slot<String>()
-            val flag = mockk<ConfigurationSetting>()
-            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
-            every { flag.value } returns """{"enabled":true}"""
-            every { client.getConfigurationSetting(capture(keySlot), any()) } returns flag
+            val flag = FeatureFlagConfigurationSetting("my-feature", true)
+            every { client.getConfigurationSetting(capture(keySlot), null) } returns flag
 
             val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
                 parameters.service.set(service)
                 parameters.featureName.set("my-feature")
             }
-            provider.get()
+            provider.orNull
 
             keySlot.captured shouldBe ".appconfig.featureflag/my-feature"
         }
     }
 }
-
-
-

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
@@ -1,0 +1,84 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.core.exception.ResourceNotFoundException
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class GetFeatureFlagValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns false for feature flag (placeholder until JSON parsing added)") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val flag = mockk<ConfigurationSetting>()
+            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { client.getConfigurationSetting(any(), any()) } returns flag
+
+            val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
+                parameters.service.set(service)
+                parameters.featureName.set("new-ui")
+            }
+            val result = provider.get()
+
+            // Currently returns false until JSON parsing is implemented
+            result shouldBe false
+        }
+
+        test("obtain - returns false when not found") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            every { client.getConfigurationSetting(any(), any()) } throws
+                ResourceNotFoundException("not found", null)
+
+            val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
+                parameters.service.set(service)
+                parameters.featureName.set("missing-flag")
+            }
+            val result = provider.get()
+
+            result shouldBe false
+        }
+
+        test("obtain - uses correct key prefix") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val keySlot = slot<String>()
+            val flag = mockk<ConfigurationSetting>()
+            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { client.getConfigurationSetting(capture(keySlot), any()) } returns flag
+
+            val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
+                parameters.service.set(service)
+                parameters.featureName.set("my-feature")
+            }
+            provider.get()
+
+            keySlot.captured shouldBe ".appconfig.featureflag/my-feature"
+        }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
@@ -4,6 +4,7 @@ import com.azure.core.exception.ResourceNotFoundException
 import com.azure.data.appconfiguration.ConfigurationClient
 import com.azure.data.appconfiguration.models.ConfigurationSetting
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -13,7 +14,7 @@ import org.gradle.testfixtures.ProjectBuilder
 
 class GetFeatureFlagValueSourceSpec : FunSpec() {
     init {
-        test("obtain - returns false for feature flag (placeholder until JSON parsing added)") {
+        test("obtain - returns true for enabled flag") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<ConfigurationClient>()
             MockAppConfigurationClientBuildService.mockClient = client
@@ -24,6 +25,7 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
 
             val flag = mockk<ConfigurationSetting>()
             every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { flag.value } returns """{"enabled":true}"""
             every { client.getConfigurationSetting(any(), any()) } returns flag
 
             val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
@@ -32,7 +34,29 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
             }
             val result = provider.get()
 
-            // Currently returns false until JSON parsing is implemented
+            result shouldBe true
+        }
+
+        test("obtain - returns false for disabled flag") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val flag = mockk<ConfigurationSetting>()
+            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { flag.value } returns """{"enabled":false}"""
+            every { client.getConfigurationSetting(any(), any()) } returns flag
+
+            val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
+                parameters.service.set(service)
+                parameters.featureName.set("old-ui")
+            }
+            val result = provider.get()
+
             result shouldBe false
         }
 
@@ -69,6 +93,7 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
             val keySlot = slot<String>()
             val flag = mockk<ConfigurationSetting>()
             every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { flag.value } returns """{"enabled":true}"""
             every { client.getConfigurationSetting(capture(keySlot), any()) } returns flag
 
             val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
@@ -81,4 +106,6 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
         }
     }
 }
+
+
 

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/GetFeatureFlagValueSourceSpec.kt
@@ -91,5 +91,27 @@ class GetFeatureFlagValueSourceSpec : FunSpec() {
 
             keySlot.captured shouldBe ".appconfig.featureflag/my-feature"
         }
+
+        test("obtain - passes label when set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val labelSlot = slot<String>()
+            val flag = FeatureFlagConfigurationSetting("my-feature", true)
+            every { client.getConfigurationSetting(any(), capture(labelSlot)) } returns flag
+
+            val provider = project.providers.ofKt(GetFeatureFlagValueSource::class) {
+                parameters.service.set(service)
+                parameters.featureName.set("my-feature")
+                parameters.label.set("prod")
+            }
+            provider.orNull
+
+            labelSlot.captured shouldBe "prod"
+        }
     }
 }

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationSettingsValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationSettingsValueSourceSpec.kt
@@ -1,0 +1,99 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldContainExactly
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListConfigurationSettingsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns key-value map from settings") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val setting1 = mockk<ConfigurationSetting>()
+            every { setting1.key } returns "db.host"
+            every { setting1.value } returns "localhost"
+            every { setting1.contentType } returns null
+
+            val setting2 = mockk<ConfigurationSetting>()
+            every { setting2.key } returns "db.port"
+            every { setting2.value } returns "5432"
+            every { setting2.contentType } returns null
+
+            every { client.listConfigurationSettings(any()) } returns
+                mockk { every { iterator() } returns listOf(setting1, setting2).toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListConfigurationSettingsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result shouldContainExactly mapOf(
+                "db.host" to "localhost",
+                "db.port" to "5432"
+            )
+        }
+
+        test("obtain - skips Key Vault reference entries") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val plainSetting = mockk<ConfigurationSetting>()
+            every { plainSetting.key } returns "app.name"
+            every { plainSetting.value } returns "myapp"
+            every { plainSetting.contentType } returns null
+
+            val kvSetting = mockk<ConfigurationSetting>()
+            every { kvSetting.key } returns "kv-ref"
+            every { kvSetting.value } returns "{...}"
+            every { kvSetting.contentType } returns "application/vnd.microsoft.appconfig.keyvaultref+json"
+
+            every { client.listConfigurationSettings(any()) } returns
+                mockk { every { iterator() } returns listOf(plainSetting, kvSetting).toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListConfigurationSettingsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result shouldContainExactly mapOf("app.name" to "myapp")
+        }
+
+        test("obtain - returns empty map when no settings") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            every { client.listConfigurationSettings(any()) } returns
+                mockk { every { iterator() } returns listOf<ConfigurationSetting>().toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListConfigurationSettingsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result.shouldBeEmpty()
+        }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationStoresValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListConfigurationStoresValueSourceSpec.kt
@@ -1,0 +1,107 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.resourcemanager.appconfiguration.AppConfigurationManager
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStore
+import com.azure.resourcemanager.appconfiguration.models.ConfigurationStores
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldContainExactly
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListConfigurationStoresValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns store name to endpoint map") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val store1 = mockk<ConfigurationStore>()
+            every { store1.name() } returns "store-1"
+            every { store1.endpoint() } returns "https://store-1.azconfig.io"
+
+            val store2 = mockk<ConfigurationStore>()
+            every { store2.name() } returns "store-2"
+            every { store2.endpoint() } returns "https://store-2.azconfig.io"
+
+            every { stores.listByResourceGroup(any()) } returns
+                mockk { every { iterator() } returns mutableListOf(store1, store2).iterator() }
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("rg")
+            }
+
+            val provider = project.providers.ofKt(ListConfigurationStoresValueSource::class) {
+                parameters.service.set(service)
+            }
+
+            provider.get() shouldContainExactly mapOf(
+                "store-1" to "https://store-1.azconfig.io",
+                "store-2" to "https://store-2.azconfig.io"
+            )
+        }
+
+        test("obtain - returns empty map when no stores") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            every { stores.listByResourceGroup(any()) } returns
+                mockk { every { iterator() } returns mutableListOf<ConfigurationStore>().iterator() }
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("rg")
+            }
+
+            val provider = project.providers.ofKt(ListConfigurationStoresValueSource::class) {
+                parameters.service.set(service)
+            }
+
+            provider.get().shouldBeEmpty()
+        }
+
+        test("obtain - skips stores with null endpoints") {
+            val project = ProjectBuilder.builder().build()
+            val manager = mockk<AppConfigurationManager>()
+            MockAppConfigurationManagerBuildService.mockClient = manager
+            val stores = mockk<ConfigurationStores>()
+            every { manager.configurationStores() } returns stores
+
+            val store1 = mockk<ConfigurationStore>()
+            every { store1.name() } returns "ready-store"
+            every { store1.endpoint() } returns "https://ready-store.azconfig.io"
+
+            val store2 = mockk<ConfigurationStore>()
+            every { store2.name() } returns "provisioning-store"
+            every { store2.endpoint() } returns null
+
+            every { stores.listByResourceGroup(any()) } returns
+                mockk { every { iterator() } returns mutableListOf(store1, store2).iterator() }
+
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig-manager",
+                MockAppConfigurationManagerBuildService::class
+            ) {
+                it.parameters.resourceGroup.set("rg")
+            }
+
+            val provider = project.providers.ofKt(ListConfigurationStoresValueSource::class) {
+                parameters.service.set(service)
+            }
+
+            provider.get() shouldContainExactly mapOf("ready-store" to "https://ready-store.azconfig.io")
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
@@ -5,8 +5,11 @@ import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import com.azure.data.appconfiguration.models.SettingSelector
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import org.gradle.kotlin.dsl.registerIfAbsent
 import org.gradle.testfixtures.ProjectBuilder
 
@@ -67,6 +70,27 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
             }
 
             provider.get() shouldContainExactly mapOf("test-flag" to true)
+        }
+
+        test("obtain - applies label filter when set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val selectorSlot = slot<SettingSelector>()
+            every { client.listConfigurationSettings(capture(selectorSlot)) } returns
+                mockk { every { iterator() } returns mutableListOf<FeatureFlagConfigurationSetting>().iterator() }
+
+            val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
+                parameters.service.set(service)
+                parameters.label.set("prod")
+            }
+            provider.get()
+
+            selectorSlot.captured.labelFilter shouldBe "prod"
         }
     }
 }

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
@@ -12,7 +12,7 @@ import org.gradle.testfixtures.ProjectBuilder
 
 class ListFeatureFlagsValueSourceSpec : FunSpec() {
     init {
-        test("obtain - returns feature name to enabled map (placeholder until JSON parsing added)") {
+        test("obtain - returns feature name to enabled map") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<ConfigurationClient>()
             MockAppConfigurationClientBuildService.mockClient = client
@@ -24,10 +24,12 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
             val flag1 = mockk<ConfigurationSetting>()
             every { flag1.key } returns ".appconfig.featureflag/feature-a"
             every { flag1.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { flag1.value } returns """{"enabled":true}"""
 
             val flag2 = mockk<ConfigurationSetting>()
             every { flag2.key } returns ".appconfig.featureflag/feature-b"
             every { flag2.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { flag2.value } returns """{"enabled":false}"""
 
             every { client.listConfigurationSettings(any()) } returns
                 mockk { every { iterator() } returns listOf(flag1, flag2).toMutableList().iterator() }
@@ -37,9 +39,8 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
             }
             val result = provider.get()
 
-            // Returns false for all until JSON parsing is implemented
             result shouldContainExactly mapOf(
-                "feature-a" to false,
+                "feature-a" to true,
                 "feature-b" to false
             )
         }
@@ -64,7 +65,7 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
             result.shouldBeEmpty()
         }
 
-        test("obtain - uses feature flag key prefix in selector") {
+        test("obtain - returns flag names without prefix") {
             val project = ProjectBuilder.builder().build()
             val client = mockk<ConfigurationClient>()
             MockAppConfigurationClientBuildService.mockClient = client
@@ -76,6 +77,7 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
             val flag = mockk<ConfigurationSetting>()
             every { flag.key } returns ".appconfig.featureflag/test-flag"
             every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+            every { flag.value } returns """{"enabled":true}"""
 
             every { client.listConfigurationSettings(any()) } returns
                 mockk { every { iterator() } returns listOf(flag).toMutableList().iterator() }
@@ -85,8 +87,10 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
             }
             val result = provider.get()
 
-            result shouldContainExactly mapOf("test-flag" to false)
+            result shouldContainExactly mapOf("test-flag" to true)
         }
     }
 }
+
+
 

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
@@ -1,7 +1,7 @@
 package com.kelvsyc.gradle.azure.appconfiguration
 
 import com.azure.data.appconfiguration.ConfigurationClient
-import com.azure.data.appconfiguration.models.ConfigurationSetting
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldContainExactly
@@ -20,29 +20,16 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
-            val flag1 = mockk<ConfigurationSetting>()
-            every { flag1.key } returns ".appconfig.featureflag/feature-a"
-            every { flag1.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
-            every { flag1.value } returns """{"enabled":true}"""
-
-            val flag2 = mockk<ConfigurationSetting>()
-            every { flag2.key } returns ".appconfig.featureflag/feature-b"
-            every { flag2.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
-            every { flag2.value } returns """{"enabled":false}"""
-
+            val flag1 = FeatureFlagConfigurationSetting("feature-a", true)
+            val flag2 = FeatureFlagConfigurationSetting("feature-b", false)
             every { client.listConfigurationSettings(any()) } returns
-                mockk { every { iterator() } returns listOf(flag1, flag2).toMutableList().iterator() }
+                mockk { every { iterator() } returns mutableListOf(flag1, flag2).iterator() }
 
             val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
                 parameters.service.set(service)
             }
-            val result = provider.get()
 
-            result shouldContainExactly mapOf(
-                "feature-a" to true,
-                "feature-b" to false
-            )
+            provider.get() shouldContainExactly mapOf("feature-a" to true, "feature-b" to false)
         }
 
         test("obtain - returns empty map when no flags") {
@@ -53,16 +40,14 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
             every { client.listConfigurationSettings(any()) } returns
-                mockk { every { iterator() } returns listOf<ConfigurationSetting>().toMutableList().iterator() }
+                mockk { every { iterator() } returns mutableListOf<FeatureFlagConfigurationSetting>().iterator() }
 
             val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
                 parameters.service.set(service)
             }
-            val result = provider.get()
 
-            result.shouldBeEmpty()
+            provider.get().shouldBeEmpty()
         }
 
         test("obtain - returns flag names without prefix") {
@@ -73,24 +58,15 @@ class ListFeatureFlagsValueSourceSpec : FunSpec() {
                 "appconfig",
                 MockAppConfigurationClientBuildService::class
             )
-
-            val flag = mockk<ConfigurationSetting>()
-            every { flag.key } returns ".appconfig.featureflag/test-flag"
-            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
-            every { flag.value } returns """{"enabled":true}"""
-
+            val flag = FeatureFlagConfigurationSetting("test-flag", true)
             every { client.listConfigurationSettings(any()) } returns
-                mockk { every { iterator() } returns listOf(flag).toMutableList().iterator() }
+                mockk { every { iterator() } returns mutableListOf(flag).iterator() }
 
             val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
                 parameters.service.set(service)
             }
-            val result = provider.get()
 
-            result shouldContainExactly mapOf("test-flag" to true)
+            provider.get() shouldContainExactly mapOf("test-flag" to true)
         }
     }
 }
-
-
-

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListFeatureFlagsValueSourceSpec.kt
@@ -1,0 +1,92 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldContainExactly
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListFeatureFlagsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns feature name to enabled map (placeholder until JSON parsing added)") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val flag1 = mockk<ConfigurationSetting>()
+            every { flag1.key } returns ".appconfig.featureflag/feature-a"
+            every { flag1.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+
+            val flag2 = mockk<ConfigurationSetting>()
+            every { flag2.key } returns ".appconfig.featureflag/feature-b"
+            every { flag2.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+
+            every { client.listConfigurationSettings(any()) } returns
+                mockk { every { iterator() } returns listOf(flag1, flag2).toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            // Returns false for all until JSON parsing is implemented
+            result shouldContainExactly mapOf(
+                "feature-a" to false,
+                "feature-b" to false
+            )
+        }
+
+        test("obtain - returns empty map when no flags") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            every { client.listConfigurationSettings(any()) } returns
+                mockk { every { iterator() } returns listOf<ConfigurationSetting>().toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result.shouldBeEmpty()
+        }
+
+        test("obtain - uses feature flag key prefix in selector") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val flag = mockk<ConfigurationSetting>()
+            every { flag.key } returns ".appconfig.featureflag/test-flag"
+            every { flag.contentType } returns "application/vnd.microsoft.appconfig.featureflag+json"
+
+            every { client.listConfigurationSettings(any()) } returns
+                mockk { every { iterator() } returns listOf(flag).toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListFeatureFlagsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result shouldContainExactly mapOf("test-flag" to false)
+        }
+    }
+}
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListSnapshotsValueSourceSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ListSnapshotsValueSourceSpec.kt
@@ -1,0 +1,98 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot
+import com.azure.data.appconfiguration.models.ConfigurationSnapshotStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mockk.every
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class ListSnapshotsValueSourceSpec : FunSpec() {
+    init {
+        test("obtain - returns names of READY snapshots") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val readySnapshot1 = mockk<ConfigurationSnapshot>()
+            every { readySnapshot1.name } returns "snapshot-1"
+            every { readySnapshot1.status } returns ConfigurationSnapshotStatus.READY
+
+            val readySnapshot2 = mockk<ConfigurationSnapshot>()
+            every { readySnapshot2.name } returns "snapshot-2"
+            every { readySnapshot2.status } returns ConfigurationSnapshotStatus.READY
+
+            val archivedSnapshot = mockk<ConfigurationSnapshot>()
+            every { archivedSnapshot.name } returns "snapshot-archived"
+            every { archivedSnapshot.status } returns ConfigurationSnapshotStatus.ARCHIVED
+
+            every { client.listSnapshots(any()) } returns
+                mockk {
+                    every { iterator() } returns
+                        listOf(readySnapshot1, readySnapshot2, archivedSnapshot).toMutableList().iterator()
+                }
+
+            val provider = project.providers.ofKt(ListSnapshotsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result shouldContainExactly listOf("snapshot-1", "snapshot-2")
+        }
+
+        test("obtain - returns empty list when no snapshots") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            every { client.listSnapshots(any()) } returns
+                mockk { every { iterator() } returns listOf<ConfigurationSnapshot>().toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListSnapshotsValueSource::class) {
+                parameters.service.set(service)
+            }
+            val result = provider.get()
+
+            result.shouldBeEmpty()
+        }
+
+        test("obtain - applies name filter when set") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val snapshot = mockk<ConfigurationSnapshot>()
+            every { snapshot.name } returns "prod-snapshot"
+            every { snapshot.status } returns ConfigurationSnapshotStatus.READY
+
+            every { client.listSnapshots(any()) } returns
+                mockk { every { iterator() } returns listOf(snapshot).toMutableList().iterator() }
+
+            val provider = project.providers.ofKt(ListSnapshotsValueSource::class) {
+                parameters.service.set(service)
+                parameters.nameFilter.set("prod*")
+            }
+            val result = provider.get()
+
+            result shouldContainExactly listOf("prod-snapshot")
+        }
+    }
+}
+
+

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/MockAppConfigurationAsyncClientBuildService.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/MockAppConfigurationAsyncClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationAsyncClient
+
+/**
+ * Test-only [AppConfigurationAsyncClientBuildService] that returns a pre-supplied mock [ConfigurationAsyncClient].
+ *
+ * Set [mockClient] before registering this service in tests.
+ */
+abstract class MockAppConfigurationAsyncClientBuildService : AppConfigurationAsyncClientBuildService() {
+    override fun createClient(): ConfigurationAsyncClient =
+        checkNotNull(mockClient) { "MockAppConfigurationAsyncClientBuildService.mockClient must be set before use" }
+
+    companion object {
+        var mockClient: ConfigurationAsyncClient? = null
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/MockAppConfigurationClientBuildService.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/MockAppConfigurationClientBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+
+/**
+ * Test-only [AppConfigurationClientBuildService] that returns a pre-supplied mock [ConfigurationClient].
+ *
+ * Set [mockClient] before registering this service in tests.
+ */
+abstract class MockAppConfigurationClientBuildService : AppConfigurationClientBuildService() {
+    override fun createClient(): ConfigurationClient =
+        checkNotNull(mockClient) { "MockAppConfigurationClientBuildService.mockClient must be set before use" }
+
+    companion object {
+        var mockClient: ConfigurationClient? = null
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/MockAppConfigurationManagerBuildService.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/MockAppConfigurationManagerBuildService.kt
@@ -1,0 +1,17 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.resourcemanager.appconfiguration.AppConfigurationManager
+
+/**
+ * Test-only [AppConfigurationManagerBuildService] that returns a pre-supplied mock [AppConfigurationManager].
+ *
+ * Set [mockClient] before registering this service in tests.
+ */
+abstract class MockAppConfigurationManagerBuildService : AppConfigurationManagerBuildService() {
+    override fun createClient(): AppConfigurationManager =
+        checkNotNull(mockClient) { "MockAppConfigurationManagerBuildService.mockClient must be set before use" }
+
+    companion object {
+        var mockClient: AppConfigurationManager? = null
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ProviderFactoryExtensions.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/ProviderFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+// Workaround: under the kotlin-gradle-library convention, Kotlin does not treat Gradle's
+// Action<in T> as T.() -> Unit, so providers.of(...) { parameters.X } fails to resolve.
+internal fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit
+) = of(valueSourceType, configuration)

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/RecoverSnapshotActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/RecoverSnapshotActionSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSnapshot
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class RecoverSnapshotActionSpec : FunSpec() {
+    init {
+        test("execute - recovers snapshot by name") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val snapshotNameSlot = slot<String>()
+            every { client.recoverSnapshot(capture(snapshotNameSlot)) } returns mockk<ConfigurationSnapshot>()
+
+            val params = project.objects.newInstance<RecoverSnapshotAction.Parameters>()
+            params.service.set(service)
+            params.snapshotName.set("snapshot-recover")
+
+            val action = object : RecoverSnapshotAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            snapshotNameSlot.captured shouldBe "snapshot-recover"
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetConfigurationSettingActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetConfigurationSettingActionSpec.kt
@@ -1,0 +1,98 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class SetConfigurationSettingActionSpec : FunSpec() {
+    init {
+        test("execute - sets key and value") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetConfigurationSettingAction.Parameters>()
+            params.service.set(service)
+            params.key.set("app.name")
+            params.value.set("my-app")
+
+            val action = object : SetConfigurationSettingAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            settingSlot.captured.getKey() shouldBe "app.name"
+            settingSlot.captured.getValue() shouldBe "my-app"
+        }
+
+        test("execute - sets label when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetConfigurationSettingAction.Parameters>()
+            params.service.set(service)
+            params.key.set("app.config")
+            params.value.set("prod-value")
+            params.label.set("prod")
+
+            val action = object : SetConfigurationSettingAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            settingSlot.captured.getKey() shouldBe "app.config"
+            settingSlot.captured.getValue() shouldBe "prod-value"
+            settingSlot.captured.getLabel() shouldBe "prod"
+        }
+
+        test("execute - sets content type when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetConfigurationSettingAction.Parameters>()
+            params.service.set(service)
+            params.key.set("app.json")
+            params.value.set("{\"timeout\": 30}")
+            params.contentType.set("application/json")
+
+            val action = object : SetConfigurationSettingAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            settingSlot.captured.getKey() shouldBe "app.json"
+            settingSlot.captured.getValue() shouldBe "{\"timeout\": 30}"
+            settingSlot.captured.getContentType() shouldBe "application/json"
+        }
+    }
+}

--- a/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetFeatureFlagActionSpec.kt
+++ b/cores/azure-app-configuration-base/src/test/kotlin/com/kelvsyc/gradle/azure/appconfiguration/SetFeatureFlagActionSpec.kt
@@ -1,0 +1,118 @@
+package com.kelvsyc.gradle.azure.appconfiguration
+
+import com.azure.data.appconfiguration.ConfigurationClient
+import com.azure.data.appconfiguration.models.ConfigurationSetting
+import com.azure.data.appconfiguration.models.FeatureFlagConfigurationSetting
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class SetFeatureFlagActionSpec : FunSpec() {
+    init {
+        test("execute - sets enabled flag") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetFeatureFlagAction.Parameters>()
+            params.service.set(service)
+            params.featureName.set("new-dashboard")
+            params.enabled.set(true)
+
+            val action = object : SetFeatureFlagAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val captured = settingSlot.captured as FeatureFlagConfigurationSetting
+            captured.isEnabled shouldBe true
+        }
+
+        test("execute - sets disabled flag") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetFeatureFlagAction.Parameters>()
+            params.service.set(service)
+            params.featureName.set("legacy-api")
+            params.enabled.set(false)
+
+            val action = object : SetFeatureFlagAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val captured = settingSlot.captured as FeatureFlagConfigurationSetting
+            captured.isEnabled shouldBe false
+        }
+
+        test("execute - sets label when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetFeatureFlagAction.Parameters>()
+            params.service.set(service)
+            params.featureName.set("canary-deploy")
+            params.enabled.set(true)
+            params.label.set("beta")
+
+            val action = object : SetFeatureFlagAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            settingSlot.captured.label shouldBe "beta"
+        }
+
+        test("execute - sets description when present") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<ConfigurationClient>()
+            MockAppConfigurationClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "appconfig",
+                MockAppConfigurationClientBuildService::class
+            )
+            val settingSlot = slot<ConfigurationSetting>()
+            every { client.setConfigurationSetting(capture(settingSlot)) } returns mockk()
+
+            val params = project.objects.newInstance<SetFeatureFlagAction.Parameters>()
+            params.service.set(service)
+            params.featureName.set("analytics")
+            params.enabled.set(true)
+            params.description.set("Enable enhanced analytics dashboard")
+
+            val action = object : SetFeatureFlagAction() {
+                override fun getParameters() = params
+            }
+            action.execute()
+
+            val captured = settingSlot.captured as FeatureFlagConfigurationSetting
+            captured.description shouldBe "Enable enhanced analytics dashboard"
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ azure-messaging-servicebus = { module = "com.azure:azure-messaging-servicebus" }
 azure-storage-common = { module = "com.azure:azure-storage-common" } # version from BOM 'azure-sdk-bom'
 azure-containers-containerregistry = { module = "com.azure:azure-containers-containerregistry" } # version from BOM 'azure-sdk-bom'
 azure-resourcemanager-appservice = { module = "com.azure.resourcemanager:azure-resourcemanager-appservice" } # version from BOM 'azure-sdk-bom'
+azure-data-appconfiguration = { module = "com.azure:azure-data-appconfiguration" } # version from BOM 'azure-sdk-bom'
+azure-resourcemanager-appconfiguration = "com.azure.resourcemanager:azure-resourcemanager-appconfiguration:1.2.0-beta.1"
 aws-appconfig-java = { module = "software.amazon.awssdk:appconfig" } # version from BOM 'aws-java-sdk-bom'
 aws-appconfigdata-java = { module = "software.amazon.awssdk:appconfigdata" } # version from BOM 'aws-java-sdk-bom'
 aws-auth-java = { module = "software.amazon.awssdk:auth" } # version from BOM 'aws-java-sdk-bom'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ azure-storage-common = { module = "com.azure:azure-storage-common" } # version f
 azure-containers-containerregistry = { module = "com.azure:azure-containers-containerregistry" } # version from BOM 'azure-sdk-bom'
 azure-resourcemanager-appservice = { module = "com.azure.resourcemanager:azure-resourcemanager-appservice" } # version from BOM 'azure-sdk-bom'
 azure-data-appconfiguration = { module = "com.azure:azure-data-appconfiguration" } # version from BOM 'azure-sdk-bom'
-azure-resourcemanager-appconfiguration = "com.azure.resourcemanager:azure-resourcemanager-appconfiguration:1.2.0-beta.1"
+azure-resourcemanager-appconfiguration = { module = "com.azure.resourcemanager:azure-resourcemanager-appconfiguration", version = "1.2.0-beta.1" } # not in azure-sdk-bom; pinned explicitly
 aws-appconfig-java = { module = "software.amazon.awssdk:appconfig" } # version from BOM 'aws-java-sdk-bom'
 aws-appconfigdata-java = { module = "software.amazon.awssdk:appconfigdata" } # version from BOM 'aws-java-sdk-bom'
 aws-auth-java = { module = "software.amazon.awssdk:auth" } # version from BOM 'aws-java-sdk-bom'

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
         api(libs.pkl.core)
         api(libs.vault.java.driver)
         api(libs.woodstox)
-        api(libs.azure.data.appconfiguration)
         api(libs.azure.resourcemanager.appconfiguration)
     }
 }

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -31,5 +31,7 @@ dependencies {
         api(libs.pkl.core)
         api(libs.vault.java.driver)
         api(libs.woodstox)
+        api(libs.azure.data.appconfiguration)
+        api(libs.azure.resourcemanager.appconfiguration)
     }
 }


### PR DESCRIPTION
## Summary

- Adds `azure-app-configuration-base` — a new Gradle plugin component for Azure App Configuration integration
- Provides 3 BuildServices (sync/async data-plane + ARM management-plane), 7 ValueSources (key-values, feature flags, snapshots, store listing/lookup), and 9 WorkActions (CRUD for settings/feature flags, snapshot lifecycle, store create/delete)
- Key Vault references are intentionally surfaced as `null` (never resolved at configuration time) to prevent secrets from entering the Gradle configuration cache
- Adds `azure-data-appconfiguration` and `azure-resourcemanager-appconfiguration` to the version catalog and platform constraints; includes a component README and root README entry

## Test Plan
- [ ] `./gradlew :azure-app-configuration-base:test` — 47 unit tests across all ValueSources and WorkActions
- [ ] `./gradlew :azure-app-configuration-base:detekt` — no violations
- [ ] `./gradlew :azure-app-configuration-base:build` — full build including Dokka docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)