### PR TITLE
feat: add aws-appconfig-kotlin-base component

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ since the two AWS SDKs are distinct libraries:
 
 | AWS Service | Java | Kotlin |
 |-------------|------|--------|
-| AppConfig | `aws-appconfig-java-base` | — |
+| AppConfig | `aws-appconfig-java-base` | `aws-appconfig-kotlin-base` |
 | S3 | `aws-s3-java-base` | `aws-s3-kotlin-base` |
 | SQS | `aws-sqs-java-base` | `aws-sqs-kotlin-base` |
 | SNS | `aws-sns-java-base` | `aws-sns-kotlin-base` |

--- a/cores/aws-appconfig-kotlin-base/README.md
+++ b/cores/aws-appconfig-kotlin-base/README.md
@@ -1,0 +1,133 @@
+# aws-appconfig-kotlin-base
+
+Gradle plugin providing AWS AppConfig integration via the AWS Kotlin SDK.
+
+## Overview
+
+Offers two independent halves:
+
+- **Pull** — retrieve the currently deployed configuration at build time, as a string `ValueSource` or a materialized file task.
+- **Push** — `DefaultTask` building blocks for lifecycle plugins to manage AppConfig resources and trigger deployments.
+
+## BuildServices
+
+| Service | Purpose |
+|---|---|
+| `AppConfigClientBuildService` | Wraps `AppConfigClient` for management operations |
+| `AppConfigDataClientBuildService` | Wraps `AppConfigDataClient`; manages session tokens; exposes `fetchConfiguration()` |
+
+Register both via `gradle.sharedServices.registerIfAbsent(...)`, configured with `AwsBuildServiceParams` (region + credentials).
+
+`AppConfigDataClientBuildService.fetchConfiguration()` is a `suspend` function. Calling it from a task `@TaskAction` requires `runBlocking { }`.
+
+## Pull
+
+### GetConfigurationValueSource
+
+Returns the current deployed configuration as a `String`:
+
+```kotlin
+val config = providers.of(GetConfigurationValueSource::class) {
+    parameters.service.set(appConfigDataService)
+    parameters.applicationIdentifier.set("my-app")
+    parameters.environmentIdentifier.set("production")
+    parameters.configurationProfileIdentifier.set("my-profile")
+}
+```
+
+Returns `null` when the configuration is unavailable or empty. Errors are logged as warnings.
+
+Extend `AbstractGetConfigurationValueSource<T, P>` and override `convert(ByteArray): T?` for custom return types.
+
+### DownloadConfigurationTask
+
+Writes the current deployed configuration to a file:
+
+```kotlin
+tasks.register<DownloadConfigurationTask>("downloadConfig") {
+    service.set(appConfigDataService)
+    applicationIdentifier.set("my-app")
+    environmentIdentifier.set("production")
+    configurationProfileIdentifier.set("my-profile")
+    outputFile.set(layout.buildDirectory.file("config/app.json"))
+}
+```
+
+## Push
+
+### Resource Setup Tasks
+
+One task each for Create/Update/Delete of **Application**, **Environment**, and **ConfigurationProfile**:
+
+| Task | Required properties | Optional properties |
+|---|---|---|
+| `CreateApplicationTask` | `applicationName` | `applicationDescription` |
+| `UpdateApplicationTask` | `applicationId` | `applicationName`, `applicationDescription` |
+| `DeleteApplicationTask` | `applicationId` | — |
+| `CreateEnvironmentTask` | `applicationId`, `environmentName` | `environmentDescription` |
+| `UpdateEnvironmentTask` | `applicationId`, `environmentId` | `environmentName`, `environmentDescription` |
+| `DeleteEnvironmentTask` | `applicationId`, `environmentId` | — |
+| `CreateConfigurationProfileTask` | `applicationId`, `profileName`, `locationUri`, `type` | `profileDescription` |
+| `UpdateConfigurationProfileTask` | `applicationId`, `configurationProfileId` | `profileName`, `profileDescription` |
+| `DeleteConfigurationProfileTask` | `applicationId`, `configurationProfileId` | — |
+
+> **Note:** Property names differ from the Java base because `DefaultTask` inherits `getName(): String` and `getDescription(): String` from the Gradle `Task` interface. Using `name` or `description` as abstract property names on a `DefaultTask` subclass causes a JVM method signature conflict that prevents Gradle from generating the concrete subclass. The entity-scoped names (e.g. `applicationName`, `profileDescription`) avoid this and are also more explicit for the caller.
+
+### Deployment Lifecycle Tasks
+
+| Task | Purpose |
+|---|---|
+| `CreateHostedConfigurationVersionTask` | Creates a hosted configuration version; writes version number to `versionNumberFile` |
+| `StartDeploymentTask` | Starts a deployment (see dual-mode behaviour below) |
+| `WaitForDeploymentTask` | Waits via SDK waiter until deployment reaches a terminal state; throws `GradleException` on failure |
+| `StopDeploymentTask` | Triggers rollback of an in-progress deployment |
+
+#### `StartDeploymentTask` dual-mode
+
+When `deploymentNumberFile` is **set**: the task starts the deployment, writes the deployment number to the file, and returns immediately. Use this when you need to perform other work between starting and waiting.
+
+When `deploymentNumberFile` is **absent**: the task starts the deployment and immediately waits for it to reach a terminal state using the SDK's built-in `waitUntilDeploymentComplete` waiter.
+
+A typical lifecycle plugin wires these tasks:
+
+```kotlin
+// Step 1 — create a hosted configuration version
+tasks.register<CreateHostedConfigurationVersionTask>("createVersion") {
+    service.set(appConfigService)
+    applicationId.set("my-app")
+    configurationProfileId.set("my-profile")
+    content.set(file("config.json").readText())
+    contentType.set("application/json")
+    versionNumberFile.set(layout.buildDirectory.file("appconfig/version.txt"))
+}
+
+// Step 2 — deploy and wait inline
+tasks.register<StartDeploymentTask>("deploy") {
+    dependsOn("createVersion")
+    service.set(appConfigService)
+    applicationId.set("my-app")
+    environmentId.set("production")
+    configurationProfileId.set("my-profile")
+    deploymentStrategyId.set("AppConfig.AllAtOnce")
+    configurationVersion.set(
+        layout.buildDirectory.file("appconfig/version.txt").map { it.asFile.readText().trim() }
+    )
+    // deploymentNumberFile not set → waits for completion inline
+}
+```
+
+## Why no WorkActions
+
+The AWS Kotlin SDK exposes all service calls as `suspend` functions. A `WorkAction` that wraps a single suspend call reduces to:
+
+```kotlin
+override fun execute() {
+    runBlocking { singleSuspendCall() }
+}
+```
+
+This adds ceremony with no benefit: no return values, no isolation beyond what coroutines already provide, and no concurrency advantage (Gradle's task graph handles cross-task concurrency; coroutines handle within-task concurrency). WorkActions were designed for blocking Java SDK calls to avoid tying up Gradle's worker thread pool — that problem doesn't exist with a coroutine-based SDK.
+
+Accordingly, this component exposes `DefaultTask` subclasses instead. Plugin authors needing compound operations should compose via Gradle task dependencies (sequential) or call `service.get().getClient()` directly inside a `runBlocking { coroutineScope { } }` block (parallel).
+
+Existing Kotlin SDK bases in this suite (`aws-secrets-manager-kotlin-base`, `aws-ssm-kotlin-base`, `aws-s3-kotlin-base`, and others) that currently use WorkActions are candidates for the same migration.

--- a/cores/aws-appconfig-kotlin-base/README.md
+++ b/cores/aws-appconfig-kotlin-base/README.md
@@ -129,5 +129,3 @@ override fun execute() {
 This adds ceremony with no benefit: no return values, no isolation beyond what coroutines already provide, and no concurrency advantage (Gradle's task graph handles cross-task concurrency; coroutines handle within-task concurrency). WorkActions were designed for blocking Java SDK calls to avoid tying up Gradle's worker thread pool — that problem doesn't exist with a coroutine-based SDK.
 
 Accordingly, this component exposes `DefaultTask` subclasses instead. Plugin authors needing compound operations should compose via Gradle task dependencies (sequential) or call `service.get().getClient()` directly inside a `runBlocking { coroutineScope { } }` block (parallel).
-
-Existing Kotlin SDK bases in this suite (`aws-secrets-manager-kotlin-base`, `aws-ssm-kotlin-base`, `aws-s3-kotlin-base`, and others) that currently use WorkActions are candidates for the same migration.

--- a/cores/aws-appconfig-kotlin-base/build.gradle.kts
+++ b/cores/aws-appconfig-kotlin-base/build.gradle.kts
@@ -1,0 +1,27 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-gradle-library")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("AppConfig Kotlin Base")
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:clients-base")
+    api("com.kelvsyc.gradle:aws-kotlin-extensions")
+
+    api(libs.aws.appconfig.kotlin)
+    api(libs.aws.appconfigdata.kotlin)
+    implementation(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+}

--- a/cores/aws-appconfig-kotlin-base/build.gradle.kts
+++ b/cores/aws-appconfig-kotlin-base/build.gradle.kts
@@ -23,5 +23,6 @@ dependencies {
 }
 
 tasks.test {
+    // FIXME https://github.com/gradle/gradle/issues/18647
     jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }

--- a/cores/aws-appconfig-kotlin-base/settings.gradle.kts
+++ b/cores/aws-appconfig-kotlin-base/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../clients-base")
+includeBuild("../aws-kotlin-extensions")

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AbstractGetConfigurationValueSource.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AbstractGetConfigurationValueSource.kt
@@ -1,0 +1,57 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.tasks.Internal
+
+/**
+ * Abstract [ValueSource] base for retrieving a deployed AppConfig configuration and converting it
+ * to a value of type [T].
+ *
+ * Subclasses implement [convert] to map the raw configuration bytes to the desired type.
+ * Returns `null` when the configuration is unavailable or the byte array is empty.
+ *
+ * @param T the non-null value type returned by [obtain].
+ * @param P the parameters type, which must extend [Parameters].
+ */
+abstract class AbstractGetConfigurationValueSource<T : Any, P : AbstractGetConfigurationValueSource.Parameters> :
+    ValueSource<T, P> {
+
+    /**
+     * Common parameters for all [AbstractGetConfigurationValueSource] implementations.
+     */
+    interface Parameters : ValueSourceParameters {
+        /** The build service managing the AppConfig Data client. */
+        @get:Internal
+        val service: Property<AppConfigDataClientBuildService>
+
+        /** Application name or ID. */
+        val applicationIdentifier: Property<String>
+
+        /** Environment name or ID. */
+        val environmentIdentifier: Property<String>
+
+        /** Configuration profile name or ID. */
+        val configurationProfileIdentifier: Property<String>
+    }
+
+    /**
+     * Converts raw configuration bytes to [T].
+     *
+     * @return the converted value, or `null` if conversion is not possible.
+     */
+    protected abstract fun convert(bytes: ByteArray): T?
+
+    override fun obtain(): T? {
+        val bytes = runBlocking {
+            parameters.service.get().fetchConfiguration(
+                parameters.applicationIdentifier.get(),
+                parameters.environmentIdentifier.get(),
+                parameters.configurationProfileIdentifier.get(),
+            )
+        } ?: return null
+        return if (bytes.isEmpty()) null else convert(bytes)
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigClientBuildService.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigClientBuildService.kt
@@ -1,0 +1,22 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
+
+/**
+ * Build service managing an [AppConfigClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent],
+ * configuring the inherited [AwsBuildServiceParams] using the supplied extension functions
+ * (e.g. [com.kelvsyc.gradle.aws.kotlin.defaultCredentials],
+ * [com.kelvsyc.gradle.aws.kotlin.staticCredentials]). The same registration can then be shared
+ * with tasks and value sources via a `Property<AppConfigClientBuildService>` parameter.
+ */
+abstract class AppConfigClientBuildService :
+    AbstractAwsKotlinClientBuildService<AppConfigClient, AwsBuildServiceParams>() {
+    override fun createClient(): AppConfigClient = AppConfigClient {
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigDataClientBuildService.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigDataClientBuildService.kt
@@ -6,6 +6,8 @@ import aws.sdk.kotlin.services.appconfigdata.model.GetLatestConfigurationRequest
 import aws.sdk.kotlin.services.appconfigdata.model.StartConfigurationSessionRequest
 import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
 import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.gradle.api.logging.Logging
 import java.util.concurrent.ConcurrentHashMap
 
@@ -31,10 +33,29 @@ abstract class AppConfigDataClientBuildService :
     )
 
     private val sessionTokens = ConcurrentHashMap<SessionKey, String>()
+    private val sessionMutex = Mutex()
 
     override fun createClient(): AppConfigDataClient = AppConfigDataClient {
         resolveRegion()?.let { region = it }
         resolveCredentialsProvider()?.let { credentialsProvider = it }
+    }
+
+    private suspend fun getOrCreateToken(key: SessionKey): String? {
+        val cached = sessionTokens[key]
+        if (cached != null) return cached
+        return sessionMutex.withLock {
+            sessionTokens[key] ?: run {
+                val newToken = getClient().startConfigurationSession(
+                    StartConfigurationSessionRequest {
+                        applicationIdentifier = key.applicationIdentifier
+                        environmentIdentifier = key.environmentIdentifier
+                        configurationProfileIdentifier = key.configurationProfileIdentifier
+                    }
+                ).initialConfigurationToken
+                if (newToken != null) sessionTokens[key] = newToken
+                newToken
+            }
+        }
     }
 
     /**
@@ -43,7 +64,8 @@ abstract class AppConfigDataClientBuildService :
      * Manages the AppConfig Data session-token protocol internally. Starts a new session on the
      * first call for a given [applicationIdentifier]/[environmentIdentifier]/
      * [configurationProfileIdentifier] combination, then reuses the cached token on subsequent
-     * calls within the same build.
+     * calls within the same build. Session creation is serialized via a mutex to prevent duplicate
+     * sessions under concurrent access.
      *
      * @return the configuration content as a [ByteArray], or `null` if the request fails.
      */
@@ -54,17 +76,7 @@ abstract class AppConfigDataClientBuildService :
     ): ByteArray? {
         return try {
             val key = SessionKey(applicationIdentifier, environmentIdentifier, configurationProfileIdentifier)
-            val token = sessionTokens[key] ?: run {
-                val newToken = getClient().startConfigurationSession(
-                    StartConfigurationSessionRequest {
-                        this.applicationIdentifier = applicationIdentifier
-                        this.environmentIdentifier = environmentIdentifier
-                        this.configurationProfileIdentifier = configurationProfileIdentifier
-                    }
-                ).initialConfigurationToken ?: return null
-                sessionTokens[key] = newToken
-                newToken
-            }
+            val token = getOrCreateToken(key) ?: return null
             val response = getClient().getLatestConfiguration(
                 GetLatestConfigurationRequest {
                     configurationToken = token

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigDataClientBuildService.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigDataClientBuildService.kt
@@ -1,0 +1,80 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfigdata.AppConfigDataClient
+import aws.sdk.kotlin.services.appconfigdata.model.AppConfigDataException
+import aws.sdk.kotlin.services.appconfigdata.model.GetLatestConfigurationRequest
+import aws.sdk.kotlin.services.appconfigdata.model.StartConfigurationSessionRequest
+import com.kelvsyc.gradle.aws.kotlin.AbstractAwsKotlinClientBuildService
+import com.kelvsyc.gradle.aws.kotlin.AwsBuildServiceParams
+import org.gradle.api.logging.Logging
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Build service managing an [AppConfigDataClient] instance with session-token caching.
+ *
+ * Wraps the AppConfig Data API's two-step session protocol. Call [fetchConfiguration] to retrieve
+ * the current deployed configuration for a given application, environment, and configuration
+ * profile. Session tokens are cached per (application, environment, profile) triple for the build
+ * lifetime, so repeated calls within the same build reuse the existing session.
+ */
+abstract class AppConfigDataClientBuildService :
+    AbstractAwsKotlinClientBuildService<AppConfigDataClient, AwsBuildServiceParams>() {
+
+    companion object {
+        private val logger = Logging.getLogger(AppConfigDataClientBuildService::class.java)
+    }
+
+    private data class SessionKey(
+        val applicationIdentifier: String,
+        val environmentIdentifier: String,
+        val configurationProfileIdentifier: String,
+    )
+
+    private val sessionTokens = ConcurrentHashMap<SessionKey, String>()
+
+    override fun createClient(): AppConfigDataClient = AppConfigDataClient {
+        resolveRegion()?.let { region = it }
+        resolveCredentialsProvider()?.let { credentialsProvider = it }
+    }
+
+    /**
+     * Retrieves the current deployed configuration for the given identifiers.
+     *
+     * Manages the AppConfig Data session-token protocol internally. Starts a new session on the
+     * first call for a given [applicationIdentifier]/[environmentIdentifier]/
+     * [configurationProfileIdentifier] combination, then reuses the cached token on subsequent
+     * calls within the same build.
+     *
+     * @return the configuration content as a [ByteArray], or `null` if the request fails.
+     */
+    open suspend fun fetchConfiguration(
+        applicationIdentifier: String,
+        environmentIdentifier: String,
+        configurationProfileIdentifier: String,
+    ): ByteArray? {
+        return try {
+            val key = SessionKey(applicationIdentifier, environmentIdentifier, configurationProfileIdentifier)
+            val token = sessionTokens[key] ?: run {
+                val newToken = getClient().startConfigurationSession(
+                    StartConfigurationSessionRequest {
+                        this.applicationIdentifier = applicationIdentifier
+                        this.environmentIdentifier = environmentIdentifier
+                        this.configurationProfileIdentifier = configurationProfileIdentifier
+                    }
+                ).initialConfigurationToken ?: return null
+                sessionTokens[key] = newToken
+                newToken
+            }
+            val response = getClient().getLatestConfiguration(
+                GetLatestConfigurationRequest {
+                    configurationToken = token
+                }
+            )
+            sessionTokens[key] = response.nextPollConfigurationToken ?: token
+            response.configuration
+        } catch (e: AppConfigDataException) {
+            logger.warn("Unable to fetch AppConfig configuration for $applicationIdentifier/$environmentIdentifier/$configurationProfileIdentifier", e)
+            null
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateApplicationTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateApplicationTask.kt
@@ -1,0 +1,39 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.createApplication
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that creates an AppConfig application.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class CreateApplicationTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** Name of the application to create. */
+    @get:Input
+    abstract val applicationName: Property<String>
+
+    /** Optional description of the application. */
+    @get:Optional
+    @get:Input
+    abstract val applicationDescription: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().createApplication {
+            name = applicationName.get()
+            if (applicationDescription.isPresent) description = applicationDescription.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateConfigurationProfileTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateConfigurationProfileTask.kt
@@ -1,0 +1,54 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.createConfigurationProfile
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that creates an AppConfig configuration profile within an application.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class CreateConfigurationProfileTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application to create the configuration profile in. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Name of the configuration profile to create. */
+    @get:Input
+    abstract val profileName: Property<String>
+
+    /** URI pointing to the configuration data location. */
+    @get:Input
+    abstract val locationUri: Property<String>
+
+    /** Type of configuration profile (e.g., AWS.AppConfig.FeatureFlags or AWS.Freeform). */
+    @get:Input
+    abstract val type: Property<String>
+
+    /** Optional description of the configuration profile. */
+    @get:Optional
+    @get:Input
+    abstract val profileDescription: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().createConfigurationProfile {
+            applicationId = this@CreateConfigurationProfileTask.applicationId.get()
+            name = profileName.get()
+            locationUri = this@CreateConfigurationProfileTask.locationUri.get()
+            type = this@CreateConfigurationProfileTask.type.get()
+            if (profileDescription.isPresent) description = profileDescription.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateEnvironmentTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateEnvironmentTask.kt
@@ -1,0 +1,44 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.createEnvironment
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that creates an AppConfig environment within an application.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class CreateEnvironmentTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application to create the environment in. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Name of the environment to create. */
+    @get:Input
+    abstract val environmentName: Property<String>
+
+    /** Optional description of the environment. */
+    @get:Optional
+    @get:Input
+    abstract val environmentDescription: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().createEnvironment {
+            applicationId = this@CreateEnvironmentTask.applicationId.get()
+            name = environmentName.get()
+            if (environmentDescription.isPresent) description = environmentDescription.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateHostedConfigurationVersionTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateHostedConfigurationVersionTask.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.createHostedConfigurationVersion
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Task that creates a hosted configuration version in AWS AppConfig.
+ *
+ * Uploads configuration content to AppConfig as a new version and writes the assigned
+ * version number to a file for use in downstream deployment tasks.
+ */
+abstract class CreateHostedConfigurationVersionTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** Application ID in AWS AppConfig. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Configuration profile ID in AWS AppConfig. */
+    @get:Input
+    abstract val configurationProfileId: Property<String>
+
+    /** Configuration content to upload. */
+    @get:Input
+    abstract val content: Property<String>
+
+    /** MIME type of the configuration content (e.g., "application/json"). */
+    @get:Input
+    abstract val contentType: Property<String>
+
+    /** File to write the version number to. */
+    @get:OutputFile
+    abstract val versionNumberFile: RegularFileProperty
+
+    @TaskAction
+    fun execute() = runBlocking {
+        val response = service.get().getClient().createHostedConfigurationVersion {
+            applicationId = this@CreateHostedConfigurationVersionTask.applicationId.get()
+            configurationProfileId = this@CreateHostedConfigurationVersionTask.configurationProfileId.get()
+            content = this@CreateHostedConfigurationVersionTask.content.get().toByteArray()
+            contentType = this@CreateHostedConfigurationVersionTask.contentType.get()
+        }
+        val version = checkNotNull(response.versionNumber) { "No version number in response" }
+        versionNumberFile.get().asFile.writeText(version.toString())
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteApplicationTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteApplicationTask.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.deleteApplication
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that deletes an AppConfig application.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class DeleteApplicationTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application to delete. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().deleteApplication {
+            applicationId = this@DeleteApplicationTask.applicationId.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteConfigurationProfileTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteConfigurationProfileTask.kt
@@ -1,0 +1,37 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.deleteConfigurationProfile
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that deletes an AppConfig configuration profile.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class DeleteConfigurationProfileTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application containing the configuration profile. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** ID of the configuration profile to delete. */
+    @get:Input
+    abstract val configurationProfileId: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().deleteConfigurationProfile {
+            applicationId = this@DeleteConfigurationProfileTask.applicationId.get()
+            configurationProfileId = this@DeleteConfigurationProfileTask.configurationProfileId.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteEnvironmentTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteEnvironmentTask.kt
@@ -1,0 +1,37 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.deleteEnvironment
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that deletes an AppConfig environment.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class DeleteEnvironmentTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application containing the environment. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** ID of the environment to delete. */
+    @get:Input
+    abstract val environmentId: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().deleteEnvironment {
+            applicationId = this@DeleteEnvironmentTask.applicationId.get()
+            environmentId = this@DeleteEnvironmentTask.environmentId.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DownloadConfigurationTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DownloadConfigurationTask.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Task that downloads the current AppConfig configuration to a local file.
+ *
+ * Retrieves the deployed configuration for the specified application, environment,
+ * and configuration profile, writing it to the task's output file. Uses the
+ * [AppConfigDataClientBuildService] which manages the AppConfig Data session protocol.
+ */
+abstract class DownloadConfigurationTask : DefaultTask() {
+
+    /** The build service managing the AppConfig Data client. */
+    @get:Internal
+    abstract val service: Property<AppConfigDataClientBuildService>
+
+    /** Application identifier in AWS AppConfig. */
+    @get:Input
+    abstract val applicationIdentifier: Property<String>
+
+    /** Environment identifier in AWS AppConfig. */
+    @get:Input
+    abstract val environmentIdentifier: Property<String>
+
+    /** Configuration profile identifier in AWS AppConfig. */
+    @get:Input
+    abstract val configurationProfileIdentifier: Property<String>
+
+    /** File to write the configuration content to. */
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun execute() = runBlocking {
+        val bytes = service.get().fetchConfiguration(
+            applicationIdentifier.get(),
+            environmentIdentifier.get(),
+            configurationProfileIdentifier.get(),
+        ) ?: throw GradleException(
+            "Failed to fetch configuration for " +
+                "${applicationIdentifier.get()}/${environmentIdentifier.get()}/" +
+                configurationProfileIdentifier.get()
+        )
+        outputFile.get().asFile.writeBytes(bytes)
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/GetConfigurationValueSource.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/GetConfigurationValueSource.kt
@@ -1,0 +1,21 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import org.gradle.api.provider.ValueSource
+
+/**
+ * [ValueSource] implementation that retrieves the current deployed AppConfig configuration as a
+ * UTF-8 decoded [String].
+ *
+ * Returns `null` when the configuration is unavailable or empty. Errors are logged as warnings
+ * and result in a `null` return rather than a thrown exception.
+ */
+abstract class GetConfigurationValueSource :
+    AbstractGetConfigurationValueSource<String, GetConfigurationValueSource.Parameters>() {
+
+    /**
+     * Parameters for [GetConfigurationValueSource].
+     */
+    interface Parameters : AbstractGetConfigurationValueSource.Parameters
+
+    override fun convert(bytes: ByteArray): String = bytes.toString(Charsets.UTF_8)
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StartDeploymentTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StartDeploymentTask.kt
@@ -1,0 +1,109 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.AppConfigException
+import aws.sdk.kotlin.services.appconfig.startDeployment
+import aws.sdk.kotlin.services.appconfig.waiters.waitUntilDeploymentComplete
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+/**
+ * Task that starts an AppConfig deployment.
+ *
+ * Initiates a deployment of a configuration version to an AppConfig environment.
+ * Optionally waits for the deployment to complete. When [deploymentNumberFile] is
+ * configured, the deployment ID is written to the file and the task returns
+ * immediately. When absent, the task waits for the deployment to reach a terminal state.
+ */
+@DisableCachingByDefault(because = "Communicates with AWS AppConfig; result depends on external state")
+abstract class StartDeploymentTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** Application ID in AWS AppConfig. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Environment ID in AWS AppConfig. */
+    @get:Input
+    abstract val environmentId: Property<String>
+
+    /** Configuration profile ID in AWS AppConfig. */
+    @get:Input
+    abstract val configurationProfileId: Property<String>
+
+    /** Deployment strategy ID controlling rollout speed. */
+    @get:Input
+    abstract val deploymentStrategyId: Property<String>
+
+    /** Configuration version to deploy. */
+    @get:Input
+    abstract val configurationVersion: Property<String>
+
+    /** Optional file to write the deployment number to. When absent, waits for completion. */
+    @get:Optional
+    @get:OutputFile
+    abstract val deploymentNumberFile: RegularFileProperty
+
+    @TaskAction
+    fun execute() = runBlocking {
+        val client = service.get().getClient()
+        val response = client.startDeployment {
+            applicationId = this@StartDeploymentTask.applicationId.get()
+            environmentId = this@StartDeploymentTask.environmentId.get()
+            configurationProfileId = this@StartDeploymentTask.configurationProfileId.get()
+            deploymentStrategyId = this@StartDeploymentTask.deploymentStrategyId.get()
+            configurationVersion = this@StartDeploymentTask.configurationVersion.get()
+        }
+        val deploymentNum = checkNotNull(response.deploymentNumber) { "No deployment number in response" }
+        if (deploymentNumberFile.isPresent) {
+            deploymentNumberFile.get().asFile.writeText(deploymentNum.toString())
+        } else {
+            try {
+                awaitDeploymentComplete(
+                    client,
+                    this@StartDeploymentTask.applicationId.get(),
+                    this@StartDeploymentTask.environmentId.get(),
+                    deploymentNum
+                )
+            } catch (e: AppConfigException) {
+                throw GradleException("Deployment $deploymentNum failed or was rolled back", e)
+            }
+        }
+    }
+
+    /**
+     * Waits for the specified deployment to reach a terminal state.
+     *
+     * Protected to allow test overrides via mocking.
+     *
+     * @param client the AppConfig client
+     * @param applicationId the application ID
+     * @param environmentId the environment ID
+     * @param deploymentNumber the deployment number to wait for
+     * @throws AppConfigException if the deployment fails or is rolled back
+     */
+    protected open suspend fun awaitDeploymentComplete(
+        client: AppConfigClient,
+        applicationId: String,
+        environmentId: String,
+        deploymentNumber: Int,
+    ) {
+        client.waitUntilDeploymentComplete {
+            this.applicationId = applicationId
+            this.environmentId = environmentId
+            this.deploymentNumber = deploymentNumber
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StopDeploymentTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StopDeploymentTask.kt
@@ -1,0 +1,46 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.stopDeployment
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that stops an in-progress AppConfig deployment.
+ *
+ * Cancels a deployment that has not yet reached a terminal state.
+ * This is useful for rolling back a problematic deployment or for
+ * cleaning up deployments that are taking too long.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class StopDeploymentTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** Application ID in AWS AppConfig. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Environment ID in AWS AppConfig. */
+    @get:Input
+    abstract val environmentId: Property<String>
+
+    /** Deployment number to stop. */
+    @get:Input
+    abstract val deploymentNumber: Property<Int>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().stopDeployment {
+            applicationId = this@StopDeploymentTask.applicationId.get()
+            environmentId = this@StopDeploymentTask.environmentId.get()
+            deploymentNumber = this@StopDeploymentTask.deploymentNumber.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateApplicationTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateApplicationTask.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.updateApplication
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that updates an AppConfig application.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class UpdateApplicationTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application to update. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Optional new name for the application. */
+    @get:Optional
+    @get:Input
+    abstract val applicationName: Property<String>
+
+    /** Optional new description for the application. */
+    @get:Optional
+    @get:Input
+    abstract val applicationDescription: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().updateApplication {
+            applicationId = this@UpdateApplicationTask.applicationId.get()
+            if (applicationName.isPresent) name = applicationName.get()
+            if (applicationDescription.isPresent) description = applicationDescription.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateConfigurationProfileTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateConfigurationProfileTask.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.updateConfigurationProfile
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that updates an AppConfig configuration profile.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class UpdateConfigurationProfileTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application containing the configuration profile. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** ID of the configuration profile to update. */
+    @get:Input
+    abstract val configurationProfileId: Property<String>
+
+    /** Optional new name for the configuration profile. */
+    @get:Optional
+    @get:Input
+    abstract val profileName: Property<String>
+
+    /** Optional new description for the configuration profile. */
+    @get:Optional
+    @get:Input
+    abstract val profileDescription: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().updateConfigurationProfile {
+            applicationId = this@UpdateConfigurationProfileTask.applicationId.get()
+            configurationProfileId = this@UpdateConfigurationProfileTask.configurationProfileId.get()
+            if (profileName.isPresent) name = profileName.get()
+            if (profileDescription.isPresent) description = profileDescription.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateEnvironmentTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateEnvironmentTask.kt
@@ -1,0 +1,50 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.updateEnvironment
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that updates an AppConfig environment.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class UpdateEnvironmentTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** ID of the application containing the environment. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** ID of the environment to update. */
+    @get:Input
+    abstract val environmentId: Property<String>
+
+    /** Optional new name for the environment. */
+    @get:Optional
+    @get:Input
+    abstract val environmentName: Property<String>
+
+    /** Optional new description for the environment. */
+    @get:Optional
+    @get:Input
+    abstract val environmentDescription: Property<String>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        service.get().getClient().updateEnvironment {
+            applicationId = this@UpdateEnvironmentTask.applicationId.get()
+            environmentId = this@UpdateEnvironmentTask.environmentId.get()
+            if (environmentName.isPresent) name = environmentName.get()
+            if (environmentDescription.isPresent) description = environmentDescription.get()
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/WaitForDeploymentTask.kt
+++ b/cores/aws-appconfig-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/WaitForDeploymentTask.kt
@@ -1,0 +1,81 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.AppConfigException
+import aws.sdk.kotlin.services.appconfig.waiters.waitUntilDeploymentComplete
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+/**
+ * Task that waits for an AppConfig deployment to reach a terminal state.
+ *
+ * Monitors a deployment's progress until it completes successfully or fails.
+ * This task is typically used after [StartDeploymentTask] when the deployment
+ * number has been written to a file and needs to be awaited separately.
+ */
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+abstract class WaitForDeploymentTask : DefaultTask() {
+
+    /** The build service managing the AppConfig client. */
+    @get:Internal
+    abstract val service: Property<AppConfigClientBuildService>
+
+    /** Application ID in AWS AppConfig. */
+    @get:Input
+    abstract val applicationId: Property<String>
+
+    /** Environment ID in AWS AppConfig. */
+    @get:Input
+    abstract val environmentId: Property<String>
+
+    /** Deployment number to wait for. */
+    @get:Input
+    abstract val deploymentNumber: Property<Int>
+
+    @TaskAction
+    fun execute() = runBlocking {
+        try {
+            awaitDeploymentComplete(
+                service.get().getClient(),
+                applicationId.get(),
+                environmentId.get(),
+                deploymentNumber.get()
+            )
+        } catch (e: AppConfigException) {
+            throw GradleException(
+                "Deployment ${deploymentNumber.get()} failed or was rolled back",
+                e
+            )
+        }
+    }
+
+    /**
+     * Waits for the specified deployment to reach a terminal state.
+     *
+     * Protected to allow test overrides via mocking.
+     *
+     * @param client the AppConfig client
+     * @param applicationId the application ID
+     * @param environmentId the environment ID
+     * @param deploymentNumber the deployment number to wait for
+     * @throws AppConfigException if the deployment fails or is rolled back
+     */
+    protected open suspend fun awaitDeploymentComplete(
+        client: AppConfigClient,
+        applicationId: String,
+        environmentId: String,
+        deploymentNumber: Int,
+    ) {
+        client.waitUntilDeploymentComplete {
+            this.applicationId = applicationId
+            this.environmentId = environmentId
+            this.deploymentNumber = deploymentNumber
+        }
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigClientBuildServiceSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigClientBuildServiceSpec.kt
@@ -1,0 +1,23 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class AppConfigClientBuildServiceSpec : FunSpec({
+    test("getClient returns the registered mock client") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+
+        service.get().getClient() shouldBe client
+
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigDataClientBuildServiceSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/AppConfigDataClientBuildServiceSpec.kt
@@ -1,0 +1,95 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfigdata.AppConfigDataClient
+import aws.sdk.kotlin.services.appconfigdata.model.AppConfigDataException
+import aws.sdk.kotlin.services.appconfigdata.model.GetLatestConfigurationResponse
+import aws.sdk.kotlin.services.appconfigdata.model.StartConfigurationSessionResponse
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+internal abstract class StubAppConfigDataClientBuildService : AppConfigDataClientBuildService() {
+    override fun createClient(): AppConfigDataClient = checkNotNull(stubClient) { "stubClient not set" }
+    companion object { var stubClient: AppConfigDataClient? = null }
+}
+
+class AppConfigDataClientBuildServiceSpec : FunSpec({
+    fun buildService(name: String) = ProjectBuilder.builder().build().gradle.sharedServices
+        .registerIfAbsent(name, StubAppConfigDataClientBuildService::class)
+
+    test("fetchConfiguration starts session and returns configuration bytes") {
+        val client = mockk<AppConfigDataClient>()
+        StubAppConfigDataClientBuildService.stubClient = client
+        coEvery { client.startConfigurationSession(any()) } returns StartConfigurationSessionResponse {
+            initialConfigurationToken = "token-1"
+        }
+        coEvery { client.getLatestConfiguration(any()) } returns GetLatestConfigurationResponse {
+            configuration = "config-data".toByteArray()
+            nextPollConfigurationToken = "token-2"
+        }
+
+        val result = runBlocking {
+            buildService("svc-1").get().fetchConfiguration("app", "env", "profile")
+        }
+
+        result shouldNotBe null
+        result!!.toString(Charsets.UTF_8) shouldBe "config-data"
+        StubAppConfigDataClientBuildService.stubClient = null
+    }
+
+    test("fetchConfiguration returns null when initialConfigurationToken is absent") {
+        val client = mockk<AppConfigDataClient>()
+        StubAppConfigDataClientBuildService.stubClient = client
+        coEvery { client.startConfigurationSession(any()) } returns StartConfigurationSessionResponse {
+            initialConfigurationToken = null
+        }
+
+        val result = runBlocking {
+            buildService("svc-2").get().fetchConfiguration("app", "env", "profile")
+        }
+
+        result shouldBe null
+        StubAppConfigDataClientBuildService.stubClient = null
+    }
+
+    test("fetchConfiguration caches the session token across calls") {
+        val client = mockk<AppConfigDataClient>()
+        StubAppConfigDataClientBuildService.stubClient = client
+        coEvery { client.startConfigurationSession(any()) } returns StartConfigurationSessionResponse {
+            initialConfigurationToken = "token-1"
+        }
+        coEvery { client.getLatestConfiguration(any()) } returns GetLatestConfigurationResponse {
+            configuration = "data".toByteArray()
+            nextPollConfigurationToken = "token-2"
+        }
+
+        val service = buildService("svc-3").get()
+        runBlocking {
+            service.fetchConfiguration("app", "env", "profile")
+            service.fetchConfiguration("app", "env", "profile")
+        }
+
+        coVerify(exactly = 1) { client.startConfigurationSession(any()) }
+        coVerify(exactly = 2) { client.getLatestConfiguration(any()) }
+        StubAppConfigDataClientBuildService.stubClient = null
+    }
+
+    test("fetchConfiguration returns null on AppConfigDataException") {
+        val client = mockk<AppConfigDataClient>()
+        StubAppConfigDataClientBuildService.stubClient = client
+        coEvery { client.startConfigurationSession(any()) } throws mockk<AppConfigDataException>()
+
+        val result = runBlocking {
+            buildService("svc-4").get().fetchConfiguration("app", "env", "profile")
+        }
+
+        result shouldBe null
+        StubAppConfigDataClientBuildService.stubClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateApplicationTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateApplicationTaskSpec.kt
@@ -1,0 +1,53 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.CreateApplicationRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateApplicationTaskSpec : FunSpec({
+    test("execute sends correct application name") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.createApplication(any()) } returns mockk()
+
+        val task = project.tasks.create("t", CreateApplicationTask::class.java)
+        task.service.set(service)
+        task.applicationName.set("my-application")
+
+        task.execute()
+
+        coVerify { client.createApplication(any()) }
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("execute sends optional description when set") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<CreateApplicationRequest>()
+        coEvery { client.createApplication(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t2", CreateApplicationTask::class.java)
+        task.service.set(service)
+        task.applicationName.set("my-app")
+        task.applicationDescription.set("my description")
+
+        task.execute()
+
+        requestSlot.captured.name shouldBe "my-app"
+        requestSlot.captured.description shouldBe "my description"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateConfigurationProfileTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateConfigurationProfileTaskSpec.kt
@@ -1,0 +1,60 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.CreateConfigurationProfileRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateConfigurationProfileTaskSpec : FunSpec({
+    test("execute sends correct application id, name, location uri, and type") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.createConfigurationProfile(any()) } returns mockk()
+
+        val task = project.tasks.create("t", CreateConfigurationProfileTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.profileName.set("my-config")
+        task.locationUri.set("hosted")
+        task.type.set("AWS.Freeform")
+
+        task.execute()
+
+        coVerify { client.createConfigurationProfile(any()) }
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("execute sends optional description when set") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<CreateConfigurationProfileRequest>()
+        coEvery { client.createConfigurationProfile(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t2", CreateConfigurationProfileTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-456")
+        task.profileName.set("prod-config")
+        task.locationUri.set("hosted")
+        task.type.set("AWS.AppConfig.FeatureFlags")
+        task.profileDescription.set("production configuration")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-456"
+        requestSlot.captured.name shouldBe "prod-config"
+        requestSlot.captured.description shouldBe "production configuration"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateEnvironmentTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateEnvironmentTaskSpec.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.CreateEnvironmentRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateEnvironmentTaskSpec : FunSpec({
+    test("execute sends correct application id and environment name") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.createEnvironment(any()) } returns mockk()
+
+        val task = project.tasks.create("t", CreateEnvironmentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentName.set("production")
+
+        task.execute()
+
+        coVerify { client.createEnvironment(any()) }
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("execute sends optional description when set") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<CreateEnvironmentRequest>()
+        coEvery { client.createEnvironment(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t2", CreateEnvironmentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-456")
+        task.environmentName.set("staging")
+        task.environmentDescription.set("staging environment")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-456"
+        requestSlot.captured.name shouldBe "staging"
+        requestSlot.captured.description shouldBe "staging environment"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateHostedConfigurationVersionTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/CreateHostedConfigurationVersionTaskSpec.kt
@@ -1,0 +1,40 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.CreateHostedConfigurationVersionResponse
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class CreateHostedConfigurationVersionTaskSpec : FunSpec({
+    test("execute calls SDK and writes version number to file") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.createHostedConfigurationVersion(any()) } returns
+            CreateHostedConfigurationVersionResponse { versionNumber = 42 }
+
+        val outFile = project.layout.buildDirectory.file("version.txt").get().asFile
+        outFile.parentFile.mkdirs()
+
+        val task = project.tasks.create("t", CreateHostedConfigurationVersionTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.configurationProfileId.set("profile-456")
+        task.content.set("{\"key\": \"value\"}")
+        task.contentType.set("application/json")
+        task.versionNumberFile.set(outFile)
+
+        task.execute()
+
+        coVerify { client.createHostedConfigurationVersion(any()) }
+        task.versionNumberFile.get().asFile.readText() shouldBe "42"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteApplicationTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteApplicationTaskSpec.kt
@@ -1,0 +1,32 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.DeleteApplicationRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteApplicationTaskSpec : FunSpec({
+    test("execute sends correct application id") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<DeleteApplicationRequest>()
+        coEvery { client.deleteApplication(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t", DeleteApplicationTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-123"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteConfigurationProfileTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteConfigurationProfileTaskSpec.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.DeleteConfigurationProfileRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteConfigurationProfileTaskSpec : FunSpec({
+    test("execute sends correct application id and configuration profile id") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<DeleteConfigurationProfileRequest>()
+        coEvery { client.deleteConfigurationProfile(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t", DeleteConfigurationProfileTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.configurationProfileId.set("cp-456")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-123"
+        requestSlot.captured.configurationProfileId shouldBe "cp-456"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteEnvironmentTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DeleteEnvironmentTaskSpec.kt
@@ -1,0 +1,34 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.DeleteEnvironmentRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DeleteEnvironmentTaskSpec : FunSpec({
+    test("execute sends correct application id and environment id") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<DeleteEnvironmentRequest>()
+        coEvery { client.deleteEnvironment(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t", DeleteEnvironmentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentId.set("env-456")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-123"
+        requestSlot.captured.environmentId shouldBe "env-456"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DownloadConfigurationTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/DownloadConfigurationTaskSpec.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.gradle.api.GradleException
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class DownloadConfigurationTaskSpec : FunSpec({
+    test("executes and writes configuration bytes to output file") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigDataClientBuildService.fetchImpl = { _, _, _ ->
+            "config content".toByteArray()
+        }
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigDataClientBuildService::class)
+
+        val outFile = project.layout.buildDirectory.file("config.txt").get().asFile
+        outFile.parentFile.mkdirs()
+
+        val task = project.tasks.create("t", DownloadConfigurationTask::class.java)
+        task.service.set(service)
+        task.applicationIdentifier.set("app-123")
+        task.environmentIdentifier.set("env-456")
+        task.configurationProfileIdentifier.set("profile-789")
+        task.outputFile.set(outFile)
+
+        task.execute()
+
+        task.outputFile.get().asFile.readText() shouldBe "config content"
+        MockAppConfigDataClientBuildService.fetchImpl = null
+    }
+
+    test("throws GradleException when fetchConfiguration returns null") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigDataClientBuildService.fetchImpl = { _, _, _ -> null }
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigDataClientBuildService::class)
+
+        val outFile = project.layout.buildDirectory.file("config.txt").get().asFile
+        outFile.parentFile.mkdirs()
+
+        val task = project.tasks.create("t", DownloadConfigurationTask::class.java)
+        task.service.set(service)
+        task.applicationIdentifier.set("app-123")
+        task.environmentIdentifier.set("env-456")
+        task.configurationProfileIdentifier.set("profile-789")
+        task.outputFile.set(outFile)
+
+        val exception = shouldThrow<GradleException> { task.execute() }
+        exception.message shouldBe
+            "Failed to fetch configuration for app-123/env-456/profile-789"
+        MockAppConfigDataClientBuildService.fetchImpl = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/GetConfigurationValueSourceSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/GetConfigurationValueSourceSpec.kt
@@ -1,0 +1,62 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class GetConfigurationValueSourceSpec : FunSpec({
+    test("obtain returns configuration as UTF-8 string on success") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigDataClientBuildService.fetchImpl = { _, _, _ ->
+            """{"enabled":true}""".toByteArray()
+        }
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig-data", MockAppConfigDataClientBuildService::class)
+
+        val provider = project.providers.ofKt(GetConfigurationValueSource::class) {
+            parameters.service.set(service)
+            parameters.applicationIdentifier.set("my-app")
+            parameters.environmentIdentifier.set("production")
+            parameters.configurationProfileIdentifier.set("my-profile")
+        }
+
+        provider.get() shouldBe """{"enabled":true}"""
+        MockAppConfigDataClientBuildService.fetchImpl = null
+    }
+
+    test("obtain returns null when fetchConfiguration returns null") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigDataClientBuildService.fetchImpl = { _, _, _ -> null }
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig-data", MockAppConfigDataClientBuildService::class)
+
+        val provider = project.providers.ofKt(GetConfigurationValueSource::class) {
+            parameters.service.set(service)
+            parameters.applicationIdentifier.set("missing-app")
+            parameters.environmentIdentifier.set("production")
+            parameters.configurationProfileIdentifier.set("missing-profile")
+        }
+
+        provider.orNull.shouldBeNull()
+        MockAppConfigDataClientBuildService.fetchImpl = null
+    }
+
+    test("obtain returns null when fetchConfiguration returns empty bytes") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigDataClientBuildService.fetchImpl = { _, _, _ -> ByteArray(0) }
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig-data", MockAppConfigDataClientBuildService::class)
+
+        val provider = project.providers.ofKt(GetConfigurationValueSource::class) {
+            parameters.service.set(service)
+            parameters.applicationIdentifier.set("my-app")
+            parameters.environmentIdentifier.set("production")
+            parameters.configurationProfileIdentifier.set("my-profile")
+        }
+
+        provider.orNull.shouldBeNull()
+        MockAppConfigDataClientBuildService.fetchImpl = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/MockAppConfigClientBuildService.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/MockAppConfigClientBuildService.kt
@@ -1,0 +1,14 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+
+/**
+ * Test-only [AppConfigClientBuildService] that returns a pre-supplied mock [AppConfigClient].
+ */
+abstract class MockAppConfigClientBuildService : AppConfigClientBuildService() {
+    override fun createClient(): AppConfigClient = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: AppConfigClient? = null
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/MockAppConfigDataClientBuildService.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/MockAppConfigDataClientBuildService.kt
@@ -1,0 +1,21 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfigdata.AppConfigDataClient
+
+/**
+ * Test-only [AppConfigDataClientBuildService] that overrides [fetchConfiguration] directly,
+ * decoupling tests from the AppConfig Data session protocol.
+ */
+abstract class MockAppConfigDataClientBuildService : AppConfigDataClientBuildService() {
+    override fun createClient(): AppConfigDataClient = error("Not used in tests")
+
+    override suspend fun fetchConfiguration(
+        applicationIdentifier: String,
+        environmentIdentifier: String,
+        configurationProfileIdentifier: String,
+    ): ByteArray? = fetchImpl?.invoke(applicationIdentifier, environmentIdentifier, configurationProfileIdentifier)
+
+    companion object {
+        var fetchImpl: (suspend (String, String, String) -> ByteArray?)? = null
+    }
+}

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/ProviderFactoryExtensions.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/ProviderFactoryExtensions.kt
@@ -1,0 +1,15 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.api.provider.ValueSource
+import org.gradle.api.provider.ValueSourceParameters
+import org.gradle.api.provider.ValueSourceSpec
+import org.gradle.kotlin.dsl.of
+import kotlin.reflect.KClass
+
+// Workaround: under the kotlin-gradle-library convention, Kotlin does not treat Gradle's
+// Action<in T> as T.() -> Unit, so providers.of(...) { parameters.X } fails to resolve.
+internal fun <T : Any, P : ValueSourceParameters> ProviderFactory.ofKt(
+    valueSourceType: KClass<out ValueSource<T, P>>,
+    configuration: ValueSourceSpec<P>.() -> Unit
+) = of(valueSourceType, configuration)

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StartDeploymentTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StartDeploymentTaskSpec.kt
@@ -1,0 +1,115 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.AppConfigException
+import aws.sdk.kotlin.services.appconfig.model.StartDeploymentResponse
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.work.DisableCachingByDefault
+
+internal var startDeploymentAwaitCalled = false
+internal var startDeploymentAwaitExceptionThrown = false
+
+@DisableCachingByDefault(because = "Communicates with AWS AppConfig; result depends on external state")
+internal abstract class TestStartDeploymentTaskWithWaitOverride : StartDeploymentTask() {
+    override suspend fun awaitDeploymentComplete(
+        client: AppConfigClient,
+        applicationId: String,
+        environmentId: String,
+        deploymentNumber: Int,
+    ) {
+        startDeploymentAwaitCalled = true
+        if (startDeploymentAwaitExceptionThrown) {
+            throw AppConfigException("Deployment failed")
+        }
+    }
+}
+
+class StartDeploymentTaskSpec : FunSpec({
+    test("with deploymentNumberFile present, writes deployment number and does not await") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.startDeployment(any()) } returns
+            StartDeploymentResponse { deploymentNumber = 123 }
+
+        val outFile = project.layout.buildDirectory.file("deployment.txt").get().asFile
+        outFile.parentFile.mkdirs()
+
+        val task = project.tasks.create("t1", StartDeploymentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentId.set("env-456")
+        task.configurationProfileId.set("profile-789")
+        task.deploymentStrategyId.set("strategy-111")
+        task.configurationVersion.set("1")
+        task.deploymentNumberFile.set(outFile)
+
+        task.execute()
+
+        coVerify { client.startDeployment(any()) }
+        task.deploymentNumberFile.get().asFile.readText() shouldBe "123"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("without deploymentNumberFile, completes without error") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        coEvery { client.startDeployment(any()) } returns
+            StartDeploymentResponse { deploymentNumber = 456 }
+
+        startDeploymentAwaitCalled = false
+        startDeploymentAwaitExceptionThrown = false
+        val task = project.tasks.create("t2", TestStartDeploymentTaskWithWaitOverride::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentId.set("env-456")
+        task.configurationProfileId.set("profile-789")
+        task.deploymentStrategyId.set("strategy-111")
+        task.configurationVersion.set("1")
+
+        task.execute()
+
+        coVerify { client.startDeployment(any()) }
+        startDeploymentAwaitCalled shouldBe true
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("without deploymentNumberFile, wraps waiter exceptions in GradleException") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig3", MockAppConfigClientBuildService::class)
+        coEvery { client.startDeployment(any()) } returns
+            StartDeploymentResponse { deploymentNumber = 789 }
+
+        startDeploymentAwaitCalled = false
+        startDeploymentAwaitExceptionThrown = true
+        val task = project.tasks.create("t3", TestStartDeploymentTaskWithWaitOverride::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentId.set("env-456")
+        task.configurationProfileId.set("profile-789")
+        task.deploymentStrategyId.set("strategy-111")
+        task.configurationVersion.set("1")
+
+        val exception = shouldThrow<GradleException> { task.execute() }
+        exception.message shouldBe "Deployment 789 failed or was rolled back"
+        startDeploymentAwaitCalled shouldBe true
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StopDeploymentTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/StopDeploymentTaskSpec.kt
@@ -1,0 +1,38 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.StopDeploymentRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class StopDeploymentTaskSpec : FunSpec({
+    test("execute calls stopDeployment with correct parameters") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<StopDeploymentRequest>()
+        coEvery { client.stopDeployment(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t", StopDeploymentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentId.set("env-456")
+        task.deploymentNumber.set(789)
+
+        task.execute()
+
+        coVerify { client.stopDeployment(any()) }
+        requestSlot.captured.applicationId shouldBe "app-123"
+        requestSlot.captured.environmentId shouldBe "env-456"
+        requestSlot.captured.deploymentNumber shouldBe 789
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateApplicationTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateApplicationTaskSpec.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.UpdateApplicationRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class UpdateApplicationTaskSpec : FunSpec({
+    test("execute sends correct application id") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.updateApplication(any()) } returns mockk()
+
+        val task = project.tasks.create("t", UpdateApplicationTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+
+        task.execute()
+
+        coVerify { client.updateApplication(any()) }
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("execute sends optional name and description when set") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<UpdateApplicationRequest>()
+        coEvery { client.updateApplication(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t2", UpdateApplicationTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-456")
+        task.applicationName.set("new-name")
+        task.applicationDescription.set("new description")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-456"
+        requestSlot.captured.name shouldBe "new-name"
+        requestSlot.captured.description shouldBe "new description"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateConfigurationProfileTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateConfigurationProfileTaskSpec.kt
@@ -1,0 +1,58 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.UpdateConfigurationProfileRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class UpdateConfigurationProfileTaskSpec : FunSpec({
+    test("execute sends correct application id and configuration profile id") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.updateConfigurationProfile(any()) } returns mockk()
+
+        val task = project.tasks.create("t", UpdateConfigurationProfileTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.configurationProfileId.set("cp-456")
+
+        task.execute()
+
+        coVerify { client.updateConfigurationProfile(any()) }
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("execute sends optional name and description when set") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<UpdateConfigurationProfileRequest>()
+        coEvery { client.updateConfigurationProfile(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t2", UpdateConfigurationProfileTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-789")
+        task.configurationProfileId.set("cp-012")
+        task.profileName.set("updated-config")
+        task.profileDescription.set("updated description")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-789"
+        requestSlot.captured.configurationProfileId shouldBe "cp-012"
+        requestSlot.captured.name shouldBe "updated-config"
+        requestSlot.captured.description shouldBe "updated description"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateEnvironmentTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/UpdateEnvironmentTaskSpec.kt
@@ -1,0 +1,58 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.UpdateEnvironmentRequest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+class UpdateEnvironmentTaskSpec : FunSpec({
+    test("execute sends correct application id and environment id") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+        coEvery { client.updateEnvironment(any()) } returns mockk()
+
+        val task = project.tasks.create("t", UpdateEnvironmentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-123")
+        task.environmentId.set("env-456")
+
+        task.execute()
+
+        coVerify { client.updateEnvironment(any()) }
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("execute sends optional name and description when set") {
+        val project = ProjectBuilder.builder().build()
+        val client = mockk<AppConfigClient>()
+        MockAppConfigClientBuildService.mockClient = client
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig2", MockAppConfigClientBuildService::class)
+        val requestSlot = slot<UpdateEnvironmentRequest>()
+        coEvery { client.updateEnvironment(capture(requestSlot)) } returns mockk()
+
+        val task = project.tasks.create("t2", UpdateEnvironmentTask::class.java)
+        task.service.set(service)
+        task.applicationId.set("app-789")
+        task.environmentId.set("env-012")
+        task.environmentName.set("new-env-name")
+        task.environmentDescription.set("new env description")
+
+        task.execute()
+
+        requestSlot.captured.applicationId shouldBe "app-789"
+        requestSlot.captured.environmentId shouldBe "env-012"
+        requestSlot.captured.name shouldBe "new-env-name"
+        requestSlot.captured.description shouldBe "new env description"
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/WaitForDeploymentTaskSpec.kt
+++ b/cores/aws-appconfig-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/appconfig/WaitForDeploymentTaskSpec.kt
@@ -1,0 +1,72 @@
+package com.kelvsyc.gradle.aws.kotlin.appconfig
+
+import aws.sdk.kotlin.services.appconfig.AppConfigClient
+import aws.sdk.kotlin.services.appconfig.model.AppConfigException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.UntrackedTask
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+
+internal var waitForDeploymentAwaitCalled = false
+internal var waitForDeploymentThrowException = false
+
+@UntrackedTask(because = "Communicates with AWS AppConfig; no local output")
+internal abstract class TestWaitForDeploymentTask : WaitForDeploymentTask() {
+    override suspend fun awaitDeploymentComplete(
+        client: AppConfigClient,
+        applicationId: String,
+        environmentId: String,
+        deploymentNumber: Int,
+    ) {
+        waitForDeploymentAwaitCalled = true
+        if (waitForDeploymentThrowException) {
+            throw AppConfigException("Deployment was rolled back")
+        }
+    }
+}
+
+class WaitForDeploymentTaskSpec : FunSpec({
+    test("waiter succeeds completes normally") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigClientBuildService.mockClient = mockk()
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+
+        waitForDeploymentAwaitCalled = false
+        waitForDeploymentThrowException = false
+        val mockTask = project.tasks.create("t1", TestWaitForDeploymentTask::class.java)
+        mockTask.service.set(service)
+        mockTask.applicationId.set("app-123")
+        mockTask.environmentId.set("env-456")
+        mockTask.deploymentNumber.set(789)
+
+        mockTask.execute()
+
+        waitForDeploymentAwaitCalled shouldBe true
+        MockAppConfigClientBuildService.mockClient = null
+    }
+
+    test("waiter throws AppConfigException is wrapped in GradleException") {
+        val project = ProjectBuilder.builder().build()
+        MockAppConfigClientBuildService.mockClient = mockk()
+        val service = project.gradle.sharedServices
+            .registerIfAbsent("appconfig", MockAppConfigClientBuildService::class)
+
+        waitForDeploymentAwaitCalled = false
+        waitForDeploymentThrowException = true
+        val mockTask = project.tasks.create("t2", TestWaitForDeploymentTask::class.java)
+        mockTask.service.set(service)
+        mockTask.applicationId.set("app-123")
+        mockTask.environmentId.set("env-456")
+        mockTask.deploymentNumber.set(999)
+
+        val exception = shouldThrow<GradleException> { mockTask.execute() }
+        exception.message shouldBe "Deployment 999 failed or was rolled back"
+        waitForDeploymentAwaitCalled shouldBe true
+        MockAppConfigClientBuildService.mockClient = null
+    }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,7 +44,9 @@ azure-resourcemanager-appservice = { module = "com.azure.resourcemanager:azure-r
 azure-data-appconfiguration = { module = "com.azure:azure-data-appconfiguration" } # version from BOM 'azure-sdk-bom'
 azure-resourcemanager-appconfiguration = { module = "com.azure.resourcemanager:azure-resourcemanager-appconfiguration", version = "1.2.0-beta.1" } # not in azure-sdk-bom; pinned explicitly
 aws-appconfig-java = { module = "software.amazon.awssdk:appconfig" } # version from BOM 'aws-java-sdk-bom'
+aws-appconfig-kotlin = { module = "aws.sdk.kotlin:appconfig" } # version from BOM 'aws-kotlin-sdk-bom'
 aws-appconfigdata-java = { module = "software.amazon.awssdk:appconfigdata" } # version from BOM 'aws-java-sdk-bom'
+aws-appconfigdata-kotlin = { module = "aws.sdk.kotlin:appconfigdata" } # version from BOM 'aws-kotlin-sdk-bom'
 aws-auth-java = { module = "software.amazon.awssdk:auth" } # version from BOM 'aws-java-sdk-bom'
 aws-config-kotlin = { module = "aws.sdk.kotlin:aws-config" } # version from BOM 'aws-kotlin-sdk-bom'
 aws-core-java = { module = "software.amazon.awssdk:aws-core" } # version from BOM 'aws-java-sdk-bom'


### PR DESCRIPTION
## Summary

- Adds `cores/aws-appconfig-kotlin-base`, a new Gradle component integrating AWS AppConfig via the AWS Kotlin SDK (`aws.sdk.kotlin:appconfig` + `aws.sdk.kotlin:appconfigdata`)
- Provides two build services (`AppConfigClientBuildService`, `AppConfigDataClientBuildService` with session-token caching), 9 CRUD `DefaultTask` subclasses, 5 pipeline tasks (including dual-mode `StartDeploymentTask` using the SDK's built-in `waitUntilDeploymentComplete` waiter), and `GetConfigurationValueSource`
- Uses `DefaultTask` instead of `WorkAction` throughout — WorkActions over a coroutine-based SDK reduce to `runBlocking { singleCall() }` with no benefit; this is documented in the component README
- Includes 20 test specs covering all public classes; resolves a `DefaultTask` property naming constraint (`name`/`description` conflict with `Task.getName()`/`getDescription()`) via entity-scoped property names

## Test plan

- [ ] `./gradlew :aws-appconfig-kotlin-base:test` — all tests pass
- [ ] `./gradlew :aws-appconfig-kotlin-base:detekt` — no violations
- [ ] `./gradlew :test :detekt` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)