### PR TITLE
feat: add batch CodeArtifact download and publish tasks for Java and Kotlin bases

### DIFF
--- a/cores/aws-codeartifact-java-base/README.md
+++ b/cores/aws-codeartifact-java-base/README.md
@@ -185,6 +185,106 @@ workerExecutor.noIsolation().submit(PublishPackageVersionAction::class) {
 }
 ```
 
+## Tasks: Batch Download
+
+Downloads multiple assets from a CodeArtifact generic repository concurrently. Coordinates are specified
+per-artifact. All artifacts must be registered via `registerArtifact`.
+
+Two concurrency models are available — choose based on which client you use:
+
+| Class | Client type | Concurrency |
+|---|---|---|
+| `BatchGetGenericPackageVersionAsset` | `CodeartifactClient` (sync) | Gradle Worker API |
+| `AsyncBatchGetGenericPackageVersionAsset` | `CodeartifactAsyncClient` (async) | `CompletableFuture.allOf` |
+
+For BYO-client usage (without auto-registered build services), extend `AbstractWorkerBatchGetGenericPackageVersionAsset`
+(sync) or `AbstractAsyncBatchGetGenericPackageVersionAsset` (async) and set the `service` or `client` property directly.
+
+```kotlin
+val downloadAll = tasks.register<BatchGetGenericPackageVersionAsset>("downloadAll") {
+    service.set(codeartifact)
+    registerArtifact("sdk") {
+        domain.set("my-domain")
+        domainOwner.set("111122223333")
+        repository.set("my-repo")
+        namespace.set("my-ns")
+        packageValue.set("my-sdk")
+        packageVersion.set("1.0.0")
+        assetName.set("my-sdk-1.0.0.zip")
+        outputFile.set(layout.buildDirectory.file("downloads/my-sdk-1.0.0.zip"))
+    }
+}
+
+// Wire output file to a downstream task without forcing evaluation:
+val sdkZip: Provider<RegularFile> = downloadAll.flatMap { it.outputFileForArtifact("sdk") }
+```
+
+| Per-artifact property | Type | Description |
+|---|---|---|
+| `domain` | `Property<String>` | CodeArtifact domain name |
+| `domainOwner` | `Property<String>` | AWS account ID owning the domain |
+| `repository` | `Property<String>` | CodeArtifact repository name |
+| `namespace` | `Property<String>` | Package namespace |
+| `packageValue` | `Property<String>` | Package name |
+| `packageVersion` | `Property<String>` | Package version |
+| `assetName` | `Property<String>` | Asset name within the package version |
+| `outputFile` | `RegularFileProperty` | Destination file for the downloaded asset |
+
+## Tasks: Batch Publish
+
+Publishes multiple assets to a CodeArtifact generic repository concurrently. Coordinates and content
+are specified per-artifact.
+
+| Class | Client type | Concurrency |
+|---|---|---|
+| `BatchPublishPackageVersion` | `CodeartifactClient` (sync) | Gradle Worker API |
+| `AsyncBatchPublishPackageVersion` | `CodeartifactAsyncClient` (async) | `CompletableFuture.allOf` |
+
+For BYO-client usage, extend `AbstractWorkerBatchPublishPackageVersion` or `AbstractAsyncBatchPublishPackageVersion`.
+
+```kotlin
+tasks.register<BatchPublishPackageVersion>("publishAll") {
+    service.set(codeartifact)
+    registerArtifact("jar") {
+        domain.set("my-domain")
+        domainOwner.set("111122223333")
+        repository.set("my-repo")
+        namespace.set("my-ns")
+        packageValue.set("my-lib")
+        packageVersion.set("1.0.0")
+        assetName.set("my-lib-1.0.0.jar")
+        assetSHA256.set("abc123...")
+        assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0.jar"))
+        unfinished.set(true)  // more assets to follow
+    }
+    registerArtifact("sources") {
+        domain.set("my-domain")
+        domainOwner.set("111122223333")
+        repository.set("my-repo")
+        namespace.set("my-ns")
+        packageValue.set("my-lib")
+        packageVersion.set("1.0.0")
+        assetName.set("my-lib-1.0.0-sources.jar")
+        assetSHA256.set("def456...")
+        assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0-sources.jar"))
+        // unfinished absent — marks version as finished
+    }
+}
+```
+
+| Per-artifact property | Type | Description |
+|---|---|---|
+| `domain` | `Property<String>` | CodeArtifact domain name |
+| `domainOwner` | `Property<String>` | AWS account ID owning the domain |
+| `repository` | `Property<String>` | CodeArtifact repository name |
+| `namespace` | `Property<String>` | Package namespace |
+| `packageValue` | `Property<String>` | Package name |
+| `packageVersion` | `Property<String>` | Package version |
+| `assetName` | `Property<String>` | Asset name within the package version |
+| `assetSHA256` | `Property<String>` | SHA-256 hash of the asset content |
+| `assetContent` | `RegularFileProperty` | Asset file to upload |
+| `unfinished` | `Property<Boolean>` | Optional; `true` keeps the version in `Unfinished` state |
+
 ## See Also
 
 - [clients-base](../clients-base) — The underlying service client infrastructure

--- a/cores/aws-codeartifact-java-base/build.gradle.kts
+++ b/cores/aws-codeartifact-java-base/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     api(libs.aws.http.client.spi.java)
     api(libs.aws.codeartifact.java)
     api(libs.aws.sdk.core.java)
+    implementation(libs.aws.core.java)
 
     testImplementation(libs.mockk)
 }

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,49 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import com.kelvsyc.gradle.providers.asPath
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.services.codeartifact.CodeartifactAsyncClient
+import java.util.concurrent.CompletableFuture
+import javax.inject.Inject
+
+/**
+ * Abstract [AbstractBatchGetGenericPackageVersionAsset] that uses a [CodeartifactAsyncClient] to download
+ * multiple assets concurrently via `CompletableFuture`.
+ *
+ * All downloads are initiated immediately and joined at the end of the task action. There is no built-in
+ * retry support — failures propagate immediately. If any future fails, the task throws.
+ *
+ * **BYO-client use:** Extend this class and set [client] directly. For automatic service registration via
+ * `@ServiceReference`, extend [AsyncBatchGetGenericPackageVersionAsset] instead.
+ *
+ * @see AsyncBatchGetGenericPackageVersionAsset
+ * @see AbstractWorkerBatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class AbstractAsyncBatchGetGenericPackageVersionAsset @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchGetGenericPackageVersionAsset(objects) {
+
+    /**
+     * The asynchronous CodeArtifact client.
+     * Set directly for BYO-client usage; [AsyncBatchGetGenericPackageVersionAsset] wires this from a build service.
+     */
+    @get:Internal
+    abstract val client: Property<CodeartifactAsyncClient>
+
+    @Suppress("detekt:SpreadOperator")
+    @TaskAction
+    fun run() {
+        val futures = requests.getOrElse(emptyList()).map { req ->
+            client.get()
+                .getPackageVersionAsset(req.request, AsyncResponseTransformer.toFile(req.outputFile.asPath.get()))
+                .thenApply { Unit }
+        }
+        CompletableFuture.allOf(*futures.toTypedArray<CompletableFuture<Unit>>()).join()
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchPublishPackageVersion.kt
@@ -1,0 +1,49 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import com.kelvsyc.gradle.providers.asPath
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.core.async.AsyncRequestBody
+import software.amazon.awssdk.services.codeartifact.CodeartifactAsyncClient
+import java.util.concurrent.CompletableFuture
+import javax.inject.Inject
+
+/**
+ * Abstract [AbstractBatchPublishPackageVersion] that uses a [CodeartifactAsyncClient] to publish
+ * multiple assets concurrently via `CompletableFuture`.
+ *
+ * All uploads are initiated immediately and joined at the end of the task action. There is no built-in
+ * retry support — failures propagate immediately. If any future fails, the task throws.
+ *
+ * **BYO-client use:** Extend this class and set [client] directly. For automatic service registration via
+ * `@ServiceReference`, extend [AsyncBatchPublishPackageVersion] instead.
+ *
+ * @see AsyncBatchPublishPackageVersion
+ * @see AbstractWorkerBatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class AbstractAsyncBatchPublishPackageVersion @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchPublishPackageVersion(objects) {
+
+    /**
+     * The asynchronous CodeArtifact client.
+     * Set directly for BYO-client usage; [AsyncBatchPublishPackageVersion] wires this from a build service.
+     */
+    @get:Internal
+    abstract val client: Property<CodeartifactAsyncClient>
+
+    @Suppress("detekt:SpreadOperator")
+    @TaskAction
+    fun run() {
+        val futures = requests.getOrElse(emptyList()).map { req ->
+            client.get()
+                .publishPackageVersion(req.request, AsyncRequestBody.fromFile(req.assetContent.asPath.get()))
+                .thenApply { Unit }
+        }
+        CompletableFuture.allOf(*futures.toTypedArray<CompletableFuture<Unit>>()).join()
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,135 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputFile
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.services.codeartifact.model.GetPackageVersionAssetRequest
+import software.amazon.awssdk.services.codeartifact.model.PackageFormat
+import javax.inject.Inject
+
+/**
+ * Abstract root [DefaultTask] that downloads multiple assets from a CodeArtifact generic repository.
+ *
+ * Handles artifact registration and request building. Subclasses provide their own `@TaskAction` to
+ * implement the actual download concurrency model using the pre-built requests.
+ *
+ * **Choosing a subclass:**
+ * - Extend [AbstractWorkerBatchGetGenericPackageVersionAsset] (or use [BatchGetGenericPackageVersionAsset])
+ *   for a Worker API-based approach using the synchronous `CodeartifactClient`. Each artifact is submitted
+ *   as a separate worker action; Gradle's worker executor manages concurrency.
+ * - Extend [AbstractAsyncBatchGetGenericPackageVersionAsset] (or use [AsyncBatchGetGenericPackageVersionAsset])
+ *   for a `CompletableFuture`-based approach using the asynchronous `CodeartifactAsyncClient`. All futures
+ *   run concurrently and are joined at the end.
+ *
+ * **BYO-client use:** Extend one of the abstract mid-level classes and set the `service` or `client`
+ * property directly rather than using the service-wired concrete classes.
+ *
+ * **Wiring output files:**
+ * ```kotlin
+ * val sdkZip: Provider<RegularFile> = downloadAll.flatMap { it.outputFileForArtifact("sdk") }
+ * ```
+ *
+ * @see AbstractWorkerBatchGetGenericPackageVersionAsset
+ * @see AbstractAsyncBatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class AbstractBatchGetGenericPackageVersionAsset @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * Per-artifact coordinates and output location for a CodeArtifact generic package version asset.
+     */
+    interface Artifact {
+        /** The CodeArtifact domain name. */
+        @get:Input
+        val domain: Property<String>
+
+        /** The 12-digit account number of the domain owner. */
+        @get:Input
+        val domainOwner: Property<String>
+
+        /** The CodeArtifact repository name. */
+        @get:Input
+        val repository: Property<String>
+
+        /** The package namespace. */
+        @get:Input
+        val namespace: Property<String>
+
+        /** The package name. */
+        @get:Input
+        val packageValue: Property<String>
+
+        /** The package version. */
+        @get:Input
+        val packageVersion: Property<String>
+
+        /** The asset name within the package version. */
+        @get:Input
+        val assetName: Property<String>
+
+        /** The location the asset is to be downloaded to. */
+        @get:OutputFile
+        val outputFile: RegularFileProperty
+    }
+
+    /** Map of artifact name to per-artifact configuration. */
+    @get:Nested
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers an artifact to download.
+     *
+     * @param name Unique name for this artifact within the batch (used in log messages and error reporting).
+     * @param action Configures the artifact's coordinates and output file.
+     */
+    fun registerArtifact(name: String, action: Action<in Artifact>) {
+        val artifact = objects.newInstance<Artifact>().also { action.execute(it) }
+        artifacts.put(name, artifact)
+    }
+
+    /**
+     * Returns a [Provider] resolving to the output file for the named artifact.
+     *
+     * Use this to wire the downloaded file as an input to a downstream task without forcing evaluation.
+     */
+    fun outputFileForArtifact(name: String): Provider<RegularFile> =
+        artifacts.getting(name).flatMap { it.outputFile }
+
+    internal data class Request(
+        val name: String,
+        val request: GetPackageVersionAssetRequest,
+        val outputFile: RegularFileProperty,
+    )
+
+    @Suppress("LeakingThis")
+    @get:Internal
+    internal val requests = artifacts.map {
+        it.map { (artifactName, artifact) ->
+            val request = GetPackageVersionAssetRequest.builder().apply {
+                domain(artifact.domain.get())
+                domainOwner(artifact.domainOwner.get())
+                repository(artifact.repository.get())
+                format(PackageFormat.GENERIC)
+                namespace(artifact.namespace.get())
+                packageValue(artifact.packageValue.get())
+                packageVersion(artifact.packageVersion.get())
+                asset(artifact.assetName.get())
+            }.build()
+            Request(artifactName, request, artifact.outputFile)
+        }
+    }
+
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchPublishPackageVersion.kt
@@ -1,0 +1,146 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.services.codeartifact.model.PackageFormat
+import software.amazon.awssdk.services.codeartifact.model.PublishPackageVersionRequest
+import javax.inject.Inject
+
+/**
+ * Abstract root [DefaultTask] that publishes multiple assets to a CodeArtifact generic repository.
+ *
+ * Handles artifact registration and request building. Subclasses implement [doExecute] to provide
+ * the actual upload concurrency model.
+ *
+ * **`unfinished` flag:** When uploading multiple assets to the same package version (e.g., a jar and its
+ * sources jar), set `unfinished = true` on all but the last asset. CodeArtifact marks the version as
+ * `Unfinished` until an asset is published with `unfinished = false` (or absent). Because uploads run
+ * concurrently, all assets in a batch will be uploaded in parallel — the ordering of `unfinished` flags
+ * across a batch is unpredictable. Use separate batch tasks (or single-asset tasks) when ordering matters.
+ *
+ * **Choosing a subclass:**
+ * - Extend [AbstractWorkerBatchPublishPackageVersion] (or use [BatchPublishPackageVersion])
+ *   for a Worker API-based approach using the synchronous `CodeartifactClient`.
+ * - Extend [AbstractAsyncBatchPublishPackageVersion] (or use [AsyncBatchPublishPackageVersion])
+ *   for a `CompletableFuture`-based approach using the asynchronous `CodeartifactAsyncClient`.
+ *
+ * **BYO-client use:** Extend one of the abstract mid-level classes and set the `service` or `client`
+ * property directly rather than using the service-wired concrete classes.
+ *
+ * @see AbstractWorkerBatchPublishPackageVersion
+ * @see AbstractAsyncBatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class AbstractBatchPublishPackageVersion @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * Per-artifact coordinates and content for publishing a CodeArtifact generic package version asset.
+     */
+    interface Artifact {
+        /** The CodeArtifact domain name. */
+        @get:Input
+        val domain: Property<String>
+
+        /** The 12-digit account number of the domain owner. */
+        @get:Input
+        val domainOwner: Property<String>
+
+        /** The CodeArtifact repository name. */
+        @get:Input
+        val repository: Property<String>
+
+        /** The package namespace. */
+        @get:Input
+        val namespace: Property<String>
+
+        /** The package name. */
+        @get:Input
+        val packageValue: Property<String>
+
+        /** The package version. */
+        @get:Input
+        val packageVersion: Property<String>
+
+        /** The asset name within the package version. */
+        @get:Input
+        val assetName: Property<String>
+
+        /** The SHA-256 hash of the asset content. */
+        @get:Input
+        val assetSHA256: Property<String>
+
+        /** The asset file to upload. */
+        @get:InputFile
+        @get:PathSensitive(PathSensitivity.NONE)
+        val assetContent: RegularFileProperty
+
+        /**
+         * Whether the package version should remain in the `Unfinished` state after publishing this asset.
+         *
+         * Set to `true` when uploading multiple assets to the same package version. When `false` or unset,
+         * CodeArtifact marks the version as finished after this asset is published.
+         */
+        @get:Input
+        @get:Optional
+        val unfinished: Property<Boolean>
+    }
+
+    /** Map of artifact name to per-artifact configuration. */
+    @get:Nested
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers an artifact to publish.
+     *
+     * @param name Unique name for this artifact within the batch (used in log messages and error reporting).
+     * @param action Configures the artifact's coordinates, content, and checksum.
+     */
+    fun registerArtifact(name: String, action: Action<in Artifact>) {
+        val artifact = objects.newInstance<Artifact>().also { action.execute(it) }
+        artifacts.put(name, artifact)
+    }
+
+    internal data class Request(
+        val name: String,
+        val request: PublishPackageVersionRequest,
+        val assetContent: RegularFileProperty,
+    )
+
+    @Suppress("LeakingThis")
+    @get:Internal
+    internal val requests = artifacts.map {
+        it.map { (artifactName, artifact) ->
+            val request = PublishPackageVersionRequest.builder().apply {
+                domain(artifact.domain.get())
+                domainOwner(artifact.domainOwner.get())
+                repository(artifact.repository.get())
+                format(PackageFormat.GENERIC)
+                namespace(artifact.namespace.get())
+                packageValue(artifact.packageValue.get())
+                packageVersion(artifact.packageVersion.get())
+                assetName(artifact.assetName.get())
+                assetSHA256(artifact.assetSHA256.get())
+                if (artifact.unfinished.isPresent) {
+                    unfinished(artifact.unfinished.get())
+                }
+            }.build()
+            Request(artifactName, request, artifact.assetContent)
+        }
+    }
+
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractWorkerBatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractWorkerBatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract [AbstractBatchGetGenericPackageVersionAsset] that uses the Gradle Worker API with a synchronous
+ * [CodeArtifactClientBuildService] to download multiple assets concurrently.
+ *
+ * Each artifact is submitted as a separate [GetGenericPackageVersionAssetAction] worker action. Gradle's
+ * worker executor manages thread-pool concurrency across submissions. There is no built-in retry support —
+ * transient failures fail the worker action immediately.
+ *
+ * **BYO-service use:** Extend this class and set [service] directly. For automatic service registration via
+ * `@ServiceReference`, extend [BatchGetGenericPackageVersionAsset] instead.
+ *
+ * @see BatchGetGenericPackageVersionAsset
+ * @see AbstractAsyncBatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class AbstractWorkerBatchGetGenericPackageVersionAsset @Inject constructor(
+    objects: ObjectFactory,
+    private val workerExecutor: WorkerExecutor,
+) : AbstractBatchGetGenericPackageVersionAsset(objects) {
+
+    /**
+     * The build service managing the synchronous CodeArtifact client.
+     * Set directly for BYO-service usage; [BatchGetGenericPackageVersionAsset] wires this via `@ServiceReference`.
+     */
+    @get:Internal
+    abstract val service: Property<CodeArtifactClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val queue = workerExecutor.noIsolation()
+        requests.getOrElse(emptyList()).forEach { req ->
+            queue.submit(GetGenericPackageVersionAssetAction::class.java) {
+                it.service.set(service)
+                it.domain.set(req.request.domain())
+                it.domainOwner.set(req.request.domainOwner())
+                it.repository.set(req.request.repository())
+                it.namespace.set(req.request.namespace())
+                it.packageValue.set(req.request.packageValue())
+                it.packageVersion.set(req.request.packageVersion())
+                it.asset.set(req.request.asset())
+                it.outputFile.set(req.outputFile)
+            }
+        }
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractWorkerBatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractWorkerBatchPublishPackageVersion.kt
@@ -1,0 +1,59 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * Abstract [AbstractBatchPublishPackageVersion] that uses the Gradle Worker API with a synchronous
+ * [CodeArtifactClientBuildService] to publish multiple assets concurrently.
+ *
+ * Each artifact is submitted as a separate [PublishPackageVersionAction] worker action. Gradle's
+ * worker executor manages thread-pool concurrency across submissions. There is no built-in retry support —
+ * transient failures fail the worker action immediately.
+ *
+ * **BYO-service use:** Extend this class and set [service] directly. For automatic service registration via
+ * `@ServiceReference`, extend [BatchPublishPackageVersion] instead.
+ *
+ * @see BatchPublishPackageVersion
+ * @see AbstractAsyncBatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class AbstractWorkerBatchPublishPackageVersion @Inject constructor(
+    objects: ObjectFactory,
+    private val workerExecutor: WorkerExecutor,
+) : AbstractBatchPublishPackageVersion(objects) {
+
+    /**
+     * The build service managing the synchronous CodeArtifact client.
+     * Set directly for BYO-service usage; [BatchPublishPackageVersion] wires this via `@ServiceReference`.
+     */
+    @get:Internal
+    abstract val service: Property<CodeArtifactClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val queue = workerExecutor.noIsolation()
+        requests.getOrElse(emptyList()).forEach { req ->
+            queue.submit(PublishPackageVersionAction::class.java) {
+                it.service.set(service)
+                it.domain.set(req.request.domain())
+                it.domainOwner.set(req.request.domainOwner())
+                it.repository.set(req.request.repository())
+                it.namespace.set(req.request.namespace())
+                it.packageValue.set(req.request.packageValue())
+                it.packageVersion.set(req.request.packageVersion())
+                it.assetName.set(req.request.assetName())
+                it.assetSHA256.set(req.request.assetSHA256())
+                it.assetContent.set(req.assetContent)
+                if (req.request.unfinished() != null) {
+                    it.unfinished.set(req.request.unfinished())
+                }
+            }
+        }
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AsyncBatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AsyncBatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that downloads multiple assets from a CodeArtifact generic repository concurrently via
+ * `CompletableFuture`, wired to a [CodeArtifactAsyncClientBuildService].
+ *
+ * Register artifacts via [registerArtifact] and wire output files downstream with [outputFileForArtifact]:
+ *
+ * ```kotlin
+ * val downloadAll = tasks.register<AsyncBatchGetGenericPackageVersionAsset>("downloadAll") {
+ *     service.set(codeartifactAsync)
+ *     registerArtifact("sdk") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-sdk")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-sdk-1.0.0.zip")
+ *         outputFile.set(layout.buildDirectory.file("downloads/my-sdk-1.0.0.zip"))
+ *     }
+ * }
+ * val sdkZip: Provider<RegularFile> = downloadAll.flatMap { it.outputFileForArtifact("sdk") }
+ * ```
+ *
+ * For BYO-client usage (no auto-registration), extend [AbstractAsyncBatchGetGenericPackageVersionAsset]
+ * and set `client` directly.
+ *
+ * For a Worker API-based approach using the synchronous client, use [BatchGetGenericPackageVersionAsset].
+ *
+ * @see AbstractAsyncBatchGetGenericPackageVersionAsset
+ * @see BatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class AsyncBatchGetGenericPackageVersionAsset @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractAsyncBatchGetGenericPackageVersionAsset(objects) {
+
+    /**
+     * The shared build service managing the asynchronous CodeArtifact client.
+     */
+    @get:ServiceReference
+    abstract val service: Property<CodeArtifactAsyncClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AsyncBatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AsyncBatchPublishPackageVersion.kt
@@ -1,0 +1,56 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that publishes multiple assets to a CodeArtifact generic repository concurrently via
+ * `CompletableFuture`, wired to a [CodeArtifactAsyncClientBuildService].
+ *
+ * Register artifacts via [registerArtifact]:
+ *
+ * ```kotlin
+ * tasks.register<AsyncBatchPublishPackageVersion>("publishAll") {
+ *     service.set(codeartifactAsync)
+ *     registerArtifact("jar") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-lib")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-lib-1.0.0.jar")
+ *         assetSHA256.set("abc123...")
+ *         assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0.jar"))
+ *     }
+ * }
+ * ```
+ *
+ * For BYO-client usage (no auto-registration), extend [AbstractAsyncBatchPublishPackageVersion]
+ * and set `client` directly.
+ *
+ * For a Worker API-based approach using the synchronous client, use [BatchPublishPackageVersion].
+ *
+ * @see AbstractAsyncBatchPublishPackageVersion
+ * @see BatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class AsyncBatchPublishPackageVersion @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractAsyncBatchPublishPackageVersion(objects) {
+
+    /**
+     * The shared build service managing the asynchronous CodeArtifact client.
+     */
+    @get:ServiceReference
+    abstract val service: Property<CodeArtifactAsyncClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/BatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/BatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,52 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that downloads multiple assets from a CodeArtifact generic repository concurrently via the
+ * Gradle Worker API, wired to a [CodeArtifactClientBuildService].
+ *
+ * Register artifacts via [registerArtifact] and wire output files downstream with [outputFileForArtifact]:
+ *
+ * ```kotlin
+ * val downloadAll = tasks.register<BatchGetGenericPackageVersionAsset>("downloadAll") {
+ *     service.set(codeartifact)
+ *     registerArtifact("sdk") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-sdk")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-sdk-1.0.0.zip")
+ *         outputFile.set(layout.buildDirectory.file("downloads/my-sdk-1.0.0.zip"))
+ *     }
+ * }
+ * val sdkZip: Provider<RegularFile> = downloadAll.flatMap { it.outputFileForArtifact("sdk") }
+ * ```
+ *
+ * For BYO-service usage (no auto-registration), extend [AbstractWorkerBatchGetGenericPackageVersionAsset]
+ * and set `service` directly.
+ *
+ * For an async-client-based approach, use [AsyncBatchGetGenericPackageVersionAsset].
+ *
+ * @see AbstractWorkerBatchGetGenericPackageVersionAsset
+ * @see AsyncBatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class BatchGetGenericPackageVersionAsset @Inject constructor(
+    objects: ObjectFactory,
+    workerExecutor: WorkerExecutor,
+) : AbstractWorkerBatchGetGenericPackageVersionAsset(objects, workerExecutor) {
+
+    /**
+     * The shared build service managing the synchronous CodeArtifact client.
+     */
+    @get:ServiceReference
+    abstract override val service: Property<CodeArtifactClientBuildService>
+}

--- a/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/BatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/BatchPublishPackageVersion.kt
@@ -1,0 +1,64 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkerExecutor
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that publishes multiple assets to a CodeArtifact generic repository concurrently via the
+ * Gradle Worker API, wired to a [CodeArtifactClientBuildService].
+ *
+ * Register artifacts via [registerArtifact]:
+ *
+ * ```kotlin
+ * tasks.register<BatchPublishPackageVersion>("publishAll") {
+ *     service.set(codeartifact)
+ *     registerArtifact("jar") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-lib")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-lib-1.0.0.jar")
+ *         assetSHA256.set("abc123...")
+ *         assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0.jar"))
+ *         unfinished.set(true)
+ *     }
+ *     registerArtifact("sources") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-lib")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-lib-1.0.0-sources.jar")
+ *         assetSHA256.set("def456...")
+ *         assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0-sources.jar"))
+ *     }
+ * }
+ * ```
+ *
+ * For BYO-service usage (no auto-registration), extend [AbstractWorkerBatchPublishPackageVersion]
+ * and set `service` directly.
+ *
+ * For an async-client-based approach, use [AsyncBatchPublishPackageVersion].
+ *
+ * @see AbstractWorkerBatchPublishPackageVersion
+ * @see AsyncBatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class BatchPublishPackageVersion @Inject constructor(
+    objects: ObjectFactory,
+    workerExecutor: WorkerExecutor,
+) : AbstractWorkerBatchPublishPackageVersion(objects, workerExecutor) {
+
+    /**
+     * The shared build service managing the synchronous CodeArtifact client.
+     */
+    @get:ServiceReference
+    abstract override val service: Property<CodeArtifactClientBuildService>
+}

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchGetGenericPackageVersionAssetSpec.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchGetGenericPackageVersionAssetSpec.kt
@@ -1,0 +1,100 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.codeartifact.CodeartifactAsyncClient
+import software.amazon.awssdk.services.codeartifact.model.PackageFormat
+
+class AbstractAsyncBatchGetGenericPackageVersionAssetSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactAsyncClient>()
+            MockCodeArtifactAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifactAsync",
+                MockCodeArtifactAsyncClientBuildService::class,
+            )
+
+            val task = project.tasks.register<AbstractAsyncBatchGetGenericPackageVersionAsset>("myTask") {
+                this.client.set(service.map { it.getClient() })
+                registerArtifact("artifact1") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("my-namespace")
+                    it.packageValue.set("my-package")
+                    it.packageVersion.set("1.0.0")
+                    it.assetName.set("my-asset.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/my-asset.zip"))
+                }
+            }
+
+            val reqs = task.get().requests.get()
+            reqs shouldHaveSize 1
+            reqs[0].name shouldBe "artifact1"
+            reqs[0].request.domain() shouldBe "my-domain"
+            reqs[0].request.domainOwner() shouldBe "123456789012"
+            reqs[0].request.repository() shouldBe "my-repo"
+            reqs[0].request.format() shouldBe PackageFormat.GENERIC
+            reqs[0].request.namespace() shouldBe "my-namespace"
+            reqs[0].request.packageValue() shouldBe "my-package"
+            reqs[0].request.packageVersion() shouldBe "1.0.0"
+            reqs[0].request.asset() shouldBe "my-asset.zip"
+
+            MockCodeArtifactAsyncClientBuildService.mockClient = null
+        }
+
+        test("Register multiple artifacts - all artifacts appear in requests") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactAsyncClient>()
+            MockCodeArtifactAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifactAsync",
+                MockCodeArtifactAsyncClientBuildService::class,
+            )
+
+            val task = project.tasks.register<AbstractAsyncBatchGetGenericPackageVersionAsset>("myTask") {
+                this.client.set(service.map { it.getClient() })
+                registerArtifact("artifact1") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("ns1")
+                    it.packageValue.set("pkg1")
+                    it.packageVersion.set("1.0.0")
+                    it.assetName.set("asset1.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/asset1.zip"))
+                }
+                registerArtifact("artifact2") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("ns2")
+                    it.packageValue.set("pkg2")
+                    it.packageVersion.set("2.0.0")
+                    it.assetName.set("asset2.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/asset2.zip"))
+                }
+            }
+
+            val artifacts = task.get().artifacts.get()
+            val reqs = task.get().requests.get()
+            reqs shouldHaveSize artifacts.size
+            artifacts.forEach { (artifactName, artifact) ->
+                reqs.any {
+                    it.name == artifactName &&
+                        it.request.asset() == artifact.assetName.orNull
+                }.shouldBeTrue()
+            }
+
+            MockCodeArtifactAsyncClientBuildService.mockClient = null
+        }
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchPublishPackageVersionSpec.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractAsyncBatchPublishPackageVersionSpec.kt
@@ -1,0 +1,153 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.codeartifact.CodeartifactAsyncClient
+import software.amazon.awssdk.services.codeartifact.model.PackageFormat
+import java.nio.file.Files
+
+class AbstractAsyncBatchPublishPackageVersionSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactAsyncClient>()
+            MockCodeArtifactAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifactAsync",
+                MockCodeArtifactAsyncClientBuildService::class,
+            )
+            val assetFile = Files.createTempFile("asset", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractAsyncBatchPublishPackageVersion>("myTask") {
+                    this.client.set(service.map { it.getClient() })
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("my-namespace")
+                        it.packageValue.set("my-package")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("my-asset.zip")
+                        it.assetSHA256.set("abc123")
+                        it.assetContent.set(assetFile)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].name shouldBe "artifact1"
+                reqs[0].request.domain() shouldBe "my-domain"
+                reqs[0].request.domainOwner() shouldBe "123456789012"
+                reqs[0].request.repository() shouldBe "my-repo"
+                reqs[0].request.format() shouldBe PackageFormat.GENERIC
+                reqs[0].request.namespace() shouldBe "my-namespace"
+                reqs[0].request.packageValue() shouldBe "my-package"
+                reqs[0].request.packageVersion() shouldBe "1.0.0"
+                reqs[0].request.assetName() shouldBe "my-asset.zip"
+                reqs[0].request.assetSHA256() shouldBe "abc123"
+                reqs[0].request.unfinished() shouldBe null
+            } finally {
+                assetFile.delete()
+                MockCodeArtifactAsyncClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register artifact with unfinished flag - includes flag in request") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactAsyncClient>()
+            MockCodeArtifactAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifactAsync",
+                MockCodeArtifactAsyncClientBuildService::class,
+            )
+            val assetFile = Files.createTempFile("asset", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractAsyncBatchPublishPackageVersion>("myTask") {
+                    this.client.set(service.map { it.getClient() })
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("my-namespace")
+                        it.packageValue.set("my-package")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("my-asset.zip")
+                        it.assetSHA256.set("abc123")
+                        it.assetContent.set(assetFile)
+                        it.unfinished.set(true)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].request.unfinished() shouldBe true
+            } finally {
+                assetFile.delete()
+                MockCodeArtifactAsyncClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register multiple artifacts - all artifacts appear in requests") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactAsyncClient>()
+            MockCodeArtifactAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifactAsync",
+                MockCodeArtifactAsyncClientBuildService::class,
+            )
+            val assetFile1 = Files.createTempFile("asset1", ".zip").toFile()
+            val assetFile2 = Files.createTempFile("asset2", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractAsyncBatchPublishPackageVersion>("myTask") {
+                    this.client.set(service.map { it.getClient() })
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("ns1")
+                        it.packageValue.set("pkg1")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("asset1.zip")
+                        it.assetSHA256.set("sha1")
+                        it.assetContent.set(assetFile1)
+                        it.unfinished.set(true)
+                    }
+                    registerArtifact("artifact2") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("ns1")
+                        it.packageValue.set("pkg1")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("asset2.zip")
+                        it.assetSHA256.set("sha2")
+                        it.assetContent.set(assetFile2)
+                    }
+                }
+
+                val artifacts = task.get().artifacts.get()
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize artifacts.size
+                artifacts.forEach { (artifactName, artifact) ->
+                    reqs.any {
+                        it.name == artifactName &&
+                            it.request.assetName() == artifact.assetName.orNull
+                    }.shouldBeTrue()
+                }
+            } finally {
+                assetFile1.delete()
+                assetFile2.delete()
+                MockCodeArtifactAsyncClientBuildService.mockClient = null
+            }
+        }
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchGetGenericPackageVersionAssetSpec.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchGetGenericPackageVersionAssetSpec.kt
@@ -1,0 +1,101 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.codeartifact.CodeartifactClient
+import software.amazon.awssdk.services.codeartifact.model.PackageFormat
+
+class AbstractBatchGetGenericPackageVersionAssetSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifact",
+                MockCodeArtifactClientBuildService::class,
+            )
+
+            val task = project.tasks.register<AbstractWorkerBatchGetGenericPackageVersionAsset>("myTask") {
+                this.service.set(service)
+                registerArtifact("artifact1") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("my-namespace")
+                    it.packageValue.set("my-package")
+                    it.packageVersion.set("1.0.0")
+                    it.assetName.set("my-asset.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/my-asset.zip"))
+                }
+            }
+
+            val reqs = task.get().requests.get()
+            reqs shouldHaveSize 1
+            reqs[0].name shouldBe "artifact1"
+            reqs[0].request.domain() shouldBe "my-domain"
+            reqs[0].request.domainOwner() shouldBe "123456789012"
+            reqs[0].request.repository() shouldBe "my-repo"
+            reqs[0].request.format() shouldBe PackageFormat.GENERIC
+            reqs[0].request.namespace() shouldBe "my-namespace"
+            reqs[0].request.packageValue() shouldBe "my-package"
+            reqs[0].request.packageVersion() shouldBe "1.0.0"
+            reqs[0].request.asset() shouldBe "my-asset.zip"
+
+            MockCodeArtifactClientBuildService.mockClient = null
+        }
+
+        test("Register multiple artifacts - configures all request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifact",
+                MockCodeArtifactClientBuildService::class,
+            )
+
+            val task = project.tasks.register<AbstractWorkerBatchGetGenericPackageVersionAsset>("myTask") {
+                this.service.set(service)
+                registerArtifact("artifact1") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("ns1")
+                    it.packageValue.set("pkg1")
+                    it.packageVersion.set("1.0.0")
+                    it.assetName.set("asset1.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/asset1.zip"))
+                }
+                registerArtifact("artifact2") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("ns2")
+                    it.packageValue.set("pkg2")
+                    it.packageVersion.set("2.0.0")
+                    it.assetName.set("asset2.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/asset2.zip"))
+                }
+            }
+
+            val artifacts = task.get().artifacts.get()
+            val reqs = task.get().requests.get()
+            reqs shouldHaveSize artifacts.size
+            artifacts.forEach { (artifactName, artifact) ->
+                reqs.any {
+                    it.name == artifactName &&
+                        it.request.packageValue() == artifact.packageValue.orNull &&
+                        it.request.packageVersion() == artifact.packageVersion.orNull
+                }.shouldBeTrue()
+            }
+
+            MockCodeArtifactClientBuildService.mockClient = null
+        }
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchPublishPackageVersionSpec.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/AbstractBatchPublishPackageVersionSpec.kt
@@ -1,0 +1,153 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.codeartifact.CodeartifactClient
+import software.amazon.awssdk.services.codeartifact.model.PackageFormat
+import java.nio.file.Files
+
+class AbstractBatchPublishPackageVersionSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifact",
+                MockCodeArtifactClientBuildService::class,
+            )
+            val assetFile = Files.createTempFile("asset", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractWorkerBatchPublishPackageVersion>("myTask") {
+                    this.service.set(service)
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("my-namespace")
+                        it.packageValue.set("my-package")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("my-asset.zip")
+                        it.assetSHA256.set("abc123")
+                        it.assetContent.set(assetFile)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].name shouldBe "artifact1"
+                reqs[0].request.domain() shouldBe "my-domain"
+                reqs[0].request.domainOwner() shouldBe "123456789012"
+                reqs[0].request.repository() shouldBe "my-repo"
+                reqs[0].request.format() shouldBe PackageFormat.GENERIC
+                reqs[0].request.namespace() shouldBe "my-namespace"
+                reqs[0].request.packageValue() shouldBe "my-package"
+                reqs[0].request.packageVersion() shouldBe "1.0.0"
+                reqs[0].request.assetName() shouldBe "my-asset.zip"
+                reqs[0].request.assetSHA256() shouldBe "abc123"
+                reqs[0].request.unfinished() shouldBe null
+            } finally {
+                assetFile.delete()
+                MockCodeArtifactClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register artifact with unfinished flag - includes flag in request") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifact",
+                MockCodeArtifactClientBuildService::class,
+            )
+            val assetFile = Files.createTempFile("asset", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractWorkerBatchPublishPackageVersion>("myTask") {
+                    this.service.set(service)
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("my-namespace")
+                        it.packageValue.set("my-package")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("my-asset.zip")
+                        it.assetSHA256.set("abc123")
+                        it.assetContent.set(assetFile)
+                        it.unfinished.set(true)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].request.unfinished() shouldBe true
+            } finally {
+                assetFile.delete()
+                MockCodeArtifactClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register multiple artifacts - configures all request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<CodeartifactClient>()
+            MockCodeArtifactClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "codeartifact",
+                MockCodeArtifactClientBuildService::class,
+            )
+            val assetFile1 = Files.createTempFile("asset1", ".zip").toFile()
+            val assetFile2 = Files.createTempFile("asset2", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractWorkerBatchPublishPackageVersion>("myTask") {
+                    this.service.set(service)
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("ns1")
+                        it.packageValue.set("pkg1")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("asset1.zip")
+                        it.assetSHA256.set("sha1")
+                        it.assetContent.set(assetFile1)
+                        it.unfinished.set(true)
+                    }
+                    registerArtifact("artifact2") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("ns1")
+                        it.packageValue.set("pkg1")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("asset2.zip")
+                        it.assetSHA256.set("sha2")
+                        it.assetContent.set(assetFile2)
+                    }
+                }
+
+                val artifacts = task.get().artifacts.get()
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize artifacts.size
+                artifacts.forEach { (artifactName, artifact) ->
+                    reqs.any {
+                        it.name == artifactName &&
+                            it.request.assetName() == artifact.assetName.orNull
+                    }.shouldBeTrue()
+                }
+            } finally {
+                assetFile1.delete()
+                assetFile2.delete()
+                MockCodeArtifactClientBuildService.mockClient = null
+            }
+        }
+    }
+}

--- a/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/MockCodeArtifactAsyncClientBuildService.kt
+++ b/cores/aws-codeartifact-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/codeartifact/MockCodeArtifactAsyncClientBuildService.kt
@@ -1,0 +1,16 @@
+package com.kelvsyc.gradle.aws.java.codeartifact
+
+import software.amazon.awssdk.services.codeartifact.CodeartifactAsyncClient
+
+/**
+ * Test-only [CodeArtifactAsyncClientBuildService] that returns a pre-supplied mock [CodeartifactAsyncClient].
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockCodeArtifactAsyncClientBuildService : CodeArtifactAsyncClientBuildService() {
+    override fun createClient(): CodeartifactAsyncClient = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: CodeartifactAsyncClient? = null
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/README.md
+++ b/cores/aws-codeartifact-kotlin-base/README.md
@@ -219,6 +219,107 @@ tasks.register<PublishPackageVersion>("publishPackageVersion") {
 | `assetContent` | `RegularFileProperty` | Asset file to upload |
 | `unfinished` | `Property<Boolean>` | Optional; set to `true` when uploading multiple assets to the same package version |
 
+## Task: `BatchGetGenericPackageVersionAsset`
+
+Downloads multiple assets from a CodeArtifact generic repository in parallel.
+Coordinates are specified per artifact. Downloads run concurrently via coroutines (`flatMapMerge`);
+transient failures are retried. If any download fails, the task throws listing the failed artifact names.
+
+```kotlin
+val downloadAll = tasks.register<BatchGetGenericPackageVersionAsset>("downloadAll") {
+    service.set(codeArtifact)
+    registerArtifact("sdk") {
+        domain.set("my-domain")
+        domainOwner.set("111122223333")
+        repository.set("my-repo")
+        namespace.set("my-ns")
+        packageValue.set("my-sdk")
+        packageVersion.set("1.0.0")
+        assetName.set("my-sdk-1.0.0.zip")
+        outputFile.set(layout.buildDirectory.file("downloads/my-sdk-1.0.0.zip"))
+    }
+}
+
+// Wire the output file to a downstream task without forcing evaluation:
+val sdkZip: Provider<RegularFile> = downloadAll.flatMap { it.outputFileForArtifact("sdk") }
+```
+
+For BYO-client usage (without a build service), extend `AbstractBatchGetGenericPackageVersionAsset` and set
+`client` directly.
+
+| Per-artifact property | Type | Description |
+|---|---|---|
+| `domain` | `Property<String>` | CodeArtifact domain name |
+| `domainOwner` | `Property<String>` | AWS account ID owning the domain |
+| `repository` | `Property<String>` | CodeArtifact repository name |
+| `namespace` | `Property<String>` | Package namespace |
+| `packageValue` | `Property<String>` | Package name |
+| `packageVersion` | `Property<String>` | Package version |
+| `assetName` | `Property<String>` | Asset name within the package version |
+| `outputFile` | `RegularFileProperty` | Destination file for the downloaded asset |
+
+| Task property | Type | Description |
+|---|---|---|
+| `service` | `Property<CodeArtifactClientBuildService>` | Build service supplying the CodeArtifact client |
+| `retries` | `Property<Int>` | Max retries per artifact on transient failure (default 1) |
+
+## Task: `BatchPublishPackageVersion`
+
+Publishes multiple assets to a CodeArtifact generic repository in parallel.
+Coordinates are specified per artifact. Uploads run concurrently via coroutines (`flatMapMerge`);
+transient failures are retried. If any upload fails, the task throws listing the failed artifact names.
+
+```kotlin
+tasks.register<BatchPublishPackageVersion>("publishAll") {
+    service.set(codeArtifact)
+    registerArtifact("jar") {
+        domain.set("my-domain")
+        domainOwner.set("111122223333")
+        repository.set("my-repo")
+        namespace.set("my-ns")
+        packageValue.set("my-lib")
+        packageVersion.set("1.0.0")
+        assetName.set("my-lib-1.0.0.jar")
+        assetSHA256.set("abc123...")
+        assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0.jar"))
+        unfinished.set(true)  // more assets to follow
+    }
+    registerArtifact("sources") {
+        domain.set("my-domain")
+        domainOwner.set("111122223333")
+        repository.set("my-repo")
+        namespace.set("my-ns")
+        packageValue.set("my-lib")
+        packageVersion.set("1.0.0")
+        assetName.set("my-lib-1.0.0-sources.jar")
+        assetSHA256.set("def456...")
+        assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0-sources.jar"))
+        // unfinished absent — marks version as finished
+    }
+}
+```
+
+For BYO-client usage (without a build service), extend `AbstractBatchPublishPackageVersion` and set
+`client` directly.
+
+| Per-artifact property | Type | Description |
+|---|---|---|
+| `domain` | `Property<String>` | CodeArtifact domain name |
+| `domainOwner` | `Property<String>` | AWS account ID owning the domain |
+| `repository` | `Property<String>` | CodeArtifact repository name |
+| `namespace` | `Property<String>` | Package namespace |
+| `packageValue` | `Property<String>` | Package name |
+| `packageVersion` | `Property<String>` | Package version |
+| `assetName` | `Property<String>` | Asset name within the package version |
+| `assetSHA256` | `Property<String>` | SHA-256 hash of the asset content |
+| `assetContent` | `RegularFileProperty` | Asset file to upload |
+| `unfinished` | `Property<Boolean>` | Optional; `true` keeps the version in `Unfinished` state |
+
+| Task property | Type | Description |
+|---|---|---|
+| `service` | `Property<CodeArtifactClientBuildService>` | Build service supplying the CodeArtifact client |
+| `retries` | `Property<Int>` | Max retries per artifact on transient failure (default 1) |
+
 ## Why no WorkActions
 
 The AWS Kotlin SDK exposes all service calls as `suspend` functions. A `WorkAction` that wraps a single suspend call reduces to:

--- a/cores/aws-codeartifact-kotlin-base/build.gradle.kts
+++ b/cores/aws-codeartifact-kotlin-base/build.gradle.kts
@@ -14,8 +14,10 @@ configure<DokkaExtension> {
 dependencies {
     api("com.kelvsyc.gradle:clients-base")
     api("com.kelvsyc.gradle:aws-kotlin-extensions")
+    implementation("com.kelvsyc.gradle:gradle-extensions")
 
     api(libs.aws.codeartifact.kotlin)
+    implementation(libs.aws.core.kotlin)
     implementation(libs.aws.smithy.runtime.core)
     implementation(libs.kotlinx.coroutines.core)
 

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,215 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import aws.sdk.kotlin.runtime.ClientException
+import aws.sdk.kotlin.services.codeartifact.CodeartifactClient
+import aws.sdk.kotlin.services.codeartifact.model.GetPackageVersionAssetRequest
+import aws.sdk.kotlin.services.codeartifact.model.PackageFormat
+import aws.smithy.kotlin.runtime.content.writeToFile
+import com.kelvsyc.gradle.logging.warn
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFile
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * Abstract [DefaultTask] that downloads multiple assets from a CodeArtifact generic repository in parallel.
+ *
+ * Each artifact is registered via [registerArtifact] with its own coordinates and destination file. Downloads
+ * run concurrently using coroutine `flatMapMerge`. Transient failures (non-[ClientException]) are retried up
+ * to [retries] times; [ClientException] (SDK-side errors) and CodeArtifact service errors are not retried.
+ * If any download fails after all retries, the task throws [GradleException] listing the failed artifact names.
+ *
+ * **BYO-client use:** Set [client] directly and leave [retries] at its default (1) or configure as needed.
+ * For service-wired use, extend [BatchGetGenericPackageVersionAsset] instead.
+ *
+ * **Wiring output files:**
+ * ```kotlin
+ * val myArtifactFile: Provider<RegularFile> = myTask.flatMap {
+ *     it.outputFileForArtifact("myArtifact")
+ * }
+ * ```
+ *
+ * @see BatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class AbstractBatchGetGenericPackageVersionAsset @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * Per-artifact coordinates and output location for a CodeArtifact generic package version asset.
+     */
+    interface Artifact {
+        /** The CodeArtifact domain name. */
+        @get:Input
+        val domain: Property<String>
+
+        /** The 12-digit account number of the domain owner. */
+        @get:Input
+        val domainOwner: Property<String>
+
+        /** The CodeArtifact repository name. */
+        @get:Input
+        val repository: Property<String>
+
+        /** The package namespace. */
+        @get:Input
+        val namespace: Property<String>
+
+        /** The package name. */
+        @get:Input
+        val packageValue: Property<String>
+
+        /** The package version. */
+        @get:Input
+        val packageVersion: Property<String>
+
+        /** The asset name within the package version. */
+        @get:Input
+        val assetName: Property<String>
+
+        /** The location the asset is to be downloaded to. */
+        @get:OutputFile
+        val outputFile: RegularFileProperty
+    }
+
+    /** Map of artifact name to per-artifact configuration. */
+    @get:Nested
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers an artifact to download.
+     *
+     * @param name Unique name for this artifact within the batch (used in log messages and error reporting).
+     * @param action Configures the artifact's coordinates and output file.
+     */
+    fun registerArtifact(name: String, action: Action<in Artifact>) {
+        val artifact = objects.newInstance<Artifact>().also { action.execute(it) }
+        artifacts.put(name, artifact)
+    }
+
+    /**
+     * Returns a [Provider] resolving to the output file for the named artifact.
+     *
+     * Use this to wire the downloaded file as an input to a downstream task without forcing evaluation.
+     */
+    fun outputFileForArtifact(name: String): Provider<RegularFile> =
+        artifacts.getting(name).flatMap { it.outputFile }
+
+    /**
+     * The CodeArtifact client to use for downloads.
+     * Set directly for BYO-client usage; [BatchGetGenericPackageVersionAsset] wires this from a build service.
+     */
+    @get:Internal
+    abstract val client: Property<CodeartifactClient>
+
+    /**
+     * Maximum number of retry attempts per artifact on transient failures. Defaults to 1.
+     * [ClientException] failures are never retried regardless of this value.
+     */
+    @get:Internal
+    abstract val retries: Property<Int>
+
+    internal data class Request(
+        val name: String,
+        val request: GetPackageVersionAssetRequest,
+        val output: Provider<RegularFile>,
+    )
+
+    @Suppress("LeakingThis")
+    @get:Internal
+    internal val requests = artifacts.map {
+        it.map { (artifactName, artifact) ->
+            val request = GetPackageVersionAssetRequest {
+                domain = artifact.domain.get()
+                domainOwner = artifact.domainOwner.get()
+                repository = artifact.repository.get()
+                format = PackageFormat.Generic
+                namespace = artifact.namespace.get()
+                `package` = artifact.packageValue.get()
+                packageVersion = artifact.packageVersion.get()
+                asset = artifact.assetName.get()
+            }
+            Request(artifactName, request, artifact.outputFile)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @TaskAction
+    fun run() {
+        val results = runBlocking {
+            requests.getOrElse(emptyList()).asFlow()
+                .flowOn(Dispatchers.IO)
+                .onStart {
+                    logger.lifecycle("Starting batch download from CodeArtifact")
+                }
+                .onEach {
+                    logger.lifecycle(
+                        "Downloading {} from {}/{}/{}",
+                        it.name,
+                        it.request.domain,
+                        it.request.repository,
+                        it.request.asset,
+                    )
+                }
+                .flatMapMerge { req ->
+                    val name = req.name
+                    flow {
+                        client.get().getPackageVersionAsset(req.request) { response ->
+                            response.asset?.writeToFile(req.output.get().asFile)
+                        }
+                        emit(name to Result.success(Unit))
+                    }.catch {
+                        if (it is ClientException) {
+                            emit(name to Result.failure(it))
+                        }
+                    }.retryWhen { cause, attempt ->
+                        val totalRetries = retries.getOrElse(1)
+                        logger.warn(cause) {
+                            "Attempt $attempt of $totalRetries to download $name from ${req.request.domain}/${req.request.repository}/${req.request.asset} has failed"
+                        }
+                        attempt < totalRetries
+                    }.catch { cause ->
+                        logger.warn(cause) {
+                            "Downloading $name from ${req.request.domain}/${req.request.repository}/${req.request.asset} has failed"
+                        }
+                        emit(name to Result.failure(cause))
+                    }
+                }
+                .fold(mutableMapOf<String, Result<Unit>>()) { map, result ->
+                    map[result.first] = result.second
+                    map
+                }
+        }
+
+        val failures = results.filterValues { it.isFailure }
+        if (failures.isNotEmpty()) {
+            throw GradleException("${failures.size} artifact(s) failed to download: ${failures.keys.joinToString()}")
+        }
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchPublishPackageVersion.kt
@@ -1,0 +1,222 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import aws.sdk.kotlin.runtime.ClientException
+import aws.sdk.kotlin.services.codeartifact.CodeartifactClient
+import aws.sdk.kotlin.services.codeartifact.model.PackageFormat
+import aws.sdk.kotlin.services.codeartifact.model.PublishPackageVersionRequest
+import aws.smithy.kotlin.runtime.content.asByteStream
+import com.kelvsyc.gradle.logging.warn
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * Abstract [DefaultTask] that publishes multiple assets to a CodeArtifact generic repository in parallel.
+ *
+ * Each artifact is registered via [registerArtifact] with its own coordinates, asset content, and checksum.
+ * Uploads run concurrently using coroutine `flatMapMerge`. Transient failures (non-[ClientException]) are
+ * retried up to [retries] times; [ClientException] failures are not retried. If any upload fails after all
+ * retries, the task throws [GradleException] listing the failed artifact names.
+ *
+ * **`unfinished` flag:** When uploading multiple assets to the same package version (e.g., a jar and its
+ * sources jar), set `unfinished = true` on all but the last asset. CodeArtifact marks the version as
+ * `Unfinished` until an asset is published with `unfinished = false` (or absent).
+ *
+ * **BYO-client use:** Set [client] directly and leave [retries] at its default (1) or configure as needed.
+ * For service-wired use, extend [BatchPublishPackageVersion] instead.
+ *
+ * @see BatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class AbstractBatchPublishPackageVersion @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * Per-artifact coordinates and content for publishing a CodeArtifact generic package version asset.
+     */
+    interface Artifact {
+        /** The CodeArtifact domain name. */
+        @get:Input
+        val domain: Property<String>
+
+        /** The 12-digit account number of the domain owner. */
+        @get:Input
+        val domainOwner: Property<String>
+
+        /** The CodeArtifact repository name. */
+        @get:Input
+        val repository: Property<String>
+
+        /** The package namespace. */
+        @get:Input
+        val namespace: Property<String>
+
+        /** The package name. */
+        @get:Input
+        val packageValue: Property<String>
+
+        /** The package version. */
+        @get:Input
+        val packageVersion: Property<String>
+
+        /** The asset name within the package version. */
+        @get:Input
+        val assetName: Property<String>
+
+        /** The SHA-256 hash of the asset content. */
+        @get:Input
+        val assetSHA256: Property<String>
+
+        /** The asset file to upload. */
+        @get:InputFile
+        @get:PathSensitive(PathSensitivity.NONE)
+        val assetContent: RegularFileProperty
+
+        /**
+         * Whether the package version should remain in the `Unfinished` state after publishing this asset.
+         *
+         * Set to `true` when uploading multiple assets to the same package version. When `false` or unset,
+         * CodeArtifact marks the version as finished after this asset is published.
+         */
+        @get:Input
+        @get:Optional
+        val unfinished: Property<Boolean>
+    }
+
+    /** Map of artifact name to per-artifact configuration. */
+    @get:Nested
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers an artifact to publish.
+     *
+     * @param name Unique name for this artifact within the batch (used in log messages and error reporting).
+     * @param action Configures the artifact's coordinates, content, and checksum.
+     */
+    fun registerArtifact(name: String, action: Action<in Artifact>) {
+        val artifact = objects.newInstance<Artifact>().also { action.execute(it) }
+        artifacts.put(name, artifact)
+    }
+
+    /**
+     * The CodeArtifact client to use for uploads.
+     * Set directly for BYO-client usage; [BatchPublishPackageVersion] wires this from a build service.
+     */
+    @get:Internal
+    abstract val client: Property<CodeartifactClient>
+
+    /**
+     * Maximum number of retry attempts per artifact on transient failures. Defaults to 1.
+     * [ClientException] failures are never retried regardless of this value.
+     */
+    @get:Internal
+    abstract val retries: Property<Int>
+
+    internal data class Request(
+        val name: String,
+        val request: PublishPackageVersionRequest,
+    )
+
+    @Suppress("LeakingThis")
+    @get:Internal
+    internal val requests = artifacts.map {
+        it.map { (artifactName, artifact) ->
+            val request = PublishPackageVersionRequest {
+                domain = artifact.domain.get()
+                domainOwner = artifact.domainOwner.get()
+                repository = artifact.repository.get()
+                format = PackageFormat.Generic
+                namespace = artifact.namespace.get()
+                `package` = artifact.packageValue.get()
+                packageVersion = artifact.packageVersion.get()
+                assetName = artifact.assetName.get()
+                assetSha256 = artifact.assetSHA256.get()
+                assetContent = artifact.assetContent.get().asFile.asByteStream()
+                if (artifact.unfinished.isPresent) {
+                    unfinished = artifact.unfinished.get()
+                }
+            }
+            Request(artifactName, request)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @TaskAction
+    fun run() {
+        val results = runBlocking {
+            requests.getOrElse(emptyList()).asFlow()
+                .flowOn(Dispatchers.IO)
+                .onStart {
+                    logger.lifecycle("Starting batch publish to CodeArtifact")
+                }
+                .onEach {
+                    logger.lifecycle(
+                        "Publishing {} to {}/{}/{}",
+                        it.name,
+                        it.request.domain,
+                        it.request.repository,
+                        it.request.assetName,
+                    )
+                }
+                .flatMapMerge { req ->
+                    val name = req.name
+                    flow {
+                        client.get().publishPackageVersion(req.request)
+                        emit(name to Result.success(Unit))
+                    }.catch {
+                        if (it is ClientException) {
+                            emit(name to Result.failure(it))
+                        }
+                    }.retryWhen { cause, attempt ->
+                        val totalRetries = retries.getOrElse(1)
+                        logger.warn(cause) {
+                            "Attempt $attempt of $totalRetries to publish $name to ${req.request.domain}/${req.request.repository}/${req.request.assetName} has failed"
+                        }
+                        attempt < totalRetries
+                    }.catch { cause ->
+                        logger.warn(cause) {
+                            "Publishing $name to ${req.request.domain}/${req.request.repository}/${req.request.assetName} has failed"
+                        }
+                        emit(name to Result.failure(cause))
+                    }
+                }
+                .fold(mutableMapOf<String, Result<Unit>>()) { map, result ->
+                    map[result.first] = result.second
+                    map
+                }
+        }
+
+        val failures = results.filterValues { it.isFailure }
+        if (failures.isNotEmpty()) {
+            throw GradleException("${failures.size} artifact(s) failed to publish: ${failures.keys.joinToString()}")
+        }
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/BatchGetGenericPackageVersionAsset.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/BatchGetGenericPackageVersionAsset.kt
@@ -1,0 +1,52 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that downloads multiple assets from a CodeArtifact generic repository in parallel,
+ * wired to a [CodeArtifactClientBuildService].
+ *
+ * Register artifacts via [registerArtifact] and wire output files downstream with [outputFileForArtifact]:
+ *
+ * ```kotlin
+ * val downloadAll = tasks.register<BatchGetGenericPackageVersionAsset>("downloadAll") {
+ *     service.set(codeArtifact)
+ *     registerArtifact("sdk") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-sdk")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-sdk-1.0.0.zip")
+ *         outputFile.set(layout.buildDirectory.file("downloads/my-sdk-1.0.0.zip"))
+ *     }
+ * }
+ * val sdkZip: Provider<RegularFile> = downloadAll.flatMap { it.outputFileForArtifact("sdk") }
+ * ```
+ *
+ * For BYO-client usage (no build service), extend [AbstractBatchGetGenericPackageVersionAsset] directly.
+ *
+ * @see AbstractBatchGetGenericPackageVersionAsset
+ */
+@DisableCachingByDefault(because = "Downloading from an external service is not cacheable")
+abstract class BatchGetGenericPackageVersionAsset @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchGetGenericPackageVersionAsset(objects) {
+
+    /**
+     * The shared build service managing the CodeArtifact client.
+     */
+    @get:ServiceReference
+    abstract val service: Property<CodeArtifactClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/BatchPublishPackageVersion.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/BatchPublishPackageVersion.kt
@@ -1,0 +1,65 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that publishes multiple assets to a CodeArtifact generic repository in parallel,
+ * wired to a [CodeArtifactClientBuildService].
+ *
+ * Register artifacts via [registerArtifact]:
+ *
+ * ```kotlin
+ * tasks.register<BatchPublishPackageVersion>("publishAll") {
+ *     service.set(codeArtifact)
+ *     registerArtifact("jar") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-lib")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-lib-1.0.0.jar")
+ *         assetSHA256.set("abc123...")
+ *         assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0.jar"))
+ *         unfinished.set(true)  // more assets to come
+ *     }
+ *     registerArtifact("sources") {
+ *         domain.set("my-domain")
+ *         domainOwner.set("111122223333")
+ *         repository.set("my-repo")
+ *         namespace.set("my-ns")
+ *         packageValue.set("my-lib")
+ *         packageVersion.set("1.0.0")
+ *         assetName.set("my-lib-1.0.0-sources.jar")
+ *         assetSHA256.set("def456...")
+ *         assetContent.set(layout.buildDirectory.file("libs/my-lib-1.0.0-sources.jar"))
+ *         // unfinished absent — marks version as finished
+ *     }
+ * }
+ * ```
+ *
+ * For BYO-client usage (no build service), extend [AbstractBatchPublishPackageVersion] directly.
+ *
+ * @see AbstractBatchPublishPackageVersion
+ */
+@DisableCachingByDefault(because = "Publishing to an external service is not cacheable")
+abstract class BatchPublishPackageVersion @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchPublishPackageVersion(objects) {
+
+    /**
+     * The shared build service managing the CodeArtifact client.
+     */
+    @get:ServiceReference
+    abstract val service: Property<CodeArtifactClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchGetGenericPackageVersionAssetSpec.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchGetGenericPackageVersionAssetSpec.kt
@@ -1,0 +1,84 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import aws.sdk.kotlin.services.codeartifact.CodeartifactClient
+import aws.sdk.kotlin.services.codeartifact.model.PackageFormat
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+
+class AbstractBatchGetGenericPackageVersionAssetSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+
+            val task = project.tasks.register<AbstractBatchGetGenericPackageVersionAsset>("myTask") {
+                client.set(mockk<CodeartifactClient>())
+                registerArtifact("artifact1") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("my-namespace")
+                    it.packageValue.set("my-package")
+                    it.packageVersion.set("1.0.0")
+                    it.assetName.set("my-asset.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/my-asset.zip"))
+                }
+            }
+
+            val reqs = task.get().requests.get()
+            reqs shouldHaveSize 1
+            reqs[0].name shouldBe "artifact1"
+            reqs[0].request.domain shouldBe "my-domain"
+            reqs[0].request.domainOwner shouldBe "123456789012"
+            reqs[0].request.repository shouldBe "my-repo"
+            reqs[0].request.format shouldBe PackageFormat.Generic
+            reqs[0].request.namespace shouldBe "my-namespace"
+            reqs[0].request.`package` shouldBe "my-package"
+            reqs[0].request.packageVersion shouldBe "1.0.0"
+            reqs[0].request.asset shouldBe "my-asset.zip"
+        }
+
+        test("Register multiple artifacts - configures all request parameters") {
+            val project = ProjectBuilder.builder().build()
+
+            val task = project.tasks.register<AbstractBatchGetGenericPackageVersionAsset>("myTask") {
+                client.set(mockk<CodeartifactClient>())
+                registerArtifact("artifact1") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("ns1")
+                    it.packageValue.set("pkg1")
+                    it.packageVersion.set("1.0.0")
+                    it.assetName.set("asset1.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/asset1.zip"))
+                }
+                registerArtifact("artifact2") {
+                    it.domain.set("my-domain")
+                    it.domainOwner.set("123456789012")
+                    it.repository.set("my-repo")
+                    it.namespace.set("ns2")
+                    it.packageValue.set("pkg2")
+                    it.packageVersion.set("2.0.0")
+                    it.assetName.set("asset2.zip")
+                    it.outputFile.set(project.layout.buildDirectory.file("downloads/asset2.zip"))
+                }
+            }
+
+            val artifacts = task.get().artifacts.get()
+            val reqs = task.get().requests.get()
+            reqs shouldHaveSize artifacts.size
+            artifacts.forEach { (artifactName, artifact) ->
+                reqs.any {
+                    it.name == artifactName &&
+                        it.request.`package` == artifact.packageValue.orNull &&
+                        it.request.packageVersion == artifact.packageVersion.orNull
+                }.shouldBeTrue()
+            }
+        }
+    }
+}

--- a/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchPublishPackageVersionSpec.kt
+++ b/cores/aws-codeartifact-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/codeartifact/AbstractBatchPublishPackageVersionSpec.kt
@@ -1,0 +1,131 @@
+package com.kelvsyc.gradle.aws.kotlin.codeartifact
+
+import aws.sdk.kotlin.services.codeartifact.CodeartifactClient
+import aws.sdk.kotlin.services.codeartifact.model.PackageFormat
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+import java.nio.file.Files
+
+class AbstractBatchPublishPackageVersionSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val assetFile = Files.createTempFile("asset", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractBatchPublishPackageVersion>("myTask") {
+                    client.set(mockk<CodeartifactClient>())
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("my-namespace")
+                        it.packageValue.set("my-package")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("my-asset.zip")
+                        it.assetSHA256.set("abc123")
+                        it.assetContent.set(assetFile)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].name shouldBe "artifact1"
+                reqs[0].request.domain shouldBe "my-domain"
+                reqs[0].request.domainOwner shouldBe "123456789012"
+                reqs[0].request.repository shouldBe "my-repo"
+                reqs[0].request.format shouldBe PackageFormat.Generic
+                reqs[0].request.namespace shouldBe "my-namespace"
+                reqs[0].request.`package` shouldBe "my-package"
+                reqs[0].request.packageVersion shouldBe "1.0.0"
+                reqs[0].request.assetName shouldBe "my-asset.zip"
+                reqs[0].request.assetSha256 shouldBe "abc123"
+                reqs[0].request.unfinished shouldBe null
+            } finally {
+                assetFile.delete()
+            }
+        }
+
+        test("Register artifact with unfinished flag - includes flag in request") {
+            val project = ProjectBuilder.builder().build()
+            val assetFile = Files.createTempFile("asset", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractBatchPublishPackageVersion>("myTask") {
+                    client.set(mockk<CodeartifactClient>())
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("my-namespace")
+                        it.packageValue.set("my-package")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("my-asset.zip")
+                        it.assetSHA256.set("abc123")
+                        it.assetContent.set(assetFile)
+                        it.unfinished.set(true)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].request.unfinished shouldBe true
+            } finally {
+                assetFile.delete()
+            }
+        }
+
+        test("Register multiple artifacts - configures all request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val assetFile1 = Files.createTempFile("asset1", ".zip").toFile()
+            val assetFile2 = Files.createTempFile("asset2", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractBatchPublishPackageVersion>("myTask") {
+                    client.set(mockk<CodeartifactClient>())
+                    registerArtifact("artifact1") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("ns1")
+                        it.packageValue.set("pkg1")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("asset1.zip")
+                        it.assetSHA256.set("sha1")
+                        it.assetContent.set(assetFile1)
+                        it.unfinished.set(true)
+                    }
+                    registerArtifact("artifact2") {
+                        it.domain.set("my-domain")
+                        it.domainOwner.set("123456789012")
+                        it.repository.set("my-repo")
+                        it.namespace.set("ns1")
+                        it.packageValue.set("pkg1")
+                        it.packageVersion.set("1.0.0")
+                        it.assetName.set("asset2.zip")
+                        it.assetSHA256.set("sha2")
+                        it.assetContent.set(assetFile2)
+                    }
+                }
+
+                val artifacts = task.get().artifacts.get()
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize artifacts.size
+                artifacts.forEach { (artifactName, artifact) ->
+                    reqs.any {
+                        it.name == artifactName &&
+                            it.request.assetName == artifact.assetName.orNull
+                    }.shouldBeTrue()
+                }
+            } finally {
+                assetFile1.delete()
+                assetFile2.delete()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BatchGetGenericPackageVersionAsset` and `BatchPublishPackageVersion` to `aws-codeartifact-kotlin-base`, using coroutine `flatMapMerge` for concurrent downloads/uploads with retry support; follows the `BatchDownloadFromS3` / `BatchUploadToS3` pattern with per-artifact coordinates and `registerArtifact` / `outputFileForArtifact` API.
- Adds the same batch operations to `aws-codeartifact-java-base` via a 3-level class hierarchy: a root abstract (artifact registration + request building), two mid-level abstracts (Worker API with sync `CodeartifactClient` and `CompletableFuture` with async `CodeartifactAsyncClient`), and service-wired concrete classes (`BatchGetGenericPackageVersionAsset`, `AsyncBatchGetGenericPackageVersionAsset`, `BatchPublishPackageVersion`, `AsyncBatchPublishPackageVersion`).
- Both bases have test specs verifying request-building (single and multi-artifact) and README updates documenting the new API, class selection guidance, and `outputFileForArtifact` wiring examples.

## Test plan

- [ ] `./gradlew :aws-codeartifact-kotlin-base:test` — 2 new specs (download + publish request-building)
- [ ] `./gradlew :aws-codeartifact-java-base:test` — 4 new specs (Worker + async, download + publish)
- [ ] `./gradlew :aws-codeartifact-kotlin-base:detekt :aws-codeartifact-java-base:detekt` — no new violations
- [ ] Verify `BatchGetGenericPackageVersionAsset` / `AsyncBatchGetGenericPackageVersionAsset` and publish counterparts register correctly in a Gradle build and that `outputFileForArtifact` correctly wires to downstream tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)