### PR TITLE
feat: add BatchUpdateFunctionCode for Java and Kotlin Lambda bases

### DIFF
--- a/cores/aws-lambda-java-base/README.md
+++ b/cores/aws-lambda-java-base/README.md
@@ -11,16 +11,23 @@ dependencies {
 }
 ```
 
-## Build Service
+## Build Services
 
-| Class | Client type |
-|---|---|
-| `LambdaClientBuildService` | `LambdaClient` (AWS SDK for Java) |
+| Class | Client type | Use case |
+|---|---|---|
+| `LambdaClientBuildService` | `LambdaClient` | Synchronous Lambda operations |
+| `LambdaAsyncClientBuildService` | `LambdaAsyncClient` | Asynchronous Lambda operations |
 
-Register the build service from a plugin or `build.gradle.kts`:
+Register a build service from a plugin or `build.gradle.kts`:
 
 ```kotlin
 val lambda = gradle.sharedServices.registerIfAbsent("lambda", LambdaClientBuildService::class) {
+    parameters {
+        regionId.set("us-east-1")
+        defaultCredentials()
+    }
+}
+val lambdaAsync = gradle.sharedServices.registerIfAbsent("lambdaAsync", LambdaAsyncClientBuildService::class) {
     parameters {
         regionId.set("us-east-1")
         defaultCredentials()
@@ -90,6 +97,56 @@ workerExecutor.noIsolation().submit(UpdateFunctionCodeAction::class) {
     publish.set(true)   // optional; defaults to false
 }
 ```
+
+## Tasks: Batch Code Update
+
+Updates the deployment package for multiple Lambda functions. Coordinates and content are specified
+per-artifact. All artifacts must be registered via `registerArtifact`.
+
+Two concurrency models are available — choose based on which client you use:
+
+| Class | Client type | Concurrency |
+|---|---|---|
+| `BatchUpdateFunctionCode` | `LambdaClient` (sync) | Sequential |
+| `AsyncBatchUpdateFunctionCode` | `LambdaAsyncClient` (async) | `CompletableFuture.allOf` |
+
+For BYO-client usage (without auto-registered build services), extend `AbstractSyncBatchUpdateFunctionCode`
+(sync) or `AbstractAsyncBatchUpdateFunctionCode` (async) and set the `service` or `client` property directly.
+
+```kotlin
+val updateAll = tasks.register<BatchUpdateFunctionCode>("updateAll") {
+    service.set(lambda)
+    registerArtifact("api") {
+        it.functionName.set("my-api-fn")
+        it.zipFile.set(layout.buildDirectory.file("dist/api.zip"))
+        it.publish.set(true)
+    }
+    registerArtifact("worker") {
+        it.functionName.set("my-worker-fn")
+        it.zipFile.set(layout.buildDirectory.file("dist/worker.zip"))
+        it.publish.set(true)
+    }
+    // waitForActive.set(false)  // opt out of post-update Active state wait
+    versionArnsFile.set(layout.buildDirectory.file("lambda/version-arns.json"))
+}
+
+// Wire the version ARNs file to a downstream task without forcing evaluation:
+val arnsFile: Provider<RegularFile> = updateAll.flatMap { it.versionArnsFile }
+```
+
+The `versionArnsFile` JSON format is `{"functionName": "arn:aws:lambda:…:function:my-fn:42", …}`.
+
+| Per-artifact property | Type | Description |
+|---|---|---|
+| `functionName` | `Property<String>` | Function name, ARN, or partial ARN |
+| `zipFile` | `RegularFileProperty` | Path to the zip file to upload |
+| `publish` | `Property<Boolean>` | Whether to publish a new version (optional) |
+
+| Task property | Type | Description |
+|---|---|---|
+| `service` / `client` | `Property<…BuildService>` | Build service (or raw async client) |
+| `waitForActive` | `Property<Boolean>` | Wait for `LastUpdateStatus = Successful` after each upload (default `true`) |
+| `versionArnsFile` | `RegularFileProperty` | Optional file to write published version ARN JSON into |
 
 ## See Also
 

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractAsyncBatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractAsyncBatchUpdateFunctionCode.kt
@@ -1,0 +1,80 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient
+import software.amazon.awssdk.services.lambda.model.GetFunctionRequest
+import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeRequest
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+/**
+ * Abstract [AbstractBatchUpdateFunctionCode] that uses a [LambdaAsyncClient] to update multiple Lambda
+ * functions concurrently via `CompletableFuture`.
+ *
+ * All updates are initiated immediately. When [waitForActive] is `true` (the default), each update future
+ * is chained to a [software.amazon.awssdk.services.lambda.waiters.LambdaAsyncWaiter] call that polls until
+ * `LastUpdateStatus` reaches `Successful`. All futures are joined at the end of the task action. There is
+ * no built-in retry support — failures propagate immediately. If any future fails, the task throws.
+ *
+ * **BYO-client use:** Extend this class and set [client] directly. For automatic service registration via
+ * `@ServiceReference`, extend [AsyncBatchUpdateFunctionCode] instead.
+ *
+ * @see AsyncBatchUpdateFunctionCode
+ * @see AbstractSyncBatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class AbstractAsyncBatchUpdateFunctionCode @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchUpdateFunctionCode(objects) {
+
+    /**
+     * The asynchronous Lambda client.
+     * Set directly for BYO-client usage; [AsyncBatchUpdateFunctionCode] wires this from a build service.
+     */
+    @get:Internal
+    abstract val client: Property<LambdaAsyncClient>
+
+    @Suppress("detekt:SpreadOperator")
+    @TaskAction
+    fun run() {
+        val lambdaClient = client.get()
+        val waiter = if (waitForActive.getOrElse(true)) lambdaClient.waiter() else null
+        val versionArns = ConcurrentHashMap<String, String>()
+
+        val futures = requests.getOrElse(emptyList()).map { req ->
+            val bytes = req.zipFile.get().asFile.readBytes()
+            val request = UpdateFunctionCodeRequest.builder()
+                .functionName(req.functionName)
+                .zipFile(SdkBytes.fromByteArray(bytes))
+                .also { if (req.publish != null) it.publish(req.publish) }
+                .build()
+            lambdaClient.updateFunctionCode(request)
+                .thenCompose { response ->
+                    if (waiter != null) {
+                        waiter.waitUntilFunctionUpdatedV2(
+                            GetFunctionRequest.builder().functionName(req.functionName).build(),
+                        ).thenApply { response }
+                    } else {
+                        CompletableFuture.completedFuture(response)
+                    }
+                }
+                .thenApply { response ->
+                    if (req.publish == true) {
+                        response.functionArn()?.let { versionArns[req.functionName] = it }
+                    }
+                }
+        }
+
+        CompletableFuture.allOf(*futures.toTypedArray<CompletableFuture<Unit>>()).join()
+
+        if (versionArnsFile.isPresent) {
+            writeVersionArnsJson(versionArnsFile.get().asFile, versionArns)
+        }
+    }
+}

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractBatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractBatchUpdateFunctionCode.kt
@@ -1,0 +1,130 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Abstract root [DefaultTask] that updates the deployment package for multiple Lambda functions.
+ *
+ * Handles artifact registration and request parameter building. Subclasses provide their own
+ * `@TaskAction` to implement the actual update using either a synchronous or asynchronous client.
+ *
+ * **Choosing a subclass:**
+ * - Extend [AbstractSyncBatchUpdateFunctionCode] (or use [BatchUpdateFunctionCode]) for direct synchronous
+ *   calls using a `LambdaClient`. Updates are executed sequentially.
+ * - Extend [AbstractAsyncBatchUpdateFunctionCode] (or use [AsyncBatchUpdateFunctionCode]) for concurrent
+ *   `CompletableFuture`-based calls using a `LambdaAsyncClient`. All updates run concurrently.
+ *
+ * **BYO-client use:** Extend one of the abstract mid-level classes and set the `service` or `client`
+ * property directly rather than using the service-wired concrete classes.
+ *
+ * @see AbstractSyncBatchUpdateFunctionCode
+ * @see AbstractAsyncBatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class AbstractBatchUpdateFunctionCode @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * Per-function coordinates and deployment package for a single Lambda code update.
+     */
+    interface Artifact {
+        /** The function name, ARN, or partial ARN to update. */
+        @get:Input
+        val functionName: Property<String>
+
+        /** Path to the deployment package zip file to upload. */
+        @get:InputFile
+        @get:PathSensitive(PathSensitivity.NONE)
+        val zipFile: RegularFileProperty
+
+        /** Whether to publish a new version after the update. When absent, defaults to `false`. */
+        @get:Input
+        @get:Optional
+        val publish: Property<Boolean>
+    }
+
+    /** Map of artifact name to per-function configuration. */
+    @get:Nested
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers a function to update.
+     *
+     * @param name Unique name for this artifact within the batch.
+     * @param action Configures the function name, zip file, and publish flag.
+     */
+    fun registerArtifact(name: String, action: Action<in Artifact>) {
+        val artifact = objects.newInstance<Artifact>().also { action.execute(it) }
+        artifacts.put(name, artifact)
+    }
+
+    /**
+     * Whether to wait for each function's `LastUpdateStatus` to reach `Successful` after uploading.
+     *
+     * Defaults to `true`. Set to `false` to skip the waiter and return as soon as the upload API call
+     * completes. Skipping may cause downstream tasks that invoke or configure the function to race the update.
+     */
+    @get:Internal
+    abstract val waitForActive: Property<Boolean>
+
+    /**
+     * Optional file to receive the `{functionName → versionArn}` JSON map after all updates complete.
+     *
+     * Only populated for functions where [Artifact.publish] is `true` and the response contains an ARN.
+     * The file is always written when configured (empty JSON `{}` if no functions were published).
+     */
+    @get:OutputFile
+    @get:Optional
+    abstract val versionArnsFile: RegularFileProperty
+
+    internal data class Request(
+        val name: String,
+        val functionName: String,
+        val zipFile: RegularFileProperty,
+        val publish: Boolean?,
+    )
+
+    @Suppress("LeakingThis")
+    @get:Internal
+    internal val requests = artifacts.map { map ->
+        map.entries.map { (artifactName, artifact) ->
+            Request(
+                name = artifactName,
+                functionName = artifact.functionName.get(),
+                zipFile = artifact.zipFile,
+                publish = artifact.publish.orNull,
+            )
+        }
+    }
+
+    internal fun writeVersionArnsJson(file: File, arns: Map<String, String>) {
+        val json = buildString {
+            append("{")
+            arns.entries.forEachIndexed { i, (name, arn) ->
+                if (i > 0) append(",")
+                append("\n    \"$name\": \"$arn\"")
+            }
+            if (arns.isNotEmpty()) append("\n")
+            append("}")
+        }
+        file.writeText(json)
+    }
+}

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractSyncBatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractSyncBatchUpdateFunctionCode.kt
@@ -1,0 +1,66 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.lambda.model.GetFunctionRequest
+import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeRequest
+import javax.inject.Inject
+
+/**
+ * Abstract [AbstractBatchUpdateFunctionCode] that uses a synchronous [LambdaClientBuildService] to update
+ * multiple Lambda functions sequentially.
+ *
+ * Functions are updated one at a time in registration order. When [waitForActive] is `true` (the default),
+ * a [software.amazon.awssdk.services.lambda.waiters.LambdaWaiter] is used to poll each function until its
+ * `LastUpdateStatus` reaches `Successful` before proceeding to the next. There is no built-in retry
+ * support — failures propagate immediately and stop the remaining updates.
+ *
+ * **BYO-service use:** Extend this class and set [service] directly. For automatic service registration via
+ * `@ServiceReference`, extend [BatchUpdateFunctionCode] instead.
+ *
+ * @see BatchUpdateFunctionCode
+ * @see AbstractAsyncBatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class AbstractSyncBatchUpdateFunctionCode @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchUpdateFunctionCode(objects) {
+
+    /**
+     * The build service managing the synchronous Lambda client.
+     * Set directly for BYO-service usage; [BatchUpdateFunctionCode] wires this via `@ServiceReference`.
+     */
+    @get:Internal
+    abstract val service: Property<LambdaClientBuildService>
+
+    @TaskAction
+    fun run() {
+        val lambdaClient = service.get().getClient()
+        val waiter = if (waitForActive.getOrElse(true)) lambdaClient.waiter() else null
+        val versionArns = mutableMapOf<String, String>()
+
+        requests.getOrElse(emptyList()).forEach { req ->
+            val bytes = req.zipFile.get().asFile.readBytes()
+            val request = UpdateFunctionCodeRequest.builder()
+                .functionName(req.functionName)
+                .zipFile(SdkBytes.fromByteArray(bytes))
+                .also { if (req.publish != null) it.publish(req.publish) }
+                .build()
+            val response = lambdaClient.updateFunctionCode(request)
+            waiter?.waitUntilFunctionUpdatedV2(
+                GetFunctionRequest.builder().functionName(req.functionName).build(),
+            )
+            if (req.publish == true) {
+                response.functionArn()?.let { versionArns[req.functionName] = it }
+            }
+        }
+
+        if (versionArnsFile.isPresent) {
+            writeVersionArnsJson(versionArnsFile.get().asFile, versionArns)
+        }
+    }
+}

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AsyncBatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/AsyncBatchUpdateFunctionCode.kt
@@ -1,0 +1,55 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that updates the deployment package for multiple Lambda functions concurrently via
+ * `CompletableFuture`, wired to a [LambdaAsyncClientBuildService].
+ *
+ * All updates are initiated concurrently. Use [waitForActive] (default `true`) to control whether the task
+ * waits for each function to reach `LastUpdateStatus = Successful` before completing. Configure
+ * [versionArnsFile] to capture published version ARNs as a JSON file for downstream tasks:
+ *
+ * ```kotlin
+ * tasks.register<AsyncBatchUpdateFunctionCode>("updateAll") {
+ *     service.set(lambdaAsync)
+ *     registerArtifact("api") {
+ *         it.functionName.set("my-api-fn")
+ *         it.zipFile.set(layout.buildDirectory.file("dist/api.zip"))
+ *         it.publish.set(true)
+ *     }
+ *     registerArtifact("worker") {
+ *         it.functionName.set("my-worker-fn")
+ *         it.zipFile.set(layout.buildDirectory.file("dist/worker.zip"))
+ *         it.publish.set(true)
+ *     }
+ *     versionArnsFile.set(layout.buildDirectory.file("lambda/version-arns.json"))
+ * }
+ * ```
+ *
+ * For BYO-client usage, extend [AbstractAsyncBatchUpdateFunctionCode] and set `client` directly.
+ * For sequential updates using the synchronous client, use [BatchUpdateFunctionCode].
+ *
+ * @see AbstractAsyncBatchUpdateFunctionCode
+ * @see BatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class AsyncBatchUpdateFunctionCode @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractAsyncBatchUpdateFunctionCode(objects) {
+
+    /** The shared build service managing the asynchronous Lambda client. */
+    @get:ServiceReference
+    abstract val service: Property<LambdaAsyncClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/BatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/BatchUpdateFunctionCode.kt
@@ -1,0 +1,43 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that updates the deployment package for multiple Lambda functions sequentially,
+ * wired to a [LambdaClientBuildService].
+ *
+ * Register functions via [registerArtifact]. Use [waitForActive] (default `true`) to control whether
+ * the task waits for each function to reach `LastUpdateStatus = Successful` before proceeding.
+ * Configure [versionArnsFile] to capture published version ARNs as a JSON file for downstream tasks:
+ *
+ * ```kotlin
+ * tasks.register<BatchUpdateFunctionCode>("updateAll") {
+ *     service.set(lambda)
+ *     registerArtifact("api") {
+ *         it.functionName.set("my-api-fn")
+ *         it.zipFile.set(layout.buildDirectory.file("dist/api.zip"))
+ *         it.publish.set(true)
+ *     }
+ *     versionArnsFile.set(layout.buildDirectory.file("lambda/version-arns.json"))
+ * }
+ * ```
+ *
+ * For BYO-service usage, extend [AbstractSyncBatchUpdateFunctionCode] and set `service` directly.
+ * For concurrent updates using the async client, use [AsyncBatchUpdateFunctionCode].
+ *
+ * @see AbstractSyncBatchUpdateFunctionCode
+ * @see AsyncBatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class BatchUpdateFunctionCode @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractSyncBatchUpdateFunctionCode(objects) {
+
+    /** The shared build service managing the synchronous Lambda client. */
+    @get:ServiceReference
+    abstract override val service: Property<LambdaClientBuildService>
+}

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/LambdaAsyncClientBuildService.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/LambdaAsyncClientBuildService.kt
@@ -1,0 +1,22 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import com.kelvsyc.gradle.aws.java.AbstractAwsJavaClientBuildService
+import com.kelvsyc.gradle.aws.java.AwsBuildServiceParams
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient
+
+/**
+ * Build service managing an asynchronous [LambdaAsyncClient] instance.
+ *
+ * Register an instance via [org.gradle.api.services.BuildServiceRegistry.registerIfAbsent], configuring
+ * parameters via the [AwsBuildServiceParams] extension functions as needed. The same registration can then
+ * be shared with tasks via a `Property<LambdaAsyncClientBuildService>` parameter.
+ *
+ * Use this service with [AsyncBatchUpdateFunctionCode] for concurrent Lambda code updates via
+ * `CompletableFuture`. For synchronous updates, use [LambdaClientBuildService] instead.
+ *
+ * @see LambdaClientBuildService
+ */
+abstract class LambdaAsyncClientBuildService :
+    AbstractAwsJavaClientBuildService<LambdaAsyncClient, AwsBuildServiceParams>() {
+    override fun createClient(): LambdaAsyncClient = configureBuilder(LambdaAsyncClient.builder()).build()
+}

--- a/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractAsyncBatchUpdateFunctionCodeSpec.kt
+++ b/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractAsyncBatchUpdateFunctionCodeSpec.kt
@@ -1,0 +1,117 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient
+import java.nio.file.Files
+
+class AbstractAsyncBatchUpdateFunctionCodeSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaAsyncClient>()
+            MockLambdaAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "lambdaAsync",
+                MockLambdaAsyncClientBuildService::class,
+            )
+            val zipFile = Files.createTempFile("fn", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractAsyncBatchUpdateFunctionCode>("myTask") {
+                    this.client.set(service.map { it.getClient() })
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn")
+                        it.zipFile.set(zipFile)
+                        it.publish.set(true)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].name shouldBe "fn1"
+                reqs[0].functionName shouldBe "my-fn"
+                reqs[0].publish shouldBe true
+            } finally {
+                zipFile.delete()
+                MockLambdaAsyncClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register artifact without publish flag - publish is null") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaAsyncClient>()
+            MockLambdaAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "lambdaAsync",
+                MockLambdaAsyncClientBuildService::class,
+            )
+            val zipFile = Files.createTempFile("fn", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractAsyncBatchUpdateFunctionCode>("myTask") {
+                    this.client.set(service.map { it.getClient() })
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn")
+                        it.zipFile.set(zipFile)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].publish.shouldBeNull()
+            } finally {
+                zipFile.delete()
+                MockLambdaAsyncClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register multiple artifacts - all artifacts appear in requests") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaAsyncClient>()
+            MockLambdaAsyncClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "lambdaAsync",
+                MockLambdaAsyncClientBuildService::class,
+            )
+            val zipFile1 = Files.createTempFile("fn1", ".zip").toFile()
+            val zipFile2 = Files.createTempFile("fn2", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractAsyncBatchUpdateFunctionCode>("myTask") {
+                    this.client.set(service.map { it.getClient() })
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn-1")
+                        it.zipFile.set(zipFile1)
+                        it.publish.set(true)
+                    }
+                    registerArtifact("fn2") {
+                        it.functionName.set("my-fn-2")
+                        it.zipFile.set(zipFile2)
+                    }
+                }
+
+                val artifacts = task.get().artifacts.get()
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize artifacts.size
+                artifacts.forEach { (artifactName, artifact) ->
+                    reqs.any {
+                        it.name == artifactName &&
+                            it.functionName == artifact.functionName.orNull
+                    }.shouldBeTrue()
+                }
+            } finally {
+                zipFile1.delete()
+                zipFile2.delete()
+                MockLambdaAsyncClientBuildService.mockClient = null
+            }
+        }
+    }
+}

--- a/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractBatchUpdateFunctionCodeSpec.kt
+++ b/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/AbstractBatchUpdateFunctionCodeSpec.kt
@@ -1,0 +1,117 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.lambda.LambdaClient
+import java.nio.file.Files
+
+class AbstractBatchUpdateFunctionCodeSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaClient>()
+            MockLambdaClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "lambda",
+                MockLambdaClientBuildService::class,
+            )
+            val zipFile = Files.createTempFile("fn", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractSyncBatchUpdateFunctionCode>("myTask") {
+                    this.service.set(service)
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn")
+                        it.zipFile.set(zipFile)
+                        it.publish.set(true)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].name shouldBe "fn1"
+                reqs[0].functionName shouldBe "my-fn"
+                reqs[0].publish shouldBe true
+            } finally {
+                zipFile.delete()
+                MockLambdaClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register artifact without publish flag - publish is null") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaClient>()
+            MockLambdaClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "lambda",
+                MockLambdaClientBuildService::class,
+            )
+            val zipFile = Files.createTempFile("fn", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractSyncBatchUpdateFunctionCode>("myTask") {
+                    this.service.set(service)
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn")
+                        it.zipFile.set(zipFile)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].publish.shouldBeNull()
+            } finally {
+                zipFile.delete()
+                MockLambdaClientBuildService.mockClient = null
+            }
+        }
+
+        test("Register multiple artifacts - all artifacts appear in requests") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaClient>()
+            MockLambdaClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent(
+                "lambda",
+                MockLambdaClientBuildService::class,
+            )
+            val zipFile1 = Files.createTempFile("fn1", ".zip").toFile()
+            val zipFile2 = Files.createTempFile("fn2", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractSyncBatchUpdateFunctionCode>("myTask") {
+                    this.service.set(service)
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn-1")
+                        it.zipFile.set(zipFile1)
+                        it.publish.set(true)
+                    }
+                    registerArtifact("fn2") {
+                        it.functionName.set("my-fn-2")
+                        it.zipFile.set(zipFile2)
+                    }
+                }
+
+                val artifacts = task.get().artifacts.get()
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize artifacts.size
+                artifacts.forEach { (artifactName, artifact) ->
+                    reqs.any {
+                        it.name == artifactName &&
+                            it.functionName == artifact.functionName.orNull
+                    }.shouldBeTrue()
+                }
+            } finally {
+                zipFile1.delete()
+                zipFile2.delete()
+                MockLambdaClientBuildService.mockClient = null
+            }
+        }
+    }
+}

--- a/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/MockLambdaAsyncClientBuildService.kt
+++ b/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/MockLambdaAsyncClientBuildService.kt
@@ -1,0 +1,16 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient
+
+/**
+ * Test-only [LambdaAsyncClientBuildService] that returns a pre-supplied mock [LambdaAsyncClient].
+ *
+ * Set [mockClient] before retrieving the client; the same instance is returned on every call.
+ */
+abstract class MockLambdaAsyncClientBuildService : LambdaAsyncClientBuildService() {
+    override fun createClient(): LambdaAsyncClient = checkNotNull(mockClient) { "mockClient not set" }
+
+    companion object {
+        var mockClient: LambdaAsyncClient? = null
+    }
+}

--- a/cores/aws-lambda-kotlin-base/README.md
+++ b/cores/aws-lambda-kotlin-base/README.md
@@ -106,6 +106,54 @@ tasks.register<UpdateFunctionCode>("updateLambdaCode") {
 | `zipFile` | `RegularFileProperty` | Path to the zip file to upload |
 | `publish` | `Property<Boolean>` | Whether to publish a new version after update (defaults to `false`) |
 
+### `BatchUpdateFunctionCode`
+
+Updates the deployment package for multiple Lambda functions concurrently via coroutine `flatMapMerge`.
+All functions registered via `registerArtifact` are uploaded in parallel. After each upload, the task
+optionally waits for the function's `LastUpdateStatus` to reach `Successful` (controlled by `waitForActive`,
+default `true`) before completing. When any function is published, the resulting version ARNs can be written
+to a JSON file via `versionArnsFile`:
+
+```kotlin
+val updateAll = tasks.register<BatchUpdateFunctionCode>("updateAll") {
+    service.set(lambda)
+    registerArtifact("api") {
+        functionName.set("my-api-fn")
+        zipFile.set(layout.buildDirectory.file("dist/api.zip"))
+        publish.set(true)
+    }
+    registerArtifact("worker") {
+        functionName.set("my-worker-fn")
+        zipFile.set(layout.buildDirectory.file("dist/worker.zip"))
+        publish.set(true)
+    }
+    // waitForActive.set(false)  // opt out of post-update Active state wait
+    versionArnsFile.set(layout.buildDirectory.file("lambda/version-arns.json"))
+}
+```
+
+Wire the version ARNs file to a downstream task without forcing evaluation:
+
+```kotlin
+val arnsFile: Provider<RegularFile> = updateAll.flatMap { it.versionArnsFile }
+```
+
+The `versionArnsFile` JSON format is `{"functionName": "arn:aws:lambda:…:function:my-fn:42", …}`.
+
+| Per-artifact property | Type | Description |
+|---|---|---|
+| `functionName` | `Property<String>` | Function name, ARN, or partial ARN |
+| `zipFile` | `RegularFileProperty` | Path to the zip file to upload |
+| `publish` | `Property<Boolean>` | Whether to publish a new version (optional) |
+
+| Task property | Type | Description |
+|---|---|---|
+| `service` | `Property<LambdaClientBuildService>` | Build service supplying the Lambda client |
+| `waitForActive` | `Property<Boolean>` | Wait for `LastUpdateStatus = Successful` after each upload (default `true`) |
+| `versionArnsFile` | `RegularFileProperty` | Optional file to write published version ARN JSON into |
+
+For BYO-client usage (no build service), extend `AbstractBatchUpdateFunctionCode` and set `client` directly.
+
 ## Why no WorkActions
 
 The AWS Kotlin SDK exposes all service calls as `suspend` functions. A `WorkAction` that wraps a single suspend call reduces to:

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/AbstractBatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/AbstractBatchUpdateFunctionCode.kt
@@ -1,0 +1,181 @@
+package com.kelvsyc.gradle.aws.kotlin.lambda
+
+import aws.sdk.kotlin.services.lambda.LambdaClient
+import aws.sdk.kotlin.services.lambda.model.UpdateFunctionCodeRequest
+import aws.sdk.kotlin.services.lambda.waiters.waitUntilFunctionUpdatedV2
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.newInstance
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+/**
+ * Abstract [DefaultTask] that updates the deployment package for multiple Lambda functions in parallel.
+ *
+ * Each function is registered via [registerArtifact] with its own zip file. Updates run concurrently
+ * using coroutine `flatMapMerge`. If any update fails the exception propagates and the task fails.
+ *
+ * When [waitForActive] is `true` (the default), the task waits for each function's `LastUpdateStatus`
+ * to reach `Successful` before completing, preventing downstream tasks from racing a function that is
+ * still activating its new code.
+ *
+ * When [versionArnsFile] is configured, the task writes a JSON map of `{functionName → versionArn}`
+ * to that file after all updates complete. Only functions where [Artifact.publish] is `true` and the
+ * response contains a function ARN are included. The file is always written when configured.
+ *
+ * **BYO-client use:** Set [client] directly. For service-wired use, extend [BatchUpdateFunctionCode] instead.
+ *
+ * @see BatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class AbstractBatchUpdateFunctionCode @Inject constructor(
+    private val objects: ObjectFactory,
+) : DefaultTask() {
+
+    /**
+     * Per-function coordinates and deployment package for a single Lambda code update.
+     */
+    interface Artifact {
+        /** The function name, ARN, or partial ARN to update. */
+        @get:Input
+        val functionName: Property<String>
+
+        /** Path to the deployment package zip file to upload. */
+        @get:InputFile
+        @get:PathSensitive(PathSensitivity.NONE)
+        val zipFile: RegularFileProperty
+
+        /** Whether to publish a new version after the update. When absent, defaults to `false`. */
+        @get:Input
+        @get:Optional
+        val publish: Property<Boolean>
+    }
+
+    /** Map of artifact name to per-function configuration. */
+    @get:Nested
+    abstract val artifacts: MapProperty<String, Artifact>
+
+    /**
+     * Registers a function to update.
+     *
+     * @param name Unique name for this artifact within the batch.
+     * @param action Configures the function name, zip file, and publish flag.
+     */
+    fun registerArtifact(name: String, action: Action<in Artifact>) {
+        val artifact = objects.newInstance<Artifact>().also { action.execute(it) }
+        artifacts.put(name, artifact)
+    }
+
+    /**
+     * The Lambda client to use for updates.
+     * Set directly for BYO-client usage; [BatchUpdateFunctionCode] wires this from a build service.
+     */
+    @get:Internal
+    abstract val client: Property<LambdaClient>
+
+    /**
+     * Whether to wait for each function's `LastUpdateStatus` to reach `Successful` after uploading.
+     *
+     * Defaults to `true`. Set to `false` to skip the waiter and return as soon as the upload API call
+     * completes. Skipping may cause downstream tasks that invoke or configure the function to race the update.
+     */
+    @get:Internal
+    abstract val waitForActive: Property<Boolean>
+
+    /**
+     * Optional file to receive the `{functionName → versionArn}` JSON map after all updates complete.
+     *
+     * Only populated for functions where [Artifact.publish] is `true` and the response contains an ARN.
+     * The file is always written when configured (empty JSON `{}` if no functions were published).
+     */
+    @get:OutputFile
+    @get:Optional
+    abstract val versionArnsFile: RegularFileProperty
+
+    internal data class Request(
+        val name: String,
+        val functionName: String,
+        val zipFile: RegularFileProperty,
+        val publish: Boolean?,
+    )
+
+    @Suppress("LeakingThis")
+    @get:Internal
+    internal val requests = artifacts.map { map ->
+        map.entries.map { (artifactName, artifact) ->
+            Request(
+                name = artifactName,
+                functionName = artifact.functionName.get(),
+                zipFile = artifact.zipFile,
+                publish = artifact.publish.orNull,
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @TaskAction
+    fun run() {
+        val versionArns = ConcurrentHashMap<String, String>()
+        runBlocking {
+            requests.getOrElse(emptyList()).asFlow()
+                .flatMapMerge { req ->
+                    flow {
+                        val bytes = req.zipFile.get().asFile.readBytes()
+                        val request = UpdateFunctionCodeRequest {
+                            functionName = req.functionName
+                            zipFile = bytes
+                            publish = req.publish
+                        }
+                        val response = client.get().updateFunctionCode(request)
+                        if (waitForActive.getOrElse(true)) {
+                            client.get().waitUntilFunctionUpdatedV2 {
+                                functionName = req.functionName
+                            }
+                        }
+                        if (req.publish == true && response.functionArn != null) {
+                            versionArns[req.functionName] = response.functionArn!!
+                        }
+                        emit(Unit)
+                    }
+                }
+                .collect()
+        }
+        if (versionArnsFile.isPresent) {
+            writeVersionArnsJson(versionArnsFile.get().asFile, versionArns)
+        }
+    }
+
+    private fun writeVersionArnsJson(file: File, arns: Map<String, String>) {
+        val json = buildString {
+            append("{")
+            arns.entries.forEachIndexed { i, (name, arn) ->
+                if (i > 0) append(",")
+                append("\n    \"$name\": \"$arn\"")
+            }
+            if (arns.isNotEmpty()) append("\n")
+            append("}")
+        }
+        file.writeText(json)
+    }
+}

--- a/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/BatchUpdateFunctionCode.kt
+++ b/cores/aws-lambda-kotlin-base/src/main/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/BatchUpdateFunctionCode.kt
@@ -1,0 +1,52 @@
+package com.kelvsyc.gradle.aws.kotlin.lambda
+
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.work.DisableCachingByDefault
+import javax.inject.Inject
+
+/**
+ * [DefaultTask] that updates the deployment package for multiple Lambda functions in parallel,
+ * wired to a [LambdaClientBuildService].
+ *
+ * Register functions via [registerArtifact]. Use [waitForActive] (default `true`) to control whether
+ * the task waits for each function to reach `LastUpdateStatus = Successful` before completing.
+ * Configure [versionArnsFile] to capture published version ARNs as a JSON file for downstream tasks:
+ *
+ * ```kotlin
+ * val updateAll = tasks.register<BatchUpdateFunctionCode>("updateAll") {
+ *     service.set(lambda)
+ *     registerArtifact("api") {
+ *         functionName.set("my-api-fn")
+ *         zipFile.set(layout.buildDirectory.file("dist/api.zip"))
+ *         publish.set(true)
+ *     }
+ *     registerArtifact("worker") {
+ *         functionName.set("my-worker-fn")
+ *         zipFile.set(layout.buildDirectory.file("dist/worker.zip"))
+ *         publish.set(true)
+ *     }
+ *     versionArnsFile.set(layout.buildDirectory.file("lambda/version-arns.json"))
+ * }
+ * ```
+ *
+ * For BYO-client usage (no build service), extend [AbstractBatchUpdateFunctionCode] directly.
+ *
+ * @see AbstractBatchUpdateFunctionCode
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class BatchUpdateFunctionCode @Inject constructor(
+    objects: ObjectFactory,
+) : AbstractBatchUpdateFunctionCode(objects) {
+
+    /** The shared build service managing the Lambda client. */
+    @get:ServiceReference
+    abstract val service: Property<LambdaClientBuildService>
+
+    init {
+        client.set(service.map { it.getClient() })
+        client.disallowChanges()
+        client.finalizeValueOnRead()
+    }
+}

--- a/cores/aws-lambda-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/AbstractBatchUpdateFunctionCodeSpec.kt
+++ b/cores/aws-lambda-kotlin-base/src/test/kotlin/com/kelvsyc/gradle/aws/kotlin/lambda/AbstractBatchUpdateFunctionCodeSpec.kt
@@ -1,0 +1,95 @@
+package com.kelvsyc.gradle.aws.kotlin.lambda
+
+import aws.sdk.kotlin.services.lambda.LambdaClient
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.gradle.kotlin.dsl.register
+import org.gradle.testfixtures.ProjectBuilder
+import java.nio.file.Files
+
+class AbstractBatchUpdateFunctionCodeSpec : FunSpec() {
+    init {
+        test("Register single artifact - configures request parameters") {
+            val project = ProjectBuilder.builder().build()
+            val zipFile = Files.createTempFile("fn", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractBatchUpdateFunctionCode>("myTask") {
+                    client.set(mockk<LambdaClient>())
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn")
+                        it.zipFile.set(zipFile)
+                        it.publish.set(true)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].name shouldBe "fn1"
+                reqs[0].functionName shouldBe "my-fn"
+                reqs[0].publish shouldBe true
+            } finally {
+                zipFile.delete()
+            }
+        }
+
+        test("Register artifact without publish flag - publish is null") {
+            val project = ProjectBuilder.builder().build()
+            val zipFile = Files.createTempFile("fn", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractBatchUpdateFunctionCode>("myTask") {
+                    client.set(mockk<LambdaClient>())
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn")
+                        it.zipFile.set(zipFile)
+                    }
+                }
+
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize 1
+                reqs[0].publish.shouldBeNull()
+            } finally {
+                zipFile.delete()
+            }
+        }
+
+        test("Register multiple artifacts - all artifacts appear in requests") {
+            val project = ProjectBuilder.builder().build()
+            val zipFile1 = Files.createTempFile("fn1", ".zip").toFile()
+            val zipFile2 = Files.createTempFile("fn2", ".zip").toFile()
+
+            try {
+                val task = project.tasks.register<AbstractBatchUpdateFunctionCode>("myTask") {
+                    client.set(mockk<LambdaClient>())
+                    registerArtifact("fn1") {
+                        it.functionName.set("my-fn-1")
+                        it.zipFile.set(zipFile1)
+                        it.publish.set(true)
+                    }
+                    registerArtifact("fn2") {
+                        it.functionName.set("my-fn-2")
+                        it.zipFile.set(zipFile2)
+                    }
+                }
+
+                val artifacts = task.get().artifacts.get()
+                val reqs = task.get().requests.get()
+                reqs shouldHaveSize artifacts.size
+                artifacts.forEach { (artifactName, artifact) ->
+                    reqs.any {
+                        it.name == artifactName &&
+                            it.functionName == artifact.functionName.orNull
+                    }.shouldBeTrue()
+                }
+            } finally {
+                zipFile1.delete()
+                zipFile2.delete()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `BatchUpdateFunctionCode` and `AbstractBatchUpdateFunctionCode` to `aws-lambda-kotlin-base`, using coroutine `flatMapMerge` for concurrent uploads with an opt-out `waitUntilFunctionUpdatedV2` waiter and an optional `versionArnsFile` for capturing published version ARNs as JSON.
- Adds a 3-level hierarchy to `aws-lambda-java-base`: root abstract (artifact registration), `AbstractSyncBatchUpdateFunctionCode`/`BatchUpdateFunctionCode` (sequential, `LambdaClient` + `LambdaWaiter`), and `AbstractAsyncBatchUpdateFunctionCode`/`AsyncBatchUpdateFunctionCode` (concurrent `CompletableFuture`, `LambdaAsyncClient` + `LambdaAsyncWaiter`).
- Introduces `LambdaAsyncClientBuildService` to the Java base alongside the existing sync service.
- Tests verify request field mapping for single/multi-artifact registration and absent publish flag; READMEs updated for both components.

## Test plan

- [ ] `./gradlew :aws-lambda-kotlin-base:test :aws-lambda-java-base:test` — all specs pass
- [ ] `./gradlew :aws-lambda-kotlin-base:detekt :aws-lambda-java-base:detekt` — no lint violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)