### PR TITLE
feat: add AWS Lambda JVM packaging and deploy plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Standalone Gradle plugins that solve a specific build problem. Apply them direct
 | `git-core` | `com.kelvsyc.gradle.git-core` | Git archival tasks and JGit extensions for remote repositories |
 | `jfrog-cli-core` | `com.kelvsyc.gradle.jfrog-cli-core` | Gradle tasks wrapping the JFrog CLI |
 | `karakum-core` | `com.kelvsyc.gradle.karakum-core` | Karakum TypeScript → Kotlin external-declaration codegen, with automatic Kotlin/JS and KMP source-set wiring |
+| `aws-lambda-jvm-plugin` | `com.kelvsyc.gradle.aws-lambda-jvm` | Composable JVM Lambda packaging plugins: fat-JAR and thin-JAR deployment ZIPs |
+| `aws-lambda-jvm-deploy-plugin` | `com.kelvsyc.gradle.aws-lambda-jvm.deploy` | Wires the `aws-lambda-jvm-plugin` deployment ZIP to an AWS Lambda upload task |
 
 All plugin IDs are prefixed with `com.kelvsyc.gradle.`.
 

--- a/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/UpdateFunctionCodeTask.kt
+++ b/cores/aws-lambda-java-base/src/main/kotlin/com/kelvsyc/gradle/aws/java/lambda/UpdateFunctionCodeTask.kt
@@ -1,0 +1,58 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import software.amazon.awssdk.core.SdkBytes
+import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeRequest
+
+/**
+ * Task that updates the deployment package (zip file) for a single Lambda function.
+ *
+ * The [zipFile] is read from disk and uploaded as the function's new code. When [publish]
+ * is `true`, AWS publishes a new function version after the update.
+ *
+ * For updating multiple functions in a single task, use [BatchUpdateFunctionCode] instead.
+ */
+@DisableCachingByDefault(because = "Communicates with AWS Lambda")
+abstract class UpdateFunctionCodeTask : DefaultTask() {
+
+    /** The build service managing the Lambda client. */
+    @get:ServiceReference
+    abstract val service: Property<LambdaClientBuildService>
+
+    /** The function name, ARN, or partial ARN to update. */
+    @get:Input
+    abstract val functionName: Property<String>
+
+    /** Path to the deployment package zip file to upload. */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val zipFile: RegularFileProperty
+
+    /** Whether to publish a new version after the update. When absent, defaults to `false`. */
+    @get:Input
+    @get:Optional
+    abstract val publish: Property<Boolean>
+
+    @TaskAction
+    fun execute() {
+        val bytes = zipFile.get().asFile.readBytes()
+        val request = UpdateFunctionCodeRequest.builder().apply {
+            functionName(functionName.get())
+            zipFile(SdkBytes.fromByteArray(bytes))
+            if (publish.isPresent) {
+                publish(publish.get())
+            }
+        }.build()
+        service.get().getClient().updateFunctionCode(request)
+    }
+}

--- a/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/UpdateFunctionCodeTaskSpec.kt
+++ b/cores/aws-lambda-java-base/src/test/kotlin/com/kelvsyc/gradle/aws/java/lambda/UpdateFunctionCodeTaskSpec.kt
@@ -1,0 +1,76 @@
+package com.kelvsyc.gradle.aws.java.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.registerIfAbsent
+import org.gradle.testfixtures.ProjectBuilder
+import software.amazon.awssdk.services.lambda.LambdaClient
+import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeRequest
+import software.amazon.awssdk.services.lambda.model.UpdateFunctionCodeResponse
+
+class UpdateFunctionCodeTaskSpec : FunSpec() {
+    init {
+        test("execute - uploads zip and publishes version") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaClient>()
+            MockLambdaClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("lambda", MockLambdaClientBuildService::class)
+            val requestSlot = slot<UpdateFunctionCodeRequest>()
+            every { client.updateFunctionCode(capture(requestSlot)) } returns mockk<UpdateFunctionCodeResponse>()
+
+            val zipFile = project.layout.buildDirectory.file("fn.zip").get().asFile
+            zipFile.parentFile.mkdirs()
+            val expectedBytes = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+            zipFile.writeBytes(expectedBytes)
+
+            try {
+                val task = project.tasks.register<UpdateFunctionCodeTask>("uploadFn") {
+                    this.service.set(service)
+                    this.functionName.set("my-fn")
+                    this.zipFile.set(zipFile)
+                    this.publish.set(true)
+                }.get()
+
+                task.execute()
+
+                val captured = requestSlot.captured
+                captured.functionName() shouldBe "my-fn"
+                captured.publish() shouldBe true
+                captured.zipFile().asByteArray().toList() shouldBe expectedBytes.toList()
+            } finally {
+                MockLambdaClientBuildService.mockClient = null
+            }
+        }
+
+        test("execute - no publish flag - uploads without setting publish") {
+            val project = ProjectBuilder.builder().build()
+            val client = mockk<LambdaClient>()
+            MockLambdaClientBuildService.mockClient = client
+            val service = project.gradle.sharedServices.registerIfAbsent("lambda", MockLambdaClientBuildService::class)
+            val requestSlot = slot<UpdateFunctionCodeRequest>()
+            every { client.updateFunctionCode(capture(requestSlot)) } returns mockk<UpdateFunctionCodeResponse>()
+
+            val zipFile = project.layout.buildDirectory.file("fn.zip").get().asFile
+            zipFile.parentFile.mkdirs()
+            zipFile.writeBytes(byteArrayOf(0x50, 0x4B, 0x03, 0x04))
+
+            try {
+                val task = project.tasks.register<UpdateFunctionCodeTask>("uploadFn") {
+                    this.service.set(service)
+                    this.functionName.set("my-fn")
+                    this.zipFile.set(zipFile)
+                }.get()
+
+                task.execute()
+
+                requestSlot.captured.functionName() shouldBe "my-fn"
+            } finally {
+                MockLambdaClientBuildService.mockClient = null
+            }
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/README.md
+++ b/cores/aws-lambda-jvm-deploy-plugin/README.md
@@ -1,0 +1,74 @@
+# aws-lambda-jvm-deploy-plugin
+
+Gradle plugins that wire the deployment ZIP produced by `aws-lambda-jvm-plugin` to an AWS Lambda
+upload task. Depends on `aws-lambda-java-base` for the upload task implementation.
+
+## Plugin IDs
+
+| Plugin ID | Type | Description |
+|-----------|------|-------------|
+| `com.kelvsyc.gradle.aws-lambda-jvm.deploy` | umbrella | Fat-JAR packaging + Lambda upload wired end-to-end |
+| `com.kelvsyc.gradle.aws-lambda-jvm.layered-deploy` | umbrella | Thin-JAR packaging + Lambda upload wired end-to-end |
+| `com.kelvsyc.gradle.aws-lambda-jvm.upload` | atomic | Upload task only, for use alongside an explicit packaging plugin |
+
+## Usage
+
+### All-in-one (fat JAR + upload)
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    id("com.kelvsyc.gradle.aws-lambda-jvm.deploy") version "<version>"
+}
+
+awsLambdaJvmDeploy {
+    functionName.set("my-lambda-function")
+    publish.set(true)           // optional: publish a new version after upload
+    regionId.set("us-east-1")  // optional: defaults to SDK region provider chain
+}
+```
+
+Run `./gradlew uploadLambdaFunction` to package and upload the function.
+
+### Layered deployment (thin JAR + upload)
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    id("com.kelvsyc.gradle.aws-lambda-jvm.layered-deploy") version "<version>"
+}
+
+awsLambdaJvmDeploy {
+    functionName.set("my-lambda-function")
+}
+```
+
+### Atomic composition
+
+Apply the packaging and upload plugins separately when you need to customize the pipeline:
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    id("com.kelvsyc.gradle.aws-lambda-jvm.fat-package") version "<version>"
+    id("com.kelvsyc.gradle.aws-lambda-jvm.upload") version "<version>"
+}
+```
+
+Plugin application order does not matter — the upload task's ZIP input is wired lazily.
+
+## Extensions
+
+### `awsLambdaJvmDeploy`
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `functionName` | `Property<String>` | Yes | Function name, partial ARN, or full ARN |
+| `publish` | `Property<Boolean>` | No | Publish a new version after upload; defaults to `false` |
+| `regionId` | `Property<String>` | No | AWS region; defaults to SDK provider chain |
+
+## Credentials
+
+The upload task uses the AWS SDK's default credential chain:
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars → `~/.aws/credentials` → IAM role.
+No credential configuration is required in most CI/CD environments.

--- a/cores/aws-lambda-jvm-deploy-plugin/build.gradle.kts
+++ b/cores/aws-lambda-jvm-deploy-plugin/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-plugin")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("AWS Lambda JVM Deploy Plugin")
+}
+
+gradlePlugin {
+    plugins.register("aws-lambda-jvm-upload") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.upload"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.deploy.AwsLambdaJvmUploadPlugin"
+    }
+    plugins.register("aws-lambda-jvm-deploy") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.deploy"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.deploy.AwsLambdaJvmDeployPlugin"
+    }
+    plugins.register("aws-lambda-jvm-layered-deploy") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.layered-deploy"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.deploy.AwsLambdaJvmLayeredDeployPlugin"
+    }
+}
+
+dependencies {
+    api("com.kelvsyc.gradle:aws-lambda-jvm-plugin")
+    api("com.kelvsyc.gradle:aws-lambda-java-base")
+    testImplementation(libs.mockk)
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/settings.gradle.kts
+++ b/cores/aws-lambda-jvm-deploy-plugin/settings.gradle.kts
@@ -1,0 +1,11 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}
+
+includeBuild("../aws-lambda-jvm-plugin")
+includeBuild("../aws-lambda-java-base")
+includeBuild("../clients-base")

--- a/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmDeployExtension.kt
+++ b/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmDeployExtension.kt
@@ -1,0 +1,33 @@
+package com.kelvsyc.gradle.aws.jvm.lambda.deploy
+
+import org.gradle.api.provider.Property
+
+/**
+ * Configuration extension for the `aws-lambda-jvm` upload plugin.
+ *
+ * Configure this extension to specify the target Lambda function and upload options.
+ * The `awsLambdaJvmDeploy` extension is created automatically when any of the upload
+ * plugins is applied.
+ *
+ * ```kotlin
+ * awsLambdaJvmDeploy {
+ *     functionName.set("my-lambda-function")
+ *     publish.set(true)
+ *     regionId.set("us-east-1")
+ * }
+ * ```
+ */
+abstract class AwsLambdaJvmDeployExtension {
+    /** Lambda function name, partial ARN, or full ARN. Required before running `uploadLambdaFunction`. */
+    abstract val functionName: Property<String>
+
+    /** Whether to publish a new function version after upload. Defaults to `false` when absent. */
+    abstract val publish: Property<Boolean>
+
+    /**
+     * AWS region ID for the Lambda client (e.g. `"us-east-1"`). Optional — when absent, the SDK
+     * resolves the region from the standard provider chain (`AWS_REGION` env var, `~/.aws/config`,
+     * EC2 instance metadata, etc.).
+     */
+    abstract val regionId: Property<String>
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmDeployPlugin.kt
+++ b/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmDeployPlugin.kt
@@ -1,0 +1,19 @@
+package com.kelvsyc.gradle.aws.jvm.lambda.deploy
+
+import com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Umbrella plugin that applies [AwsLambdaJvmPlugin] (fat-JAR packaging) and [AwsLambdaJvmUploadPlugin].
+ *
+ * This is the recommended entry point for JVM Lambda projects that build a fat JAR and upload it
+ * directly to AWS Lambda. Configure the target function via the `awsLambdaJvmDeploy` extension and
+ * run `./gradlew uploadLambdaFunction` to deploy.
+ */
+class AwsLambdaJvmDeployPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply(AwsLambdaJvmPlugin::class.java)
+        project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+    }
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmLayeredDeployPlugin.kt
+++ b/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmLayeredDeployPlugin.kt
@@ -1,0 +1,22 @@
+package com.kelvsyc.gradle.aws.jvm.lambda.deploy
+
+import com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmLayeredPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Umbrella plugin that applies [AwsLambdaJvmLayeredPlugin] (thin-JAR packaging) and [AwsLambdaJvmUploadPlugin].
+ *
+ * Use this instead of [AwsLambdaJvmDeployPlugin] when the Lambda function is backed by a layer
+ * that provides its runtime dependencies. The thin-JAR deployment ZIP contains only the function's
+ * own compiled classes alongside a `lib/` directory.
+ *
+ * Configure the target function via the `awsLambdaJvmDeploy` extension and run
+ * `./gradlew uploadLambdaFunction` to deploy.
+ */
+class AwsLambdaJvmLayeredDeployPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply(AwsLambdaJvmLayeredPlugin::class.java)
+        project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+    }
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmUploadPlugin.kt
+++ b/cores/aws-lambda-jvm-deploy-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmUploadPlugin.kt
@@ -1,0 +1,64 @@
+package com.kelvsyc.gradle.aws.jvm.lambda.deploy
+
+import com.kelvsyc.gradle.aws.java.defaultCredentials
+import com.kelvsyc.gradle.aws.java.lambda.LambdaClientBuildService
+import com.kelvsyc.gradle.aws.java.lambda.UpdateFunctionCodeTask
+import com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Atomic plugin that registers an `uploadLambdaFunction` task wired to the deployment ZIP produced
+ * by the `aws-lambda-jvm.fat-package` or `aws-lambda-jvm.thin-package` plugin.
+ *
+ * The plugin auto-registers a [LambdaClientBuildService] using the default AWS credential chain
+ * and wires it directly to the task. Configure the target function and optional region via the
+ * `awsLambdaJvmDeploy` extension:
+ *
+ * ```kotlin
+ * awsLambdaJvmDeploy {
+ *     functionName.set("my-function")
+ *     publish.set(true)
+ *     regionId.set("us-east-1")  // optional; defaults to SDK provider chain
+ * }
+ * ```
+ *
+ * This plugin is applied automatically by [AwsLambdaJvmDeployPlugin] and
+ * [AwsLambdaJvmLayeredDeployPlugin]. Apply it directly when you want upload wiring without the
+ * bundled packaging plugins.
+ *
+ * **Plugin application order is irrelevant.** The upload task's `zipFile` input is wired to
+ * [AwsLambdaJvmExtension.deploymentZipFile] via a lazy provider chain resolved at task execution
+ * time, after all plugins have been applied.
+ */
+class AwsLambdaJvmUploadPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val packagingExtension = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            ?: project.extensions.create("awsLambdaJvm", AwsLambdaJvmExtension::class.java).also {
+                it.archiveBaseName.convention(project.name)
+            }
+
+        val deployExtension = project.extensions.create(
+            "awsLambdaJvmDeploy",
+            AwsLambdaJvmDeployExtension::class.java,
+        )
+
+        val lambdaService = project.gradle.sharedServices.registerIfAbsent(
+            "awsLambdaJvmLambdaClient",
+            LambdaClientBuildService::class.java,
+        ) {
+            parameters {
+                regionId.set(deployExtension.regionId)
+                defaultCredentials()
+            }
+        }
+
+        project.tasks.register<UpdateFunctionCodeTask>("uploadLambdaFunction") {
+            service.set(lambdaService)
+            functionName.set(deployExtension.functionName)
+            zipFile.set(packagingExtension.deploymentZipFile)
+            publish.set(deployExtension.publish)
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmDeployUmbrellaPluginsSpec.kt
+++ b/cores/aws-lambda-jvm-deploy-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmDeployUmbrellaPluginsSpec.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.aws.jvm.lambda.deploy
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import org.gradle.testfixtures.ProjectBuilder
+
+class AwsLambdaJvmDeployUmbrellaPluginsSpec : FunSpec() {
+    init {
+        test("AwsLambdaJvmDeployPlugin - applies fat-package and upload plugins") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmDeployPlugin::class.java)
+
+            val deps = project.configurations.getByName("implementation").dependencies
+            deps.any { it.name == "aws-lambda-java-core" }.shouldBeTrue()
+            project.tasks.findByName("lambdaFatJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+            project.tasks.findByName("uploadLambdaFunction").shouldNotBeNull()
+        }
+
+        test("AwsLambdaJvmLayeredDeployPlugin - applies thin-package and upload plugins") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmLayeredDeployPlugin::class.java)
+
+            val deps = project.configurations.getByName("implementation").dependencies
+            deps.any { it.name == "aws-lambda-java-core" }.shouldBeTrue()
+            project.tasks.findByName("lambdaJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+            project.tasks.findByName("uploadLambdaFunction").shouldNotBeNull()
+        }
+
+        test("AwsLambdaJvmDeployPlugin - deploy extension is wired after java plugin") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmDeployPlugin::class.java)
+
+            project.extensions.findByType(AwsLambdaJvmDeployExtension::class.java).shouldNotBeNull()
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-deploy-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmUploadPluginSpec.kt
+++ b/cores/aws-lambda-jvm-deploy-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/deploy/AwsLambdaJvmUploadPluginSpec.kt
@@ -1,0 +1,65 @@
+package com.kelvsyc.gradle.aws.jvm.lambda.deploy
+
+import com.kelvsyc.gradle.aws.java.lambda.UpdateFunctionCodeTask
+import com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmExtension
+import com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmFatPackagePlugin
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.gradle.testfixtures.ProjectBuilder
+
+class AwsLambdaJvmUploadPluginSpec : FunSpec() {
+    init {
+        test("apply - registers uploadLambdaFunction task") {
+            val project = ProjectBuilder.builder().build()
+
+            project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+
+            project.tasks.findByName("uploadLambdaFunction").shouldNotBeNull()
+                .shouldBeInstanceOf<UpdateFunctionCodeTask>()
+        }
+
+        test("apply - creates awsLambdaJvmDeploy extension") {
+            val project = ProjectBuilder.builder().build()
+
+            project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+
+            project.extensions.findByType(AwsLambdaJvmDeployExtension::class.java).shouldNotBeNull()
+        }
+
+        test("apply - creates awsLambdaJvm extension with project name default") {
+            val project = ProjectBuilder.builder().withName("my-lambda").build()
+
+            project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+
+            val ext = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            ext.shouldNotBeNull()
+            ext.archiveBaseName.get() shouldBe "my-lambda"
+        }
+
+        test("apply - functionName wires from deploy extension to upload task") {
+            val project = ProjectBuilder.builder().build()
+
+            project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+
+            val deployExt = project.extensions.getByType(AwsLambdaJvmDeployExtension::class.java)
+            deployExt.functionName.set("my-fn")
+
+            val task = project.tasks.getByName("uploadLambdaFunction") as UpdateFunctionCodeTask
+            task.functionName.get() shouldBe "my-fn"
+        }
+
+        test("apply after fat-package plugin - reuses existing awsLambdaJvm extension") {
+            val project = ProjectBuilder.builder().withName("my-lambda").build()
+            project.pluginManager.apply("java")
+            project.pluginManager.apply(AwsLambdaJvmFatPackagePlugin::class.java)
+
+            project.pluginManager.apply(AwsLambdaJvmUploadPlugin::class.java)
+
+            val ext = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            ext.shouldNotBeNull()
+            ext.archiveBaseName.get() shouldBe "my-lambda"
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/README.md
+++ b/cores/aws-lambda-jvm-plugin/README.md
@@ -1,0 +1,66 @@
+# aws-lambda-jvm-plugin
+
+Composable Gradle plugins for packaging JVM Lambda functions into deployable ZIP artifacts.
+
+## Plugin IDs
+
+| Plugin ID | Type | Description |
+|-----------|------|-------------|
+| `com.kelvsyc.gradle.aws-lambda-jvm` | umbrella | Adds `aws-lambda-java-core` to `implementation` and registers fat-JAR packaging tasks |
+| `com.kelvsyc.gradle.aws-lambda-jvm.layered` | umbrella | Adds `aws-lambda-java-core` to `implementation` and registers thin-JAR packaging tasks |
+| `com.kelvsyc.gradle.aws-lambda-jvm.runtime` | atomic | Adds `aws-lambda-java-core` to `implementation` only |
+| `com.kelvsyc.gradle.aws-lambda-jvm.fat-package` | atomic | Registers fat-JAR packaging tasks only |
+| `com.kelvsyc.gradle.aws-lambda-jvm.thin-package` | atomic | Registers thin-JAR packaging tasks only |
+
+## Usage
+
+Apply the umbrella plugin alongside a JVM language plugin:
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    id("com.kelvsyc.gradle.aws-lambda-jvm") version "<version>"
+}
+```
+
+This registers two tasks:
+- `lambdaFatJar` — all-in-one JAR with all runtime dependencies merged in.
+- `lambdaDeploymentZip` — wraps the fat JAR in a ZIP ready for Lambda upload.
+
+Run `./gradlew lambdaDeploymentZip` to produce the artifact.
+
+### Layered deployment
+
+For functions backed by a Lambda layer that provides the runtime dependencies:
+
+```kotlin
+plugins {
+    kotlin("jvm")
+    id("com.kelvsyc.gradle.aws-lambda-jvm.layered") version "<version>"
+}
+```
+
+This registers:
+- `lambdaJar` — JAR containing only the function's compiled classes.
+- `lambdaDeploymentZip` — ZIP with the thin JAR at the root and dependencies under `lib/`.
+
+### Extension
+
+Both packaging plugins expose the `awsLambdaJvm` extension:
+
+```kotlin
+awsLambdaJvm {
+    archiveBaseName.set("my-function")
+}
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `archiveBaseName` | `Property<String>` | project name | Base name for generated archives |
+| `deploymentZipFile` | `RegularFileProperty` | set by packaging plugin | Path to the deployment ZIP (read-only for consumers) |
+
+## Upload
+
+To also wire the deployment ZIP to an AWS Lambda upload task, add the
+`aws-lambda-jvm-deploy-plugin` component and apply `com.kelvsyc.gradle.aws-lambda-jvm.deploy`
+(fat-JAR upload) or `com.kelvsyc.gradle.aws-lambda-jvm.layered-deploy` (thin-JAR upload).

--- a/cores/aws-lambda-jvm-plugin/build.gradle.kts
+++ b/cores/aws-lambda-jvm-plugin/build.gradle.kts
@@ -1,0 +1,39 @@
+import org.jetbrains.dokka.gradle.DokkaExtension
+
+plugins {
+    id("com.kelvsyc.internal.dokka")
+    id("com.kelvsyc.internal.jacoco")
+    id("com.kelvsyc.internal.kotlin-plugin")
+    id("com.kelvsyc.internal.github-publishing")
+}
+
+configure<DokkaExtension> {
+    moduleName.set("AWS Lambda JVM Plugin")
+}
+
+gradlePlugin {
+    plugins.register("aws-lambda-jvm") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmPlugin"
+    }
+    plugins.register("aws-lambda-jvm-runtime") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.runtime"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmRuntimePlugin"
+    }
+    plugins.register("aws-lambda-jvm-fat-package") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.fat-package"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmFatPackagePlugin"
+    }
+    plugins.register("aws-lambda-jvm-thin-package") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.thin-package"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmThinPackagePlugin"
+    }
+    plugins.register("aws-lambda-jvm-layered") {
+        id = "com.kelvsyc.gradle.aws-lambda-jvm.layered"
+        implementationClass = "com.kelvsyc.gradle.aws.jvm.lambda.AwsLambdaJvmLayeredPlugin"
+    }
+}
+
+dependencies {
+    testImplementation(libs.mockk)
+}

--- a/cores/aws-lambda-jvm-plugin/settings.gradle.kts
+++ b/cores/aws-lambda-jvm-plugin/settings.gradle.kts
@@ -1,0 +1,7 @@
+pluginManagement {
+    includeBuild("../../gradle/settings")
+}
+
+plugins {
+    id("com.kelvsyc.internal")
+}

--- a/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmExtension.kt
+++ b/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmExtension.kt
@@ -1,0 +1,24 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+
+/**
+ * Configuration extension for the `aws-lambda-jvm` plugin family.
+ *
+ * Created by any packaging plugin (fat-package or thin-package) when first applied. Serves as the
+ * cross-plugin communication point so that the upload plugin can locate the deployment ZIP without
+ * knowing which packaging strategy was used.
+ */
+abstract class AwsLambdaJvmExtension {
+    /** Base name for generated archives. Defaults to the project name. */
+    abstract val archiveBaseName: Property<String>
+
+    /**
+     * The deployment ZIP file produced by the active packaging plugin.
+     *
+     * Set automatically by [AwsLambdaJvmFatPackagePlugin] or [AwsLambdaJvmThinPackagePlugin].
+     * The upload plugin reads this to wire the ZIP file path to the upload task input.
+     */
+    abstract val deploymentZipFile: RegularFileProperty
+}

--- a/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmFatPackagePlugin.kt
+++ b/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmFatPackagePlugin.kt
@@ -1,0 +1,66 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+import javax.inject.Inject
+
+/**
+ * Registers tasks that package a JVM Lambda function as a fat JAR.
+ *
+ * When applied alongside a JVM language plugin (e.g. `java`, `kotlin("jvm")`), this plugin
+ * registers two tasks:
+ * - `lambdaFatJar` — an all-in-one JAR containing the project's own classes merged with all
+ *   runtime dependencies. Duplicate entries are suppressed; signature files are stripped to
+ *   prevent JAR signature verification failures at Lambda runtime.
+ * - `lambdaDeploymentZip` — wraps the fat JAR in a ZIP suitable for uploading to AWS Lambda.
+ *
+ * The path to the generated ZIP is published to [AwsLambdaJvmExtension.deploymentZipFile] for
+ * downstream consumption by the upload plugin.
+ *
+ * This plugin is applied automatically by [AwsLambdaJvmPlugin]. Apply it directly when you want
+ * fat-JAR packaging without the `aws-lambda-java-core` runtime dependency.
+ */
+abstract class AwsLambdaJvmFatPackagePlugin @Inject constructor(
+    private val archiveOperations: ArchiveOperations,
+) : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            ?: project.extensions.create("awsLambdaJvm", AwsLambdaJvmExtension::class.java).also {
+                it.archiveBaseName.convention(project.name)
+            }
+        project.pluginManager.withPlugin("java") {
+            configurePackaging(project, extension)
+        }
+    }
+
+    private fun configurePackaging(project: Project, extension: AwsLambdaJvmExtension) {
+        val mainOutput = project.extensions.getByType<JavaPluginExtension>()
+            .sourceSets.named("main").map { it.output }
+        val runtimeClasspath = project.configurations.named("runtimeClasspath")
+
+        val fatJar = project.tasks.register<Jar>("lambdaFatJar") {
+            archiveBaseName.convention(extension.archiveBaseName)
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            from(mainOutput)
+            from(runtimeClasspath.map { config ->
+                config.files.map { archiveOperations.zipTree(it) }
+            })
+            exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "META-INF/LICENSE*")
+        }
+
+        val zip = project.tasks.register<Zip>("lambdaDeploymentZip") {
+            archiveBaseName.convention(extension.archiveBaseName)
+            from(fatJar)
+        }
+
+        extension.deploymentZipFile.set(zip.flatMap { it.archiveFile })
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmLayeredPlugin.kt
+++ b/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmLayeredPlugin.kt
@@ -1,0 +1,22 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Umbrella plugin that applies [AwsLambdaJvmRuntimePlugin] and [AwsLambdaJvmThinPackagePlugin].
+ *
+ * Use this instead of [AwsLambdaJvmPlugin] when the Lambda function is backed by a layer that
+ * provides its runtime dependencies. The thin-JAR deployment ZIP is small — it contains only the
+ * function's own compiled classes alongside a `lib/` directory of runtime JARs — so deployments
+ * are fast when the dependency set is large but changes infrequently.
+ *
+ * To upload the deployment ZIP to AWS Lambda, also apply `aws-lambda-jvm.layered-deploy` from
+ * the `aws-lambda-jvm-deploy-plugin` component.
+ */
+class AwsLambdaJvmLayeredPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply(AwsLambdaJvmRuntimePlugin::class.java)
+        project.pluginManager.apply(AwsLambdaJvmThinPackagePlugin::class.java)
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmPlugin.kt
+++ b/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmPlugin.kt
@@ -1,0 +1,21 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Umbrella plugin that applies [AwsLambdaJvmRuntimePlugin] and [AwsLambdaJvmFatPackagePlugin].
+ *
+ * This is the recommended entry point for most JVM Lambda projects. It adds the
+ * `aws-lambda-java-core` handler API to `implementation` and registers `lambdaFatJar` /
+ * `lambdaDeploymentZip` tasks that produce a single fat JAR deployment package.
+ *
+ * To upload the deployment ZIP to AWS Lambda, also apply `aws-lambda-jvm.deploy` from the
+ * `aws-lambda-jvm-deploy-plugin` component.
+ */
+class AwsLambdaJvmPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.pluginManager.apply(AwsLambdaJvmRuntimePlugin::class.java)
+        project.pluginManager.apply(AwsLambdaJvmFatPackagePlugin::class.java)
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmRuntimePlugin.kt
+++ b/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmRuntimePlugin.kt
@@ -1,0 +1,22 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Adds the `aws-lambda-java-core` runtime dependency to the applied project.
+ *
+ * This is an atomic plugin providing only the Lambda runtime interfaces. Apply it when you want the
+ * `com.amazonaws:aws-lambda-java-core` handler API without packaging tasks. It is applied
+ * automatically by [AwsLambdaJvmPlugin] and [AwsLambdaJvmLayeredPlugin].
+ */
+class AwsLambdaJvmRuntimePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.dependencies.add("implementation", "com.amazonaws:aws-lambda-java-core:$LAMBDA_CORE_VERSION")
+    }
+
+    companion object {
+        /** Version of `aws-lambda-java-core` added to the project's `implementation` configuration. */
+        const val LAMBDA_CORE_VERSION = "1.2.3"
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmThinPackagePlugin.kt
+++ b/cores/aws-lambda-jvm-plugin/src/main/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmThinPackagePlugin.kt
@@ -1,0 +1,61 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Registers tasks that package a JVM Lambda function as a thin JAR with a separate `lib/` directory.
+ *
+ * When applied alongside a JVM language plugin (e.g. `java`, `kotlin("jvm")`), this plugin
+ * registers two tasks:
+ * - `lambdaJar` — a JAR containing only the project's own classes (no dependencies).
+ * - `lambdaDeploymentZip` — a ZIP containing the thin JAR at the root and all runtime
+ *   dependencies under `lib/`.
+ *
+ * This layout suits Lambda deployments backed by a layer that provides the `lib/` dependencies,
+ * since the function code ZIP is small and redeploys quickly even when dependencies are large.
+ *
+ * The path to the generated ZIP is published to [AwsLambdaJvmExtension.deploymentZipFile] for
+ * downstream consumption by the upload plugin.
+ *
+ * This plugin is applied automatically by [AwsLambdaJvmLayeredPlugin]. Apply it directly when you
+ * want thin-JAR packaging without the `aws-lambda-java-core` runtime dependency.
+ */
+class AwsLambdaJvmThinPackagePlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val extension = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            ?: project.extensions.create("awsLambdaJvm", AwsLambdaJvmExtension::class.java).also {
+                it.archiveBaseName.convention(project.name)
+            }
+        project.pluginManager.withPlugin("java") {
+            configurePackaging(project, extension)
+        }
+    }
+
+    private fun configurePackaging(project: Project, extension: AwsLambdaJvmExtension) {
+        val mainOutput = project.extensions.getByType<JavaPluginExtension>()
+            .sourceSets.named("main").map { it.output }
+        val runtimeClasspath = project.configurations.named("runtimeClasspath")
+
+        val jar = project.tasks.register<Jar>("lambdaJar") {
+            archiveBaseName.convention(extension.archiveBaseName)
+            from(mainOutput)
+        }
+
+        val zip = project.tasks.register<Zip>("lambdaDeploymentZip") {
+            archiveBaseName.convention(extension.archiveBaseName)
+            from(jar)
+            into("lib") {
+                from(runtimeClasspath)
+            }
+        }
+
+        extension.deploymentZipFile.set(zip.flatMap { it.archiveFile })
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmFatPackagePluginSpec.kt
+++ b/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmFatPackagePluginSpec.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.gradle.testfixtures.ProjectBuilder
+
+class AwsLambdaJvmFatPackagePluginSpec : FunSpec() {
+    init {
+        test("apply with java plugin - registers lambdaFatJar and lambdaDeploymentZip tasks") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmFatPackagePlugin::class.java)
+
+            project.tasks.findByName("lambdaFatJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+        }
+
+        test("apply - creates awsLambdaJvm extension with project name as archiveBaseName default") {
+            val project = ProjectBuilder.builder().withName("my-lambda").build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmFatPackagePlugin::class.java)
+
+            val extension = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            extension.shouldNotBeNull()
+            extension.archiveBaseName.get() shouldBe "my-lambda"
+        }
+
+        test("apply without java plugin - defers task registration until java is applied") {
+            val project = ProjectBuilder.builder().build()
+
+            project.pluginManager.apply(AwsLambdaJvmFatPackagePlugin::class.java)
+
+            project.tasks.findByName("lambdaFatJar") shouldBe null
+            project.tasks.findByName("lambdaDeploymentZip") shouldBe null
+
+            project.pluginManager.apply("java")
+
+            project.tasks.findByName("lambdaFatJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmRuntimePluginSpec.kt
+++ b/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmRuntimePluginSpec.kt
@@ -1,0 +1,23 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import org.gradle.testfixtures.ProjectBuilder
+
+class AwsLambdaJvmRuntimePluginSpec : FunSpec() {
+    init {
+        test("apply - adds aws-lambda-java-core to implementation configuration") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmRuntimePlugin::class.java)
+
+            val deps = project.configurations.getByName("implementation").dependencies
+            deps.any { dep ->
+                dep.group == "com.amazonaws" &&
+                    dep.name == "aws-lambda-java-core" &&
+                    dep.version == AwsLambdaJvmRuntimePlugin.LAMBDA_CORE_VERSION
+            }.shouldBeTrue()
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmThinPackagePluginSpec.kt
+++ b/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmThinPackagePluginSpec.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.gradle.testfixtures.ProjectBuilder
+
+class AwsLambdaJvmThinPackagePluginSpec : FunSpec() {
+    init {
+        test("apply with java plugin - registers lambdaJar and lambdaDeploymentZip tasks") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmThinPackagePlugin::class.java)
+
+            project.tasks.findByName("lambdaJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+        }
+
+        test("apply - creates awsLambdaJvm extension with project name as archiveBaseName default") {
+            val project = ProjectBuilder.builder().withName("my-lambda").build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmThinPackagePlugin::class.java)
+
+            val extension = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            extension.shouldNotBeNull()
+            extension.archiveBaseName.get() shouldBe "my-lambda"
+        }
+
+        test("apply without java plugin - defers task registration until java is applied") {
+            val project = ProjectBuilder.builder().build()
+
+            project.pluginManager.apply(AwsLambdaJvmThinPackagePlugin::class.java)
+
+            project.tasks.findByName("lambdaJar") shouldBe null
+            project.tasks.findByName("lambdaDeploymentZip") shouldBe null
+
+            project.pluginManager.apply("java")
+
+            project.tasks.findByName("lambdaJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+        }
+    }
+}

--- a/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmUmbrellaPluginsSpec.kt
+++ b/cores/aws-lambda-jvm-plugin/src/test/kotlin/com/kelvsyc/gradle/aws/jvm/lambda/AwsLambdaJvmUmbrellaPluginsSpec.kt
@@ -1,0 +1,45 @@
+package com.kelvsyc.gradle.aws.jvm.lambda
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldNotBeNull
+import org.gradle.testfixtures.ProjectBuilder
+
+class AwsLambdaJvmUmbrellaPluginsSpec : FunSpec() {
+    init {
+        test("AwsLambdaJvmPlugin - applies runtime and fat-package plugins") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmPlugin::class.java)
+
+            val deps = project.configurations.getByName("implementation").dependencies
+            deps.any { it.name == "aws-lambda-java-core" }.shouldBeTrue()
+            project.tasks.findByName("lambdaFatJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+        }
+
+        test("AwsLambdaJvmLayeredPlugin - applies runtime and thin-package plugins") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmLayeredPlugin::class.java)
+
+            val deps = project.configurations.getByName("implementation").dependencies
+            deps.any { it.name == "aws-lambda-java-core" }.shouldBeTrue()
+            project.tasks.findByName("lambdaJar").shouldNotBeNull()
+            project.tasks.findByName("lambdaDeploymentZip").shouldNotBeNull()
+        }
+
+        test("AwsLambdaJvmPlugin - extension deploymentZipFile is set after java plugin applied") {
+            val project = ProjectBuilder.builder().build()
+            project.pluginManager.apply("java")
+
+            project.pluginManager.apply(AwsLambdaJvmPlugin::class.java)
+
+            val extension = project.extensions.findByType(AwsLambdaJvmExtension::class.java)
+            extension.shouldNotBeNull()
+            extension.deploymentZipFile.isPresent.shouldBeTrue()
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,7 @@ aws-imds-kotlin = { module = "aws.sdk.kotlin:imds" } # version from BOM 'aws-kot
 aws-kms-java = { module = "software.amazon.awssdk:kms" } # version from BOM 'aws-java-sdk-bom'
 aws-kms-kotlin = { module = "aws.sdk.kotlin:kms" } # version from BOM 'aws-kotlin-sdk-bom'
 aws-lambda-java = { module = "software.amazon.awssdk:lambda" } # version from BOM 'aws-java-sdk-bom'
+aws-lambda-java-core = "com.amazonaws:aws-lambda-java-core:1.2.3"
 aws-lambda-kotlin = { module = "aws.sdk.kotlin:lambda" } # version from BOM 'aws-kotlin-sdk-bom'
 aws-s3-java = { module = "software.amazon.awssdk:s3" } # version from BOM 'aws-java-sdk-bom'
 aws-s3-kotlin = { module = "aws.sdk.kotlin:s3" } # version from BOM 'aws-kotlin-sdk-bom'

--- a/gradle/platform/build.gradle.kts
+++ b/gradle/platform/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     api(platform(libs.kotlin.tools.bom))
     api(platform(libs.kotlinx.coroutines.bom))
     constraints {
+        api(libs.aws.lambda.java.core)
         api(libs.commons.lang)
         api(libs.moshi)
         api(libs.moshi.kotlin)


### PR DESCRIPTION
## Summary

- Adds `aws-lambda-jvm-plugin` with 5 composable plugin IDs for fat-JAR and thin-JAR Lambda packaging (`runtime`, `fat-package`, `thin-package`, `aws-lambda-jvm`, `layered`)
- Adds `aws-lambda-jvm-deploy-plugin` with 3 plugin IDs that wire the deployment ZIP to an auto-registered `LambdaClientBuildService` upload task (`upload`, `deploy`, `layered-deploy`)
- Adds `UpdateFunctionCodeTask` to `aws-lambda-java-base` — a single-function `DefaultTask` counterpart to the existing batch task, with a unit test
- Pins `com.amazonaws:aws-lambda-java-core:1.2.3` in the version catalog and platform BOM

## Test plan

- [ ] `./gradlew :aws-lambda-java-base:build` — new task and spec compile and tests pass
- [ ] `./gradlew :aws-lambda-jvm-plugin:build` — all 5 plugin IDs register, all specs pass
- [ ] `./gradlew :aws-lambda-jvm-deploy-plugin:build` — all 3 plugin IDs register, all specs pass
- [ ] `./gradlew :build` — full composite build including BOM and aggregation succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)