### PR TITLE
build(deps): resolve open Dependabot security alerts

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,12 +12,12 @@ aws-kotlin-sdk-bom = "aws.sdk.kotlin:bom:1.8.19"
 azure-sdk-bom = "com.azure:azure-sdk-bom:1.3.7"
 google-cloud-libraries-bom = "com.google.cloud:libraries-bom:26.83.0"
 opentelemetry-bom = "io.opentelemetry:opentelemetry-bom:1.64.0"
-jackson-bom = "com.fasterxml.jackson:jackson-bom:2.22.0"
+jackson-bom = "com.fasterxml.jackson:jackson-bom:2.22.1"
 kotlin-gradle-plugins-bom = { module = "org.jetbrains.kotlin:kotlin-gradle-plugins-bom", version.ref = "kotlin" }
 kotlin-tools-bom = { module = "com.kelvsyc.kotlin:bom", version.ref = "kotlin-tools" }
 kotlinx-coroutines-bom = "org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.11.0"
 kotest-bom = "io.kotest:kotest-bom:6.2.3"
-netty-bom = "io.netty:netty-bom:4.2.15.Final"
+netty-bom = "io.netty:netty-bom:4.2.16.Final"
 okhttp-bom = "com.squareup.okhttp3:okhttp-bom:5.4.0"
 retrofit-bom = "com.squareup.retrofit2:retrofit-bom:3.0.0"
 
@@ -111,6 +111,7 @@ kotlin-tools-moshi-extensions = { module = "com.kelvsyc.kotlin:moshi-extensions"
 kotlin-tools-snakeyaml-extensions = { module = "com.kelvsyc.kotlin:snakeyaml-extensions" } # version from BOM 'kotlin-tools-bom'
 kotlin-tools-xml-extensions = { module = "com.kelvsyc.kotlin:xml-extensions" } # version from BOM 'kotlin-tools-bom'
 jgit = "org.eclipse.jgit:org.eclipse.jgit:7.7.1.202607240634-r"
+jsoup = "org.jsoup:jsoup:1.23.1"
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core" } # version from BOM 'kotest-bom'
 kotest-assertions-shared = { module = "io.kotest:kotest-assertions-shared" } # version from BOM 'kotest-bom'
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine" } # version from BOM 'kotest-bom'

--- a/gradle/plugins/dokka-convention/src/main/kotlin/com.kelvsyc.internal.dokka.gradle.kts
+++ b/gradle/plugins/dokka-convention/src/main/kotlin/com.kelvsyc.internal.dokka.gradle.kts
@@ -1,8 +1,21 @@
+import kotlin.jvm.optionals.getOrNull
 import org.jetbrains.dokka.gradle.DokkaExtension
 import java.net.URI
 
 plugins {
     id("org.jetbrains.dokka")
+}
+
+val libs = versionCatalogs.named("libs")
+
+// Dokka's own internal resolver configurations (not derived from `implementation`/`api`, so the
+// `com.kelvsyc.internal:platform` BOM's constraints never reach them) pull in a vulnerable transitive
+// jsoup via dokka-base/analysis-markdown; force the patched version on just those configurations.
+val jsoup = libs.findLibrary("jsoup").getOrNull()
+configurations.matching { it.name.startsWith("dokka") }.configureEach {
+    resolutionStrategy {
+        jsoup?.let { force(it.get()) }
+    }
 }
 
 val gitCommitHash: Provider<String> = providers.exec {


### PR DESCRIPTION
## Summary
- Bump `jackson-bom` 2.22.0 → 2.22.1 and `netty-bom` 4.2.15.Final → 4.2.16.Final in the version catalog, fixing all reported jackson-databind/jackson-core and netty-codec-* CVEs (alerts #44-#50, #52-#64).
- Force the transitive `jsoup` pulled in by `dokka-base`/`analysis-marketdown` (resolved at 1.16.1) up to the patched 1.23.1 (alert #65). This dependency flows through Dokka's own internal resolver configurations, which don't extend `implementation`/`api`, so the `com.kelvsyc.internal:platform` BOM's `constraints {}` block can't reach it — the fix is scoped via `resolutionStrategy.force` on just the `dokka*`-prefixed configurations in the dokka convention plugin.

## Test plan
- [x] `./gradlew :test` — BUILD SUCCESSFUL
- [x] `./gradlew :detekt` — BUILD SUCCESSFUL
- [x] Verified via `dependencies`/`dependencyInsight` in real consuming modules (`cores/google-cloud-storage-base`, `cores/aws-secrets-manager-java-base`, `aggregation/dokka`) that jackson-databind, jackson-core, netty-codec-*, and jsoup all resolve to the patched versions
- [x] `dokkaGeneratePublicationHtml` runs clean with jsoup 1.23.1 resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)